### PR TITLE
Remove unused gomod update config, remove alpine updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,6 @@ updates:
       "GitHub Actions updates":
         patterns:
           - "*"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -24,8 +20,6 @@ updates:
     groups:
       "Go modules updates":
         dependency-type: "production"
-      "Go modules updates for tests":
-        dependency-type: "development"
   - package-ecosystem: "gomod"
     directory: "/_examples/simplechat"
     schedule:
@@ -33,5 +27,3 @@ updates:
     groups:
       "Go modules updates":
         dependency-type: "production"
-      "Go modules updates for tests":
-        dependency-type: "development"


### PR DESCRIPTION
There are no Go development dependencies in existence, and there is no point in updating alpine in Dockerfile the moment it releases new version.