### PR TITLE
add basic ui to check a message for spam

### DIFF
--- a/app/webapi/templates/spam_check.html
+++ b/app/webapi/templates/spam_check.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>TG-Spam Checker</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
+    <script src="https://unpkg.com/htmx.org"></script>
+</head>
+<body>
+<div class="container mt-4">
+    <h1 class="text-center mb-4">TG-Spam Message Checker</h1>
+    <p class="text-center">Version: {{.Version}}</p>
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <form hx-post="/check" hx-target="#result" hx-encoding="json" hx-swap="innerHTML" class="mb-4">
+                <div class="mb-3">
+                    <label for="userId" class="form-label">User ID</label>
+                    <input type="text" class="form-control" id="userId" name="user_id" placeholder="Enter User ID">
+                </div>
+                <div class="mb-3">
+                    <label for="message" class="form-label">Message</label>
+                    <textarea id="message" name="msg" class="form-control" placeholder="Enter message to check" rows="4"></textarea>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Check</button>
+            </form>
+            <div id="result" class="alert alert-light" role="alert"></div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.min.js"></script>
+
+</body>
+</html>

--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -157,7 +157,7 @@ func (s *Server) checkHandler(w http.ResponseWriter, r *http.Request) {
                 <strong>Result:</strong> {{if .Spam}}Spam detected{{else}}No spam detected{{end}}
             </div>
             {{range .Checks}}
-                <div class="mb-2">
+                <div class="mb-2 {{if .Spam}}text-danger{{else}}text-success{{end}}">
                     <strong>{{.Name}}:</strong> {{.Details}}
                 </div>
             {{end}}


### PR DESCRIPTION
This is just a simple page allowing to run a message with an (optional) userID against the tg-bot spam checks. Need the same basic auth as the API 

<img width="736" alt="image" src="https://github.com/umputun/tg-spam/assets/535880/b8406b52-1649-4cc7-bd65-f1d0617bf4b2">
