### PR TITLE
add training mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Success! The new status is: DISABLED. /help
       --dry                         dry mode, no bans [$DRY]
       --dbg                         debug mode [$DEBUG]
       --tg-dbg                      telegram debug mode [$TG_DEBUG]
+      --training                    training mode, do not ban [$TRAINING]
 
 telegram:
       --telegram.token=             telegram bot token [$TELEGRAM_TOKEN]
@@ -244,6 +245,8 @@ To do so, three conditions must be met:
 - admin name(s) should be set with `--super [$SUPER_USER]` parameter.  
 
 After that, the moment admin run into a spam message, he could forward it to the tg-spam bot. The bot will add this message to the spam samples file, ban user and delete the message. By doing so, the bot will learn new spam patterns on the fly and eventually will be able to detect spam without admin help. Note: the only thing admin should do is to forward the message to the bot, no need to add any text or comments, or remove/ban the original spammer. The bot will do all the work.
+
+In case if such a training on a live system is not possible, the bot can be trained without banning user and deleting messages. Setting `--training ` parameter will disable banning and deleting messages but the rest of the functionality will be the same. This is useful for testing and training purposes as bot can be trained on false-positive samples, by unbanning them in the admin chat as well as with false-negative samples by forwarding them to the bot.
 
 ## Example of docker-compose.yml
 

--- a/app/main.go
+++ b/app/main.go
@@ -88,9 +88,10 @@ var opts struct {
 		Dry     string `long:"dry" env:"DRY" default:"this is spam (dry mode)" description:"spam dry message"`
 	} `group:"message" namespace:"message" env-namespace:"MESSAGE"`
 
-	Dry   bool `long:"dry" env:"DRY" description:"dry mode, no bans"`
-	Dbg   bool `long:"dbg" env:"DEBUG" description:"debug mode"`
-	TGDbg bool `long:"tg-dbg" env:"TG_DEBUG" description:"telegram debug mode"`
+	Training bool `long:"training" env:"TRAINING" description:"training mode, passive spam detection only"`
+	Dry      bool `long:"dry" env:"DRY" description:"dry mode, no bans"`
+	Dbg      bool `long:"dbg" env:"DEBUG" description:"debug mode"`
+	TGDbg    bool `long:"tg-dbg" env:"TG_DEBUG" description:"telegram debug mode"`
 }
 
 var revision = "local"
@@ -228,6 +229,7 @@ func execute(ctx context.Context) error {
 		AdminGroup:   opts.AdminGroup,
 		TestingIDs:   opts.TestingIDs,
 		Locator:      events.NewLocator(opts.HistoryDuration, opts.HistoryMinSize),
+		TrainingMode: opts.Training,
 		Dry:          opts.Dry,
 	}
 	log.Printf("[DEBUG] telegram listener config: {group: %s, idle: %v, super: %v, admin: %s, testing: %v, no-reply: %v, dry: %v}",

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -180,6 +180,7 @@ Success! The new status is: DISABLED. /help
       --dry                         dry mode, no bans [$DRY]
       --dbg                         debug mode [$DEBUG]
       --tg-dbg                      telegram debug mode [$TG_DEBUG]
+      --training                    training mode, do not ban [$TRAINING]
 
 telegram:
       --telegram.token=             telegram bot token [$TELEGRAM_TOKEN]
@@ -244,6 +245,8 @@ To do so, three conditions must be met:
 - admin name(s) should be set with `--super [$SUPER_USER]` parameter.  
 
 After that, the moment admin run into a spam message, he could forward it to the tg-spam bot. The bot will add this message to the spam samples file, ban user and delete the message. By doing so, the bot will learn new spam patterns on the fly and eventually will be able to detect spam without admin help. Note: the only thing admin should do is to forward the message to the bot, no need to add any text or comments, or remove/ban the original spammer. The bot will do all the work.
+
+In case if such a training on a live system is not possible, the bot can be trained without banning user and deleting messages. Setting `--training ` parameter will disable banning and deleting messages but the rest of the functionality will be the same. This is useful for testing and training purposes as bot can be trained on false-positive samples, by unbanning them in the admin chat as well as with false-negative samples by forwarding them to the bot.
 
 ## Example of docker-compose.yml
 


### PR DESCRIPTION
This is to train the bot without annoying users with false positives. The `--training` flag is somewhat similar to `--dry` however, it disables only destructive actions, like deleting messages, banning users or sending ban-reports to the primary chat. 

However the rest of things works the same way as in the full mode, i.e. detected spam will be forwarder to admin group/chat with the ability to unban. Forwarding messages to admin chat works as well, to indicate spam messages missed by the bot.

See #17 