### PR TITLE
Added /report command

### DIFF
--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -145,7 +145,7 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 
 			// handle spam reports from superusers
 			if update.Message.ReplyToMessage != nil && l.SuperUsers.IsSuper(update.Message.From.UserName) {
-				if strings.EqualFold(update.Message.Text, "/spam") || strings.EqualFold(update.Message.Text, "spam") {
+				if strings.EqualFold(update.Message.Text, "/spam") || strings.EqualFold(update.Message.Text, "spam") || strings.EqualFold(update.Message.Text, "/report") {
 					log.Printf("[DEBUG] superuser %s reported spam", update.Message.From.UserName)
 					if err := l.adminHandler.DirectSpamReport(update); err != nil {
 						log.Printf("[WARN] failed to process direct spam report: %v", err)


### PR DESCRIPTION
The /report command has been added as an analogue of /spam, because most likely many people are more familiar with this command for reporting a message containing spam.