### PR TITLE
ignore classifier check if either spam or ham samples not loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Another useful feature is the ability to keep the list of approved users persist
 
 This is the main spam detection module. It uses the list of spam and ham samples to detect spam by using Bayes classifier. The bot is enabled as long as `--files.samples=, [$FILES_SAMPLES]`, point to existing directory with all the sample files (see above). There is also a parameter to set minimum spam probability percent to ban the user. If the probability of spam is less than `--min-probability=, [$MIN_PROBABILITY]` (default is 50), the message is not marked as spam. 
 
+The analysis is active only if both ham and spam samples files are present and not empty. 
+
 **Spam message similarity check**
 
 This check uses provides samples files and active by default. The bot compares the message with the samples and if the similarity is greater than `--similarity-threshold=, [$SIMILARITY_THRESHOLD]` (default is 0.5), the message is marked as spam. Setting the similarity threshold to 1 will effectively disable this check.  

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -163,7 +163,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	}
 
 	// check for spam with classifier if classifier is loaded
-	if d.classifier.nAllDocument > 0 {
+	if d.classifier.nAllDocument > 0 && d.classifier.nDocumentByClass["ham"] > 0 && d.classifier.nDocumentByClass["spam"] > 0 {
 		cr = append(cr, d.isSpamClassified(req.Msg))
 	}
 


### PR DESCRIPTION
In the discussion at https://github.com/umputun/tg-spam/discussions/98, we encountered a scenario where there were no samples available, yet dynamic spam was being learned. This occurred because a binary version was executed without any spam or ham samples. Consequently, the classifier only had spam samples (without any ham samples) and tended to label many messages as spam. While this behavior is technically logical, it is surprising and unexpected for users.

This pull request addresses the issue by disabling the classifier check when either the spam samples or ham samples are empty. Although this fix is not perfect and may lead to some confusion when users add spam samples without observing any immediate changes, it is considered preferable as it is less disruptive.

Furthermore, the documentation will be updated to explain how the system operates in the absence of ham or spam samples.