### PR TITLE
retry plain text send if md fails

### DIFF
--- a/app/events/events_test.go
+++ b/app/events/events_test.go
@@ -1264,3 +1264,44 @@ func prepTestLocator(t *testing.T) (loc *storage.Locator, teardown func()) {
 		os.Remove(f.Name())
 	}
 }
+
+func TestTelegramListener_send(t *testing.T) {
+	mockAPI := &mocks.TbAPIMock{
+		SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+			if mc, ok := c.(tbapi.MessageConfig); ok {
+				if mc.Text == "badmd" && mc.ParseMode == "Markdown" {
+					return tbapi.Message{}, errors.New("bad markdown")
+				}
+			}
+			return tbapi.Message{}, nil
+		},
+	}
+	listener := TelegramListener{TbAPI: mockAPI}
+
+	t.Run("send with markdown passed", func(t *testing.T) {
+		mockAPI.ResetCalls()
+		err := listener.send(tbapi.NewMessage(123, "test"))
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(mockAPI.SendCalls()))
+		assert.Equal(t, int64(123), mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ChatID)
+		assert.Equal(t, "test", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text)
+		assert.Equal(t, "Markdown", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ParseMode)
+	})
+
+	t.Run("send with markdown failed", func(t *testing.T) {
+		mockAPI.ResetCalls()
+		err := listener.send(tbapi.NewMessage(123, "badmd"))
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, len(mockAPI.SendCalls()))
+
+		assert.Equal(t, int64(123), mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ChatID)
+		assert.Equal(t, "badmd", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text)
+		assert.Equal(t, "Markdown", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ParseMode)
+
+		assert.Equal(t, int64(123), mockAPI.SendCalls()[1].C.(tbapi.MessageConfig).ChatID)
+		assert.Equal(t, "badmd", mockAPI.SendCalls()[1].C.(tbapi.MessageConfig).Text)
+		assert.Equal(t, "", mockAPI.SendCalls()[1].C.(tbapi.MessageConfig).ParseMode)
+	})
+
+}


### PR DESCRIPTION
On some messages forwarded to the admin chat or edited in this chat by the bot occasionally, we get errors on entity decoding. This is likely some incompatibility with the message text and enforced markdown mode. I have tried to sanitize all I can, but to prevent those errors, this PR adds failback to plain text if the markdown send call fails.

