### PR TITLE
add parameter to change the default 50% spam probability threshold 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Another useful feature is the ability to keep the list of approved users persist
 
 **Message Analysis**
 
-This is the main spam detection module. It uses the list of spam and ham samples to detect spam by using Bayes classifier. The bot is enabled as long as `--files.samples-spam=, [$FILES_SAMPLES_SPAM]`, `--files.samples-ham=, [$FILES_SAMPLES_HAM]` and `--files.exclude-tokens=, [$FILES_EXCLUDE_TOKENS]` parameters point to existing files. It can be disabled by setting those parameters to empty strings or non-existing files.
+This is the main spam detection module. It uses the list of spam and ham samples to detect spam by using Bayes classifier. The bot is enabled as long as `--files.samples-spam=, [$FILES_SAMPLES_SPAM]`, `--files.samples-ham=, [$FILES_SAMPLES_HAM]` and `--files.exclude-tokens=, [$FILES_EXCLUDE_TOKENS]` parameters point to existing files. It can be disabled by setting those parameters to empty strings or non-existing files. There is also a parameter to set minimum spam probability percent to ban the user. If the probability of spam is less than `--min-probability=, [$MIN_PROBABILITY]` (default is 50), the message is not marked as spam. 
 
 **Spam message similarity check**
 
@@ -200,6 +200,7 @@ Success! The new status is: DISABLED. /help
       --super=                      super-users [$SUPER_USER]
       --no-spam-reply               do not reply to spam messages [$NO_SPAM_REPLY]
       --similarity-threshold=       spam threshold (default: 0.5) [$SIMILARITY_THRESHOLD]
+      --min-probability=            min spam probability to ban (default: 50) [$MIN_PROBABILITY]
       --min-msg-len=                min message length to check (default: 50) [$MIN_MSG_LEN]
       --max-emoji=                  max emoji count in message, -1 to disable check (default: 2) [$MAX_EMOJI]
       --paranoid                    paranoid mode, check all messages [$PARANOID]

--- a/app/events/events_test.go
+++ b/app/events/events_test.go
@@ -761,7 +761,7 @@ func TestTelegramListener_DoWithAdminShowInfo(t *testing.T) {
 	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).Text, "unban user blah")
 	kb := mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).ReplyMarkup.InlineKeyboard
 	assert.Equal(t, 0, len(kb), "buttons cleared")
-	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).Text, "results:\nrule1: spam, details1\nrule2: spam, details2")
+	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).Text, "results**\n- rule1: spam, details1\n- rule2: spam, details2")
 	assert.Equal(t, 0, len(mockAPI.RequestCalls()))
 	assert.Equal(t, 0, len(b.UpdateSpamCalls()))
 	assert.Equal(t, 0, len(b.UpdateHamCalls()))

--- a/app/main.go
+++ b/app/main.go
@@ -82,6 +82,7 @@ type options struct {
 	MaxEmoji            int     `long:"max-emoji" env:"MAX_EMOJI" default:"2" description:"max emoji count in message, -1 to disable check"`
 	ParanoidMode        bool    `long:"paranoid" env:"PARANOID" description:"paranoid mode, check all messages"`
 	FirstMessagesCount  int     `long:"first-messages-count" env:"FIRST_MESSAGES_COUNT" default:"1" description:"number of first messages to check"`
+	MinSpamProbability  float64 `long:"min-probability" env:"MIN_PROBABILITY" default:"50" description:"min spam probability percent to ban"`
 
 	Message struct {
 		Startup string `long:"startup" env:"STARTUP" default:"" description:"startup message"`
@@ -206,6 +207,7 @@ func makeDetector(opts options) *lib.Detector {
 		MaxAllowedEmoji:     opts.MaxEmoji,
 		MinMsgLen:           opts.MinMsgLen,
 		SimilarityThreshold: opts.SimilarityThreshold,
+		MinSpamProbability:  opts.MinSpamProbability,
 		CasAPI:              opts.CAS.API,
 		HTTPClient:          &http.Client{Timeout: opts.CAS.Timeout},
 		FirstMessageOnly:    !opts.ParanoidMode,

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -79,7 +79,7 @@ Another useful feature is the ability to keep the list of approved users persist
 
 **Message Analysis**
 
-This is the main spam detection module. It uses the list of spam and ham samples to detect spam by using Bayes classifier. The bot is enabled as long as `--files.samples-spam=, [$FILES_SAMPLES_SPAM]`, `--files.samples-ham=, [$FILES_SAMPLES_HAM]` and `--files.exclude-tokens=, [$FILES_EXCLUDE_TOKENS]` parameters point to existing files. It can be disabled by setting those parameters to empty strings or non-existing files.
+This is the main spam detection module. It uses the list of spam and ham samples to detect spam by using Bayes classifier. The bot is enabled as long as `--files.samples-spam=, [$FILES_SAMPLES_SPAM]`, `--files.samples-ham=, [$FILES_SAMPLES_HAM]` and `--files.exclude-tokens=, [$FILES_EXCLUDE_TOKENS]` parameters point to existing files. It can be disabled by setting those parameters to empty strings or non-existing files. There is also a parameter to set minimum spam probability percent to ban the user. If the probability of spam is less than `--min-probability=, [$MIN_PROBABILITY]` (default is 50), the message is not marked as spam. 
 
 **Spam message similarity check**
 
@@ -200,6 +200,7 @@ Success! The new status is: DISABLED. /help
       --super=                      super-users [$SUPER_USER]
       --no-spam-reply               do not reply to spam messages [$NO_SPAM_REPLY]
       --similarity-threshold=       spam threshold (default: 0.5) [$SIMILARITY_THRESHOLD]
+      --min-probability=            min spam probability to ban (default: 50) [$MIN_PROBABILITY]
       --min-msg-len=                min message length to check (default: 50) [$MIN_MSG_LEN]
       --max-emoji=                  max emoji count in message, -1 to disable check (default: 2) [$MAX_EMOJI]
       --paranoid                    paranoid mode, check all messages [$PARANOID]


### PR DESCRIPTION
sometimes 50% threshold for spam detection (by classifier) can cause false positives. This PR adds a new parameter `--min-probability=   [$MIN_PROBABILITY]` (default 50) to change (increase) it.
