### PR TITLE
OnlyIfBanned flag for unbanChatMember telegram API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ telegram:
       --telegram.group=             group name/id [$TELEGRAM_GROUP]
       --telegram.timeout=           http client timeout for telegram (default: 30s) [$TELEGRAM_TIMEOUT]
       --telegram.idle=              idle duration (default: 30s) [$TELEGRAM_IDLE]
+      --telegram.preserve-unbanned  preserve user after unban [$TELEGRAM_PRESERVE_UNBANNED]
 
 logger:
       --logger.enabled              enable spam rotated logs [$LOGGER_ENABLED]
@@ -261,6 +262,7 @@ Help Options:
 - `no-spam-reply` - if set to `true`, the bot will not reply to spam messages. By default, the bot will reply to spam messages with the text `this is spam` and `this is spam (dry mode)` for dry mode. In non-dry mode, the bot will delete the spam message and ban the user permanently with no reply to the group.
 - `history-duration` defines how long to keep the message in the internal cache. If the message is older than this value, it will be removed from the cache. The default value is 1 hour. The cache is used to match the original message with the forwarded one. See [Updating spam and ham samples dynamically](#updating-spam-and-ham-samples-dynamically) section for more details.
 - `history-min-size` defines the minimal number of messages to keep in the internal cache. If the number of messages is greater than this value, and the `history-duration` exceeded, the oldest messages will be removed from the cache.
+- `--telegram.preserve-unbanned` - if set to `true`, the bot **will not remove** unbanned user from the group, which is default behaviour of [telegram API unbanChatMember](https://core.telegram.org/bots/api#unbanchatmember) method.
 - `--testing-id` - this is needed to debug things if something unusual is going on. All it does is adding any chat ID to the list of chats bots will listen to. This is useful for debugging purposes only, but should not be used in production. 
 - `--paranoid` - if set to `true`, the bot will check all the messages for spam, not just the first one. This is useful for testing and training purposes.
 - `--first-messages-count` - defines how many messages to check for spam. By default, the bot checks only the first message from a given user. However, in some cases, it is useful to check more than one message. For example, if the observed spam starts with a few non-spam messages, the bot will not be able to detect it. Setting this parameter to a higher value will allow the bot to detect such spam. Note: this parameter is ignored if `--paranoid` mode is enabled.

--- a/app/events/events.go
+++ b/app/events/events.go
@@ -43,6 +43,7 @@ type TelegramListener struct {
 	NoSpamReply  bool
 	TrainingMode bool
 	Dry          bool
+	KeepUser     bool
 	Locator      *Locator
 
 	chatID      int64
@@ -481,7 +482,7 @@ func (l *TelegramListener) handleUnbanCallback(query *tbapi.CallbackQuery) error
 
 	// unban user
 	if !l.TrainingMode {
-		_, err = l.TbAPI.Request(tbapi.UnbanChatMemberConfig{ChatMemberConfig: tbapi.ChatMemberConfig{UserID: userID, ChatID: l.chatID}})
+		_, err = l.TbAPI.Request(tbapi.UnbanChatMemberConfig{ChatMemberConfig: tbapi.ChatMemberConfig{UserID: userID, ChatID: l.chatID}, OnlyIfBanned: l.KeepUser})
 		if err != nil {
 			return fmt.Errorf("failed to unban user %d: %w", userID, err)
 		}

--- a/app/main.go
+++ b/app/main.go
@@ -31,10 +31,11 @@ import (
 
 type options struct {
 	Telegram struct {
-		Token        string        `long:"token" env:"TOKEN" description:"telegram bot token" required:"true"`
-		Group        string        `long:"group" env:"GROUP" description:"group name/id" required:"true"`
-		Timeout      time.Duration `long:"timeout" env:"TIMEOUT" default:"30s" description:"http client timeout for telegram" `
-		IdleDuration time.Duration `long:"idle" env:"IDLE" default:"30s" description:"idle duration"`
+		Token            string        `long:"token" env:"TOKEN" description:"telegram bot token" required:"true"`
+		Group            string        `long:"group" env:"GROUP" description:"group name/id" required:"true"`
+		Timeout          time.Duration `long:"timeout" env:"TIMEOUT" default:"30s" description:"http client timeout for telegram" `
+		IdleDuration     time.Duration `long:"idle" env:"IDLE" default:"30s" description:"idle duration"`
+		PreserveUnbanned bool          `long:"preserve-unbanned" env:"PRESERVE_UNBANNED" description:"preserve user after unban"`
 	} `group:"telegram" namespace:"telegram" env-namespace:"TELEGRAM"`
 
 	AdminGroup      string        `long:"admin.group" env:"ADMIN_GROUP" description:"admin group name, or channel id"`
@@ -191,10 +192,11 @@ func execute(ctx context.Context, opts options) error {
 		Locator:      events.NewLocator(opts.HistoryDuration, opts.HistoryMinSize),
 		TrainingMode: opts.Training,
 		Dry:          opts.Dry,
+		KeepUser:     !opts.Telegram.PreserveUnbanned,
 	}
-	log.Printf("[DEBUG] telegram listener config: {group: %s, idle: %v, super: %v, admin: %s, testing: %v, no-reply: %v, dry: %v}",
+	log.Printf("[DEBUG] telegram listener config: {group: %s, idle: %v, super: %v, admin: %s, testing: %v, no-reply: %v, dry: %v, preserve-unbanned: %v}",
 		tgListener.Group, tgListener.IdleDuration, tgListener.SuperUsers, tgListener.AdminGroup,
-		tgListener.TestingIDs, tgListener.NoSpamReply, tgListener.Dry)
+		tgListener.TestingIDs, tgListener.NoSpamReply, tgListener.Dry, tgListener.KeepUser)
 
 	// run telegram listener and event processor loop
 	if err := tgListener.Do(ctx); err != nil {


### PR DESCRIPTION
Addresses #12 

Adds `--telegram.preserve-unbanned` flag for avoiding situation when user is removed from group after unban. Also updates docs accordingly.

Telegram API [docs](https://core.telegram.org/bots/api#unbanchatmember) for reference.

