### PR TITLE
Add from detected spam

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -363,15 +363,15 @@ func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *
 	}
 
 	srv := webapi.Server{Config: webapi.Config{
-		ListenAddr:         opts.Server.ListenAddr,
-		Detector:           sf.Detector,
-		SpamFilter:         sf,
-		Locator:            loc,
-		DetectedSpamReader: detectedSpamStore,
-		AuthPasswd:         authPassswd,
-		Version:            revision,
-		Dbg:                opts.Dbg,
-		Settings:           settings,
+		ListenAddr:   opts.Server.ListenAddr,
+		Detector:     sf.Detector,
+		SpamFilter:   sf,
+		Locator:      loc,
+		DetectedSpam: detectedSpamStore,
+		AuthPasswd:   authPassswd,
+		Version:      revision,
+		Dbg:          opts.Dbg,
+		Settings:     settings,
 	}}
 
 	go func() {

--- a/app/webapi/assets/components/heads.html
+++ b/app/webapi/assets/components/heads.html
@@ -1,0 +1,4 @@
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
+<script src="https://unpkg.com/htmx.org"></script>
+<link href="styles.css" rel="stylesheet">

--- a/app/webapi/assets/detected_spam.html
+++ b/app/webapi/assets/detected_spam.html
@@ -2,10 +2,7 @@
 <html>
 <head>
     <title>Detected Spam - TG-Spam</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
-    <script src="https://unpkg.com/htmx.org"></script>
-    <link href="styles.css" rel="stylesheet">
+    {{template "heads.html"}}
 </head>
 <body>
 {{template "navbar.html"}}
@@ -26,6 +23,9 @@
                 </thead>
                 <tbody>
                 {{range .DetectedSpamEntries}}
+                {{$text := .Text}}
+                {{$id := .ID}}
+                {{$added := .Added}}
                 <tr>
                     <td class="ds-timestamp">{{.Timestamp.Format "2006-01-02 15:04:05"}}</td>
                     <td>{{.UserID}}</td>
@@ -33,10 +33,21 @@
                     <td class="ds-text">{{.Text}}</td>
                     <td class="ds-checks">
                         {{range .Checks}}
-                        <div class="{{if .Spam}}text-danger{{else}}text-success{{end}}">
-                            <strong>{{.Name}}:</strong> {{.Details}}
+                        <div style="display: flex; align-items: center;">
+                            <div class="{{if .Spam}}text-danger{{else}}text-success{{end}}" style="flex-grow: 1;">
+                                <strong>{{.Name}}:</strong> {{.Details}}
+                            </div>
+                            {{if and (not .Spam) (not $added) (eq .Name "classifier")}}
+                            <button
+                                    hx-post="/detected_spam/add" hx-vals='{"id": {{$id}}, "msg": "{{$text}}"}' hx-target="html"
+                                    hx-swap="innerHTML" class="btn btn-sm btn-warning"
+                                    title="Add this message to spam samples">
+                                Add
+                            </button>
+                            {{end}}
                         </div>
                         {{end}}
+                    </td>
                 </tr>
                 {{else}}
                 <tr>

--- a/app/webapi/assets/detected_spam.html
+++ b/app/webapi/assets/detected_spam.html
@@ -10,6 +10,7 @@
 <div class="container mt-4">
     <div class="row" id="spam-list">
         <div class="col-md-12">
+            <div id="error-message" class="alert alert-danger d-none" role="alert"></div>
             <h4>Detected Spam ({{.TotalDetectedSpam}})</h4>
             <table class="table table-striped">
                 <thead class="custom-table-header">
@@ -39,8 +40,9 @@
                             </div>
                             {{if and (not .Spam) (not $added) (eq .Name "classifier")}}
                             <button
-                                    hx-post="/detected_spam/add" hx-vals='{"id": {{$id}}, "msg": "{{$text}}"}' hx-target="html"
-                                    hx-swap="innerHTML" class="btn btn-sm btn-warning"
+                                    hx-post="/detected_spam/add" hx-vals='{"id": {{$id}}, "msg": "{{$text}}"}'
+                                    hx-target="#error-message" hx-error="#error-message" hx-swap="outerHTML"
+                                    class="btn btn-sm btn-warning"
                                     title="Add this message to spam samples">
                                 Add
                             </button>

--- a/app/webapi/assets/manage_samples.html
+++ b/app/webapi/assets/manage_samples.html
@@ -2,10 +2,7 @@
 <html>
 <head>
     <title>Manage Samples - TG-Spam</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
-    <script src="https://unpkg.com/htmx.org"></script>
-    <link href="styles.css" rel="stylesheet">
+    {{template "heads.html"}}
 </head>
 <body>
 {{template "navbar.html"}}

--- a/app/webapi/assets/manage_users.html
+++ b/app/webapi/assets/manage_users.html
@@ -2,10 +2,7 @@
 <html>
 <head>
     <title>Manage Users - TG-Spam</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
-    <script src="https://unpkg.com/htmx.org"></script>
-    <link href="styles.css" rel="stylesheet">
+    {{template "heads.html"}}
 </head>
 <body>
 {{template "navbar.html"}}

--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -2,9 +2,7 @@
 <html>
 <head>
     <title>Settings - TG-Spam</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="styles.css" rel="stylesheet">
+    {{template "heads.html"}}
 </head>
 <body>
 

--- a/app/webapi/mocks/detected_spam.go
+++ b/app/webapi/mocks/detected_spam.go
@@ -8,38 +8,50 @@ import (
 	"sync"
 )
 
-// DetectedSpamReaderMock is a mock implementation of webapi.DetectedSpamReader.
+// DetectedSpamMock is a mock implementation of webapi.DetectedSpam.
 //
-//	func TestSomethingThatUsesDetectedSpamReader(t *testing.T) {
+//	func TestSomethingThatUsesDetectedSpam(t *testing.T) {
 //
-//		// make and configure a mocked webapi.DetectedSpamReader
-//		mockedDetectedSpamReader := &DetectedSpamReaderMock{
+//		// make and configure a mocked webapi.DetectedSpam
+//		mockedDetectedSpam := &DetectedSpamMock{
 //			ReadFunc: func() ([]storage.DetectedSpamInfo, error) {
 //				panic("mock out the Read method")
 //			},
+//			SetAddedToSamplesFlagFunc: func(id int64) error {
+//				panic("mock out the SetAddedToSamplesFlag method")
+//			},
 //		}
 //
-//		// use mockedDetectedSpamReader in code that requires webapi.DetectedSpamReader
+//		// use mockedDetectedSpam in code that requires webapi.DetectedSpam
 //		// and then make assertions.
 //
 //	}
-type DetectedSpamReaderMock struct {
+type DetectedSpamMock struct {
 	// ReadFunc mocks the Read method.
 	ReadFunc func() ([]storage.DetectedSpamInfo, error)
+
+	// SetAddedToSamplesFlagFunc mocks the SetAddedToSamplesFlag method.
+	SetAddedToSamplesFlagFunc func(id int64) error
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// Read holds details about calls to the Read method.
 		Read []struct {
 		}
+		// SetAddedToSamplesFlag holds details about calls to the SetAddedToSamplesFlag method.
+		SetAddedToSamplesFlag []struct {
+			// ID is the id argument value.
+			ID int64
+		}
 	}
-	lockRead sync.RWMutex
+	lockRead                  sync.RWMutex
+	lockSetAddedToSamplesFlag sync.RWMutex
 }
 
 // Read calls ReadFunc.
-func (mock *DetectedSpamReaderMock) Read() ([]storage.DetectedSpamInfo, error) {
+func (mock *DetectedSpamMock) Read() ([]storage.DetectedSpamInfo, error) {
 	if mock.ReadFunc == nil {
-		panic("DetectedSpamReaderMock.ReadFunc: method is nil but DetectedSpamReader.Read was just called")
+		panic("DetectedSpamMock.ReadFunc: method is nil but DetectedSpam.Read was just called")
 	}
 	callInfo := struct {
 	}{}
@@ -52,8 +64,8 @@ func (mock *DetectedSpamReaderMock) Read() ([]storage.DetectedSpamInfo, error) {
 // ReadCalls gets all the calls that were made to Read.
 // Check the length with:
 //
-//	len(mockedDetectedSpamReader.ReadCalls())
-func (mock *DetectedSpamReaderMock) ReadCalls() []struct {
+//	len(mockedDetectedSpam.ReadCalls())
+func (mock *DetectedSpamMock) ReadCalls() []struct {
 } {
 	var calls []struct {
 	}
@@ -64,15 +76,58 @@ func (mock *DetectedSpamReaderMock) ReadCalls() []struct {
 }
 
 // ResetReadCalls reset all the calls that were made to Read.
-func (mock *DetectedSpamReaderMock) ResetReadCalls() {
+func (mock *DetectedSpamMock) ResetReadCalls() {
 	mock.lockRead.Lock()
 	mock.calls.Read = nil
 	mock.lockRead.Unlock()
 }
 
+// SetAddedToSamplesFlag calls SetAddedToSamplesFlagFunc.
+func (mock *DetectedSpamMock) SetAddedToSamplesFlag(id int64) error {
+	if mock.SetAddedToSamplesFlagFunc == nil {
+		panic("DetectedSpamMock.SetAddedToSamplesFlagFunc: method is nil but DetectedSpam.SetAddedToSamplesFlag was just called")
+	}
+	callInfo := struct {
+		ID int64
+	}{
+		ID: id,
+	}
+	mock.lockSetAddedToSamplesFlag.Lock()
+	mock.calls.SetAddedToSamplesFlag = append(mock.calls.SetAddedToSamplesFlag, callInfo)
+	mock.lockSetAddedToSamplesFlag.Unlock()
+	return mock.SetAddedToSamplesFlagFunc(id)
+}
+
+// SetAddedToSamplesFlagCalls gets all the calls that were made to SetAddedToSamplesFlag.
+// Check the length with:
+//
+//	len(mockedDetectedSpam.SetAddedToSamplesFlagCalls())
+func (mock *DetectedSpamMock) SetAddedToSamplesFlagCalls() []struct {
+	ID int64
+} {
+	var calls []struct {
+		ID int64
+	}
+	mock.lockSetAddedToSamplesFlag.RLock()
+	calls = mock.calls.SetAddedToSamplesFlag
+	mock.lockSetAddedToSamplesFlag.RUnlock()
+	return calls
+}
+
+// ResetSetAddedToSamplesFlagCalls reset all the calls that were made to SetAddedToSamplesFlag.
+func (mock *DetectedSpamMock) ResetSetAddedToSamplesFlagCalls() {
+	mock.lockSetAddedToSamplesFlag.Lock()
+	mock.calls.SetAddedToSamplesFlag = nil
+	mock.lockSetAddedToSamplesFlag.Unlock()
+}
+
 // ResetCalls reset all the calls that were made to all mocked methods.
-func (mock *DetectedSpamReaderMock) ResetCalls() {
+func (mock *DetectedSpamMock) ResetCalls() {
 	mock.lockRead.Lock()
 	mock.calls.Read = nil
 	mock.lockRead.Unlock()
+
+	mock.lockSetAddedToSamplesFlag.Lock()
+	mock.calls.SetAddedToSamplesFlag = nil
+	mock.lockSetAddedToSamplesFlag.Unlock()
 }

--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -579,7 +579,8 @@ func (s *Server) htmlAddDetectedSpamHandler(w http.ResponseWriter, r *http.Reque
 		fmt.Fprintf(w, "<div class='alert alert-danger'>%s</div>", err)
 	}
 	msg := r.FormValue("msg")
-	id, err := strconv.Atoi(r.FormValue("id"))
+
+	id, err := strconv.ParseInt(r.FormValue("id"), 10, 64)
 	if err != nil || msg == "" {
 		log.Printf("[WARN] bad request: %v", err)
 		reportErr(fmt.Errorf("bad request: %v", err), http.StatusBadRequest)
@@ -592,7 +593,7 @@ func (s *Server) htmlAddDetectedSpamHandler(w http.ResponseWriter, r *http.Reque
 		return
 
 	}
-	if err := s.DetectedSpam.SetAddedToSamplesFlag(int64(id)); err != nil {
+	if err := s.DetectedSpam.SetAddedToSamplesFlag(id); err != nil {
 		log.Printf("[WARN] failed to update detected spam: %v", err)
 		reportErr(fmt.Errorf("can't update detected spam: %v", err), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
this is needed if spam detected by heuristic method, like number of emojis or links but failed to be detected by classifier. in this case it makes sense to add it to dynamic spam samples directly from WebUI