### PR TITLE
Implement duplicate prevention in file append function for samples

### DIFF
--- a/app/bot/sample_updater_test.go
+++ b/app/bot/sample_updater_test.go
@@ -28,6 +28,32 @@ func TestSampleUpdater(t *testing.T) {
 		assert.Equal(t, "Test message\n", string(content))
 	})
 
+	t.Run("dedup", func(t *testing.T) {
+		file, err := os.CreateTemp(os.TempDir(), "sample")
+		require.NoError(t, err)
+		defer os.Remove(file.Name())
+
+		updater := NewSampleUpdater(file.Name())
+		err = updater.Append("Test message")
+		assert.NoError(t, err)
+
+		// duplicate message
+		err = updater.Append(" Test message  ")
+		assert.NoError(t, err)
+
+		// duplicate message
+		err = updater.Append(" TesT MessagE")
+		assert.NoError(t, err)
+
+		reader, err := updater.Reader()
+		require.NoError(t, err)
+		defer reader.Close()
+
+		content, err := io.ReadAll(reader)
+		assert.NoError(t, err)
+		assert.Equal(t, "Test message\n", string(content))
+	})
+
 	t.Run("multi-line", func(t *testing.T) {
 		file, err := os.CreateTemp(os.TempDir(), "sample")
 		require.NoError(t, err)


### PR DESCRIPTION
Added logic to `SampleUpdater`'s `Append` method to check for duplicate messages in the file before appending new ones. This functionality prevents the addition of duplicate entries, with case and leading/trailing whitespace irrelevant in determining duplicates.

fixes #63 