### PR TITLE
support for removal users from aproved list

### DIFF
--- a/app/bot/mocks/detector.go
+++ b/app/bot/mocks/detector.go
@@ -19,13 +19,16 @@ import (
 //				panic("mock out the AddApprovedUsers method")
 //			},
 //			CheckFunc: func(msg string, userID string) (bool, []lib.CheckResult) {
-//				panic("mock out the check method")
+//				panic("mock out the Check method")
 //			},
 //			LoadSamplesFunc: func(exclReader io.Reader, spamReaders []io.Reader, hamReaders []io.Reader) (lib.LoadResult, error) {
 //				panic("mock out the LoadSamples method")
 //			},
 //			LoadStopWordsFunc: func(readers ...io.Reader) (lib.LoadResult, error) {
 //				panic("mock out the LoadStopWords method")
+//			},
+//			RemoveApprovedUsersFunc: func(ids ...string)  {
+//				panic("mock out the RemoveApprovedUsers method")
 //			},
 //			UpdateHamFunc: func(msg string) error {
 //				panic("mock out the UpdateHam method")
@@ -51,6 +54,9 @@ type DetectorMock struct {
 
 	// LoadStopWordsFunc mocks the LoadStopWords method.
 	LoadStopWordsFunc func(readers ...io.Reader) (lib.LoadResult, error)
+
+	// RemoveApprovedUsersFunc mocks the RemoveApprovedUsers method.
+	RemoveApprovedUsersFunc func(ids ...string)
 
 	// UpdateHamFunc mocks the UpdateHam method.
 	UpdateHamFunc func(msg string) error
@@ -86,6 +92,11 @@ type DetectorMock struct {
 			// Readers is the readers argument value.
 			Readers []io.Reader
 		}
+		// RemoveApprovedUsers holds details about calls to the RemoveApprovedUsers method.
+		RemoveApprovedUsers []struct {
+			// Ids is the ids argument value.
+			Ids []string
+		}
 		// UpdateHam holds details about calls to the UpdateHam method.
 		UpdateHam []struct {
 			// Msg is the msg argument value.
@@ -97,12 +108,13 @@ type DetectorMock struct {
 			Msg string
 		}
 	}
-	lockAddApprovedUsers sync.RWMutex
-	lockCheck            sync.RWMutex
-	lockLoadSamples      sync.RWMutex
-	lockLoadStopWords    sync.RWMutex
-	lockUpdateHam        sync.RWMutex
-	lockUpdateSpam       sync.RWMutex
+	lockAddApprovedUsers    sync.RWMutex
+	lockCheck               sync.RWMutex
+	lockLoadSamples         sync.RWMutex
+	lockLoadStopWords       sync.RWMutex
+	lockRemoveApprovedUsers sync.RWMutex
+	lockUpdateHam           sync.RWMutex
+	lockUpdateSpam          sync.RWMutex
 }
 
 // AddApprovedUsers calls AddApprovedUsersFunc.
@@ -147,7 +159,7 @@ func (mock *DetectorMock) ResetAddApprovedUsersCalls() {
 // Check calls CheckFunc.
 func (mock *DetectorMock) Check(msg string, userID string) (bool, []lib.CheckResult) {
 	if mock.CheckFunc == nil {
-		panic("DetectorMock.CheckFunc: method is nil but Detector.check was just called")
+		panic("DetectorMock.CheckFunc: method is nil but Detector.Check was just called")
 	}
 	callInfo := struct {
 		Msg    string
@@ -273,6 +285,45 @@ func (mock *DetectorMock) ResetLoadStopWordsCalls() {
 	mock.lockLoadStopWords.Unlock()
 }
 
+// RemoveApprovedUsers calls RemoveApprovedUsersFunc.
+func (mock *DetectorMock) RemoveApprovedUsers(ids ...string) {
+	if mock.RemoveApprovedUsersFunc == nil {
+		panic("DetectorMock.RemoveApprovedUsersFunc: method is nil but Detector.RemoveApprovedUsers was just called")
+	}
+	callInfo := struct {
+		Ids []string
+	}{
+		Ids: ids,
+	}
+	mock.lockRemoveApprovedUsers.Lock()
+	mock.calls.RemoveApprovedUsers = append(mock.calls.RemoveApprovedUsers, callInfo)
+	mock.lockRemoveApprovedUsers.Unlock()
+	mock.RemoveApprovedUsersFunc(ids...)
+}
+
+// RemoveApprovedUsersCalls gets all the calls that were made to RemoveApprovedUsers.
+// Check the length with:
+//
+//	len(mockedDetector.RemoveApprovedUsersCalls())
+func (mock *DetectorMock) RemoveApprovedUsersCalls() []struct {
+	Ids []string
+} {
+	var calls []struct {
+		Ids []string
+	}
+	mock.lockRemoveApprovedUsers.RLock()
+	calls = mock.calls.RemoveApprovedUsers
+	mock.lockRemoveApprovedUsers.RUnlock()
+	return calls
+}
+
+// ResetRemoveApprovedUsersCalls reset all the calls that were made to RemoveApprovedUsers.
+func (mock *DetectorMock) ResetRemoveApprovedUsersCalls() {
+	mock.lockRemoveApprovedUsers.Lock()
+	mock.calls.RemoveApprovedUsers = nil
+	mock.lockRemoveApprovedUsers.Unlock()
+}
+
 // UpdateHam calls UpdateHamFunc.
 func (mock *DetectorMock) UpdateHam(msg string) error {
 	if mock.UpdateHamFunc == nil {
@@ -368,6 +419,10 @@ func (mock *DetectorMock) ResetCalls() {
 	mock.lockLoadStopWords.Lock()
 	mock.calls.LoadStopWords = nil
 	mock.lockLoadStopWords.Unlock()
+
+	mock.lockRemoveApprovedUsers.Lock()
+	mock.calls.RemoveApprovedUsers = nil
+	mock.lockRemoveApprovedUsers.Unlock()
 
 	mock.lockUpdateHam.Lock()
 	mock.calls.UpdateHam = nil

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -53,6 +53,7 @@ type Detector interface {
 	UpdateSpam(msg string) error
 	UpdateHam(msg string) error
 	AddApprovedUsers(ids ...string)
+	RemoveApprovedUsers(ids ...string)
 }
 
 // NewSpamFilter creates new spam filter
@@ -120,6 +121,17 @@ func (s *SpamFilter) AddApprovedUsers(id int64, ids ...int64) {
 		sids[i] = strconv.FormatInt(id, 10)
 	}
 	s.director.AddApprovedUsers(sids...)
+}
+
+// RemoveApprovedUsers removes users from the list of approved users
+func (s *SpamFilter) RemoveApprovedUsers(id int64, ids ...int64) {
+	combinedIDs := append([]int64{id}, ids...)
+	log.Printf("[DEBUG] remove aproved users: %v", combinedIDs)
+	sids := make([]string, len(combinedIDs))
+	for i, id := range combinedIDs {
+		sids[i] = strconv.FormatInt(id, 10)
+	}
+	s.director.RemoveApprovedUsers(sids...)
 }
 
 // watch watches for changes in samples files and reloads them

--- a/app/bot/spam_test.go
+++ b/app/bot/spam_test.go
@@ -364,3 +364,31 @@ func TestAddApprovedUsers(t *testing.T) {
 		assert.Equal(t, []string{"1", "2", "3"}, mockDirector.AddApprovedUsersCalls()[0].Ids)
 	})
 }
+
+func TestRemoveApprovedUsers(t *testing.T) {
+	mockDirector := &mocks.DetectorMock{RemoveApprovedUsersFunc: func(ids ...string) {}}
+
+	t.Run("remove single approved user", func(t *testing.T) {
+		mockDirector.ResetCalls()
+		sf := SpamFilter{director: mockDirector}
+		sf.RemoveApprovedUsers(1)
+		require.Equal(t, 1, len(mockDirector.RemoveApprovedUsersCalls()))
+		assert.Equal(t, []string{"1"}, mockDirector.RemoveApprovedUsersCalls()[0].Ids)
+	})
+
+	t.Run("remove multiple approved users", func(t *testing.T) {
+		mockDirector.ResetCalls()
+		sf := SpamFilter{director: mockDirector}
+		sf.RemoveApprovedUsers(1, 2, 3)
+		require.Equal(t, 1, len(mockDirector.RemoveApprovedUsersCalls()))
+		assert.Equal(t, []string{"1", "2", "3"}, mockDirector.RemoveApprovedUsersCalls()[0].Ids)
+	})
+
+	t.Run("remove empty list of approved users", func(t *testing.T) {
+		mockDirector.ResetCalls()
+		sf := SpamFilter{director: mockDirector}
+		sf.RemoveApprovedUsers(1, 2, 3)
+		require.Equal(t, 1, len(mockDirector.RemoveApprovedUsersCalls()))
+		assert.Equal(t, []string{"1", "2", "3"}, mockDirector.RemoveApprovedUsersCalls()[0].Ids)
+	})
+}

--- a/app/events/events.go
+++ b/app/events/events.go
@@ -82,6 +82,7 @@ type Bot interface {
 	UpdateSpam(msg string) error
 	UpdateHam(msg string) error
 	AddApprovedUsers(id int64, ids ...int64)
+	RemoveApprovedUsers(id int64, ids ...int64)
 }
 
 // SpamWeb is an interface for the web component
@@ -305,6 +306,10 @@ func (l *TelegramListener) adminChatMsgHandler(update tbapi.Update) error {
 	if err := l.banUserOrChannel(bot.PermanentBanDuration, l.chatID, info.userID, 0); err != nil {
 		return fmt.Errorf("failed to ban user %d: %w", info.userID, err)
 	}
+
+	// remove user from the approved list
+	l.Bot.RemoveApprovedUsers(info.userID)
+
 	log.Printf("[INFO] user %q (%d) banned", update.Message.ForwardSenderName, info.userID)
 	return nil
 }

--- a/app/events/events_test.go
+++ b/app/events/events_test.go
@@ -380,6 +380,7 @@ func TestTelegramListener_DoWithForwarded(t *testing.T) {
 			t.Logf("update-spam: %s", msg)
 			return nil
 		},
+		RemoveApprovedUsersFunc: func(id int64, ids ...int64) {},
 	}
 
 	l := TelegramListener{
@@ -428,6 +429,9 @@ func TestTelegramListener_DoWithForwarded(t *testing.T) {
 
 	assert.Equal(t, int64(123), mockAPI.RequestCalls()[1].C.(tbapi.RestrictChatMemberConfig).ChatID)
 	assert.Equal(t, int64(88), mockAPI.RequestCalls()[1].C.(tbapi.RestrictChatMemberConfig).UserID)
+
+	assert.Equal(t, 1, len(b.RemoveApprovedUsersCalls()))
+	assert.Equal(t, int64(88), b.RemoveApprovedUsersCalls()[0].ID)
 }
 
 func TestTelegramListener_DoWithForwarded_Reply(t *testing.T) {

--- a/app/events/mocks/bot.go
+++ b/app/events/mocks/bot.go
@@ -20,6 +20,9 @@ import (
 //			OnMessageFunc: func(msg bot.Message) bot.Response {
 //				panic("mock out the OnMessage method")
 //			},
+//			RemoveApprovedUsersFunc: func(id int64, ids ...int64)  {
+//				panic("mock out the RemoveApprovedUsers method")
+//			},
 //			UpdateHamFunc: func(msg string) error {
 //				panic("mock out the UpdateHam method")
 //			},
@@ -38,6 +41,9 @@ type BotMock struct {
 
 	// OnMessageFunc mocks the OnMessage method.
 	OnMessageFunc func(msg bot.Message) bot.Response
+
+	// RemoveApprovedUsersFunc mocks the RemoveApprovedUsers method.
+	RemoveApprovedUsersFunc func(id int64, ids ...int64)
 
 	// UpdateHamFunc mocks the UpdateHam method.
 	UpdateHamFunc func(msg string) error
@@ -59,6 +65,13 @@ type BotMock struct {
 			// Msg is the msg argument value.
 			Msg bot.Message
 		}
+		// RemoveApprovedUsers holds details about calls to the RemoveApprovedUsers method.
+		RemoveApprovedUsers []struct {
+			// ID is the id argument value.
+			ID int64
+			// Ids is the ids argument value.
+			Ids []int64
+		}
 		// UpdateHam holds details about calls to the UpdateHam method.
 		UpdateHam []struct {
 			// Msg is the msg argument value.
@@ -70,10 +83,11 @@ type BotMock struct {
 			Msg string
 		}
 	}
-	lockAddApprovedUsers sync.RWMutex
-	lockOnMessage        sync.RWMutex
-	lockUpdateHam        sync.RWMutex
-	lockUpdateSpam       sync.RWMutex
+	lockAddApprovedUsers    sync.RWMutex
+	lockOnMessage           sync.RWMutex
+	lockRemoveApprovedUsers sync.RWMutex
+	lockUpdateHam           sync.RWMutex
+	lockUpdateSpam          sync.RWMutex
 }
 
 // AddApprovedUsers calls AddApprovedUsersFunc.
@@ -95,7 +109,7 @@ func (mock *BotMock) AddApprovedUsers(id int64, ids ...int64) {
 }
 
 // AddApprovedUsersCalls gets all the calls that were made to AddApprovedUsers.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedBot.AddApprovedUsersCalls())
 func (mock *BotMock) AddApprovedUsersCalls() []struct {
@@ -136,7 +150,7 @@ func (mock *BotMock) OnMessage(msg bot.Message) bot.Response {
 }
 
 // OnMessageCalls gets all the calls that were made to OnMessage.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedBot.OnMessageCalls())
 func (mock *BotMock) OnMessageCalls() []struct {
@@ -158,6 +172,49 @@ func (mock *BotMock) ResetOnMessageCalls() {
 	mock.lockOnMessage.Unlock()
 }
 
+// RemoveApprovedUsers calls RemoveApprovedUsersFunc.
+func (mock *BotMock) RemoveApprovedUsers(id int64, ids ...int64) {
+	if mock.RemoveApprovedUsersFunc == nil {
+		panic("BotMock.RemoveApprovedUsersFunc: method is nil but Bot.RemoveApprovedUsers was just called")
+	}
+	callInfo := struct {
+		ID  int64
+		Ids []int64
+	}{
+		ID:  id,
+		Ids: ids,
+	}
+	mock.lockRemoveApprovedUsers.Lock()
+	mock.calls.RemoveApprovedUsers = append(mock.calls.RemoveApprovedUsers, callInfo)
+	mock.lockRemoveApprovedUsers.Unlock()
+	mock.RemoveApprovedUsersFunc(id, ids...)
+}
+
+// RemoveApprovedUsersCalls gets all the calls that were made to RemoveApprovedUsers.
+// Check the length with:
+//
+//	len(mockedBot.RemoveApprovedUsersCalls())
+func (mock *BotMock) RemoveApprovedUsersCalls() []struct {
+	ID  int64
+	Ids []int64
+} {
+	var calls []struct {
+		ID  int64
+		Ids []int64
+	}
+	mock.lockRemoveApprovedUsers.RLock()
+	calls = mock.calls.RemoveApprovedUsers
+	mock.lockRemoveApprovedUsers.RUnlock()
+	return calls
+}
+
+// ResetRemoveApprovedUsersCalls reset all the calls that were made to RemoveApprovedUsers.
+func (mock *BotMock) ResetRemoveApprovedUsersCalls() {
+	mock.lockRemoveApprovedUsers.Lock()
+	mock.calls.RemoveApprovedUsers = nil
+	mock.lockRemoveApprovedUsers.Unlock()
+}
+
 // UpdateHam calls UpdateHamFunc.
 func (mock *BotMock) UpdateHam(msg string) error {
 	if mock.UpdateHamFunc == nil {
@@ -175,7 +232,7 @@ func (mock *BotMock) UpdateHam(msg string) error {
 }
 
 // UpdateHamCalls gets all the calls that were made to UpdateHam.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedBot.UpdateHamCalls())
 func (mock *BotMock) UpdateHamCalls() []struct {
@@ -214,7 +271,7 @@ func (mock *BotMock) UpdateSpam(msg string) error {
 }
 
 // UpdateSpamCalls gets all the calls that were made to UpdateSpam.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedBot.UpdateSpamCalls())
 func (mock *BotMock) UpdateSpamCalls() []struct {
@@ -245,6 +302,10 @@ func (mock *BotMock) ResetCalls() {
 	mock.lockOnMessage.Lock()
 	mock.calls.OnMessage = nil
 	mock.lockOnMessage.Unlock()
+
+	mock.lockRemoveApprovedUsers.Lock()
+	mock.calls.RemoveApprovedUsers = nil
+	mock.lockRemoveApprovedUsers.Unlock()
 
 	mock.lockUpdateHam.Lock()
 	mock.calls.UpdateHam = nil

--- a/app/events/mocks/spam_logger.go
+++ b/app/events/mocks/spam_logger.go
@@ -59,7 +59,7 @@ func (mock *SpamLoggerMock) Save(msg *bot.Message, response *bot.Response) {
 }
 
 // SaveCalls gets all the calls that were made to Save.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedSpamLogger.SaveCalls())
 func (mock *SpamLoggerMock) SaveCalls() []struct {

--- a/app/events/mocks/spam_web.go
+++ b/app/events/mocks/spam_web.go
@@ -58,7 +58,7 @@ func (mock *SpamWebMock) UnbanURL(userID int64, msg string) string {
 }
 
 // UnbanURLCalls gets all the calls that were made to UnbanURL.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedSpamWeb.UnbanURLCalls())
 func (mock *SpamWebMock) UnbanURLCalls() []struct {

--- a/app/events/mocks/tb_api.go
+++ b/app/events/mocks/tb_api.go
@@ -103,7 +103,7 @@ func (mock *TbAPIMock) GetChat(config tbapi.ChatInfoConfig) (tbapi.Chat, error) 
 }
 
 // GetChatCalls gets all the calls that were made to GetChat.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedTbAPI.GetChatCalls())
 func (mock *TbAPIMock) GetChatCalls() []struct {
@@ -142,7 +142,7 @@ func (mock *TbAPIMock) GetChatAdministrators(config tbapi.ChatAdministratorsConf
 }
 
 // GetChatAdministratorsCalls gets all the calls that were made to GetChatAdministrators.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedTbAPI.GetChatAdministratorsCalls())
 func (mock *TbAPIMock) GetChatAdministratorsCalls() []struct {
@@ -181,7 +181,7 @@ func (mock *TbAPIMock) GetUpdatesChan(config tbapi.UpdateConfig) tbapi.UpdatesCh
 }
 
 // GetUpdatesChanCalls gets all the calls that were made to GetUpdatesChan.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedTbAPI.GetUpdatesChanCalls())
 func (mock *TbAPIMock) GetUpdatesChanCalls() []struct {
@@ -220,7 +220,7 @@ func (mock *TbAPIMock) Request(c tbapi.Chattable) (*tbapi.APIResponse, error) {
 }
 
 // RequestCalls gets all the calls that were made to Request.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedTbAPI.RequestCalls())
 func (mock *TbAPIMock) RequestCalls() []struct {
@@ -259,7 +259,7 @@ func (mock *TbAPIMock) Send(c tbapi.Chattable) (tbapi.Message, error) {
 }
 
 // SendCalls gets all the calls that were made to Send.
-// check the length with:
+// Check the length with:
 //
 //	len(mockedTbAPI.SendCalls())
 func (mock *TbAPIMock) SendCalls() []struct {

--- a/lib/detector.go
+++ b/lib/detector.go
@@ -182,6 +182,15 @@ func (d *Detector) AddApprovedUsers(ids ...string) {
 	}
 }
 
+// RemoveApprovedUsers removes user IDs from the list of approved users.
+func (d *Detector) RemoveApprovedUsers(ids ...string) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	for _, id := range ids {
+		delete(d.approvedUsers, id)
+	}
+}
+
 // LoadSamples loads spam samples from a reader and updates the classifier.
 // Reset spam, ham samples/classifier, and excluded tokens.
 func (d *Detector) LoadSamples(exclReader io.Reader, spamReaders, hamReaders []io.Reader) (LoadResult, error) {

--- a/lib/detector_test.go
+++ b/lib/detector_test.go
@@ -537,7 +537,7 @@ func TestDetector_FirstMessagesCount(t *testing.T) {
 	})
 }
 
-func TestDetector_AddApprovedUsers(t *testing.T) {
+func TestDetector_AddAndRemoveApprovedUsers(t *testing.T) {
 	t.Run("user not approved, sent spam", func(t *testing.T) {
 		d := NewDetector(Config{MaxAllowedEmoji: -1, MinMsgLen: 5, FirstMessageOnly: true})
 		_, err := d.LoadStopWords(strings.NewReader("spam\nbuy cryptocurrency"))
@@ -572,6 +572,26 @@ func TestDetector_AddApprovedUsers(t *testing.T) {
 		require.Len(t, info, 1)
 		assert.Equal(t, "pre-approved", info[0].Name)
 	})
+
+	t.Run("remove user", func(t *testing.T) {
+		d := NewDetector(Config{MaxAllowedEmoji: -1, MinMsgLen: 5, FirstMessageOnly: true})
+		_, err := d.LoadStopWords(strings.NewReader("spam\nbuy cryptocurrency"))
+		require.NoError(t, err)
+		d.AddApprovedUsers("123")
+		isSpam, info := d.Check("Hello, how are you my friend? buy cryptocurrency now!", "123")
+		t.Logf("%+v", info)
+		assert.Equal(t, false, isSpam)
+		require.Len(t, info, 1)
+		assert.Equal(t, "pre-approved", info[0].Name)
+
+		d.RemoveApprovedUsers("123")
+		isSpam, info = d.Check("Hello, how are you my friend? buy cryptocurrency now!", "123")
+		t.Logf("%+v", info)
+		assert.Equal(t, true, isSpam)
+		require.Len(t, info, 1)
+		assert.Equal(t, "stopword", info[0].Name)
+	})
+
 }
 
 func TestDetector_tokenize(t *testing.T) {


### PR DESCRIPTION
If a message was not detected as spam and the `first-messages-count` is above 1, the user will stay in the approved list even after being forwarded to the admin chat as spam. Practically, it doesn't cause any issues as the user is already banned, but it is still inconsistent.

This PR extends the detector's API with `RemoveApprovedUsers(ids ...string)`, which is asymmetrical to the existing `AddApprovedUsers(ids ...string)` and adds the call to admin forward handling.