### PR TITLE
Openai veto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Setting `--openai.token [$OPENAI_PROMPT]` enables OpenAI integration. All other 
 
 To keep the number of calls low and the price manageable, the bot uses the following approach:
 
-- Only the first message from a given user is checked for spam. If `--paranoid` mode is enabled, openai will not be used at all.
-- OpenAI check is the last in the chain of checks. If any of the previous checks marked the message as spam, the bot will not call OpenAI.
+- Only the first message(s) from a given user is checked for spam. If `--paranoid` mode is enabled, openai will not be used at all.
+- OpenAI check is the last in the chain of checks. Unless `--openai.veto` is not set, the bot will not even call OpenAI if any of the previous checks marked the message as spam. However, if `--openai.veto` is set, it will be called and the message will be marked as spam only if OpenAI thinks so.
 - By default, OpenAI integration is disabled. 
 
 **Emoji Count**
@@ -230,6 +230,7 @@ openai:
       --openai.token=               openai token, disabled if not set [$OPENAI_TOKEN]
       --openai.prompt=              openai system prompt, if empty uses builtin default [$OPENAI_PROMPT]
       --openai.model=               openai model (default: gpt-4) [$OPENAI_MODEL]
+      --openai.veto                 veto mode, confirm detected spam [$OPENAI_VETO]
       --openai.max-tokens-response= openai max tokens in response (default: 1024) [$OPENAI_MAX_TOKENS_RESPONSE]
       --openai.max-tokens-request=  openai max tokens in request (default: 2048) [$OPENAI_MAX_TOKENS_REQUEST]
       --openai.max-symbols-request= openai max symbols in request, failback if tokenizer failed (default: 16000) [$OPENAI_MAX_SYMBOLS_REQUEST]

--- a/app/main.go
+++ b/app/main.go
@@ -59,6 +59,7 @@ type options struct {
 
 	OpenAI struct {
 		Token                            string `long:"token" env:"TOKEN" description:"openai token, disabled if not set"`
+		Veto                             bool   `long:"veto" env:"VETO" description:"veto mode, confirm detected spam"`
 		Prompt                           string `long:"prompt" env:"PROMPT" default:"" description:"openai system prompt, if empty uses builtin default"`
 		Model                            string `long:"model" env:"MODEL" default:"gpt-4" description:"openai model"`
 		MaxTokensResponse                int    `long:"max-tokens-response" env:"MAX_TOKENS_RESPONSE" default:"1024" description:"openai max tokens in response"`
@@ -212,6 +213,7 @@ func makeDetector(opts options) *lib.Detector {
 		HTTPClient:          &http.Client{Timeout: opts.CAS.Timeout},
 		FirstMessageOnly:    !opts.ParanoidMode,
 		FirstMessagesCount:  opts.FirstMessagesCount,
+		OpenAIVeto:          opts.OpenAI.Veto,
 	}
 
 	// FirstMessagesCount and ParanoidMode are mutually exclusive.

--- a/lib/detector_test.go
+++ b/lib/detector_test.go
@@ -312,6 +312,62 @@ func TestDetector_CheckOpenAI(t *testing.T) {
 		assert.Equal(t, "some message", cr[0].Details)
 		assert.Equal(t, 0, len(mockOpenAIClient.CreateChatCompletionCalls()))
 	})
+
+	t.Run("with openai, first-only spam detected before, veto passes", func(t *testing.T) {
+		d := NewDetector(Config{MaxAllowedEmoji: -1, FirstMessageOnly: true, OpenAIVeto: true})
+		mockOpenAIClient := &mocks.OpenAIClientMock{
+			CreateChatCompletionFunc: func(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+				return openai.ChatCompletionResponse{
+					Choices: []openai.ChatCompletionChoice{{
+						Message: openai.ChatCompletionMessage{Content: `{"spam": true, "reason":"bad text", "confidence":100}`},
+					}},
+				}, nil
+			},
+		}
+		d.WithOpenAIChecker(mockOpenAIClient, OpenAIConfig{Model: "gpt4"})
+		d.LoadStopWords(strings.NewReader("some message"))
+
+		spam, cr := d.Check("some message 1234", "")
+		assert.Equal(t, true, spam)
+		require.Len(t, cr, 2)
+		assert.Equal(t, "stopword", cr[0].Name)
+		assert.Equal(t, true, cr[0].Spam)
+		assert.Equal(t, "some message", cr[0].Details)
+
+		assert.Equal(t, "openai", cr[1].Name)
+		assert.Equal(t, true, cr[1].Spam)
+		assert.Equal(t, "bad text, confidence: 100%", cr[1].Details)
+
+		assert.Equal(t, 1, len(mockOpenAIClient.CreateChatCompletionCalls()))
+	})
+
+	t.Run("with openai, first-only spam detected before, veto failed", func(t *testing.T) {
+		d := NewDetector(Config{MaxAllowedEmoji: -1, FirstMessageOnly: true, OpenAIVeto: true})
+		mockOpenAIClient := &mocks.OpenAIClientMock{
+			CreateChatCompletionFunc: func(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+				return openai.ChatCompletionResponse{
+					Choices: []openai.ChatCompletionChoice{{
+						Message: openai.ChatCompletionMessage{Content: `{"spam": false, "reason":"good text", "confidence":100}`},
+					}},
+				}, nil
+			},
+		}
+		d.WithOpenAIChecker(mockOpenAIClient, OpenAIConfig{Model: "gpt4"})
+		d.LoadStopWords(strings.NewReader("some message"))
+
+		spam, cr := d.Check("some message 1234", "")
+		assert.Equal(t, false, spam)
+		require.Len(t, cr, 2)
+		assert.Equal(t, "stopword", cr[0].Name)
+		assert.Equal(t, true, cr[0].Spam)
+		assert.Equal(t, "some message", cr[0].Details)
+
+		assert.Equal(t, "openai", cr[1].Name)
+		assert.Equal(t, false, cr[1].Spam)
+		assert.Equal(t, "good text, confidence: 100%", cr[1].Details)
+
+		assert.Equal(t, 1, len(mockOpenAIClient.CreateChatCompletionCalls()))
+	})
 }
 
 func TestDetector_UpdateSpam(t *testing.T) {

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -99,8 +99,8 @@ Setting `--openai.token [$OPENAI_PROMPT]` enables OpenAI integration. All other 
 
 To keep the number of calls low and the price manageable, the bot uses the following approach:
 
-- Only the first message from a given user is checked for spam. If `--paranoid` mode is enabled, openai will not be used at all.
-- OpenAI check is the last in the chain of checks. If any of the previous checks marked the message as spam, the bot will not call OpenAI.
+- Only the first message(s) from a given user is checked for spam. If `--paranoid` mode is enabled, openai will not be used at all.
+- OpenAI check is the last in the chain of checks. Unless `--openai.veto` is not set, the bot will not even call OpenAI if any of the previous checks marked the message as spam. However, if `--openai.veto` is set, it will be called and the message will be marked as spam only if OpenAI thinks so.
 - By default, OpenAI integration is disabled. 
 
 **Emoji Count**
@@ -230,6 +230,7 @@ openai:
       --openai.token=               openai token, disabled if not set [$OPENAI_TOKEN]
       --openai.prompt=              openai system prompt, if empty uses builtin default [$OPENAI_PROMPT]
       --openai.model=               openai model (default: gpt-4) [$OPENAI_MODEL]
+      --openai.veto                 veto mode, confirm detected spam [$OPENAI_VETO]
       --openai.max-tokens-response= openai max tokens in response (default: 1024) [$OPENAI_MAX_TOKENS_RESPONSE]
       --openai.max-tokens-request=  openai max tokens in request (default: 2048) [$OPENAI_MAX_TOKENS_REQUEST]
       --openai.max-symbols-request= openai max symbols in request, failback if tokenizer failed (default: 16000) [$OPENAI_MAX_SYMBOLS_REQUEST]


### PR DESCRIPTION
Before this change, OpenAI was called only if all other checks passed with the "ham" results. This meant that OpenAI was used to improve the false-negative rate. However, improving the false-positive rate is important, and in some cases, even more so. The change introduces a `--openai.veto` flag, which enforces an OpenAI call if spam is detected by other checks. The final result will be labeled as "spam" only if OpenAI agrees.

The change is backward compatible, with the veto set to false by default.