### PR TITLE
Volume warns and base image change

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+data/ham-dynamic.txt
+data/spam-dynamic.txt
+data/tg-spam.db

--- a/app/events/admin.go
+++ b/app/events/admin.go
@@ -178,7 +178,7 @@ func (a *admin) InlineCallbackHandler(query *tbapi.CallbackQuery) error {
 }
 
 // callbackAskBanConfirmation sends a confirmation message to admin chat with two buttons: "unban" and "keep it banned"
-// callback data: +userID
+// callback data: ?userID
 func (a *admin) callbackAskBanConfirmation(query *tbapi.CallbackQuery) error {
 	callbackData := query.Data
 

--- a/app/main.go
+++ b/app/main.go
@@ -142,6 +142,9 @@ func main() {
 		cancel()
 	}()
 
+	opts.Files.DynamicDataPath = expandPath(opts.Files.DynamicDataPath)
+	opts.Files.SamplesDataPath = expandPath(opts.Files.SamplesDataPath)
+
 	if err := execute(ctx, opts); err != nil {
 		log.Printf("[ERROR] %v", err)
 		os.Exit(1)
@@ -472,6 +475,24 @@ func autoSaveApprovedUsers(ctx context.Context, detector *lib.Detector, store *s
 			lastCount = len(ids)
 		}
 	}
+}
+
+func expandPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	if path[0] == '~' {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		return filepath.Join(home, path[1:])
+	}
+	ep, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return ep
 }
 
 type nopWriteCloser struct{ io.Writer }

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -253,7 +253,7 @@ func Test_checkVolumeMount(t *testing.T) {
 		}
 
 		if notMountedExists {
-			os.WriteFile(filepath.Join(tempDir, dynamicDataPath, ".not_mounted"), []byte{}, 00644)
+			os.WriteFile(filepath.Join(tempDir, dynamicDataPath, ".not_mounted"), []byte{}, 0o644)
 		}
 
 		if dynamicDataPath == "" {

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -1,6 +1,9 @@
 package storage
 
-import "github.com/jmoiron/sqlx"
+import (
+	"github.com/jmoiron/sqlx"
+	_ "modernc.org/sqlite" // sqlite driver loaded here
+)
 
 // NewSqliteDB creates a new sqlite database
 func NewSqliteDB(file string) (*sqlx.DB, error) {

--- a/data/.not_mounted
+++ b/data/.not_mounted
@@ -1,0 +1,1 @@
+this file indicates what the data directory is not mounted


### PR DESCRIPTION
Related to #32 

The base scratch image doesn't play well with permissions. It is okay if the volume is mounted or the file is already present, but making a new one under /srv/data directory requires some crazy hacks to ensure this directory is under app user. To address it, I just switched base to Alpine.

In addition, as #32 indicated, users may run it without mounting the dynamic location to the host volume. In some rare case, it can be intentional, so I have decided not to fail load in this case but instead show a warning.