### PR TITLE
Delete the system message about joining a group (issue #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Success! The new status is: DISABLED. /help
       --history-min-size=           history minimal size to keep (default: 1000) [$HISTORY_MIN_SIZE]
       --super=                      super-users [$SUPER_USER]
       --no-spam-reply               do not reply to spam messages [$NO_SPAM_REPLY]
+      --suppress-join-message       delete join message if user is kicked out [$SUPPRESS_JOIN_MESSAGE]
       --similarity-threshold=       spam threshold (default: 0.5) [$SIMILARITY_THRESHOLD]
       --min-msg-len=                min message length to check (default: 50) [$MIN_MSG_LEN]
       --max-emoji=                  max emoji count in message, -1 to disable check (default: 2) [$MAX_EMOJI]
@@ -307,6 +308,7 @@ Help Options:
 - `no-spam-reply` - if set to `true`, the bot will not reply to spam messages. By default, the bot will reply to spam messages with the text `this is spam` and `this is spam (dry mode)` for dry mode. In non-dry mode, the bot will delete the spam message and ban the user permanently with no reply to the group.
 - `history-duration` defines how long to keep the message in the internal cache. If the message is older than this value, it will be removed from the cache. The default value is 1 hour. The cache is used to match the original message with the forwarded one. See [Updating spam and ham samples dynamically](#updating-spam-and-ham-samples-dynamically) section for more details.
 - `history-min-size` defines the minimal number of messages to keep in the internal cache. If the number of messages is greater than this value, and the `history-duration` exceeded, the oldest messages will be removed from the cache.
+- `suppress-join-message` - if set to `true`, the bot will delete the join message from the group if the user is kicked out. This is useful to keep the group clean from spam messages.
 - `--testing-id` - this is needed to debug things if something unusual is going on. All it does is adding any chat ID to the list of chats bots will listen to. This is useful for debugging purposes only, but should not be used in production. 
 - `--paranoid` - if set to `true`, the bot will check all the messages for spam, not just the first one. This is useful for testing and training purposes.
 - `--first-messages-count` - defines how many messages to check for spam. By default, the bot checks only the first message from a given user. However, in some cases, it is useful to check more than one message. For example, if the observed spam starts with a few non-spam messages, the bot will not be able to detect it. Setting this parameter to a higher value will allow the bot to detect such spam. Note: this parameter is ignored if `--paranoid` mode is enabled.

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -150,6 +150,22 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 				continue
 			}
 
+			if update.Message.NewChatMembers != nil {
+				err := l.procNewChatMemberMessage(update)
+				if err != nil {
+					log.Printf("[WARN] failed to process new chat member: %v", err)
+				}
+				continue
+			}
+
+			if update.Message.LeftChatMember != nil {
+				err := l.procLeftChatMemberMessage(update)
+				if err != nil {
+					log.Printf("[WARN] failed to process left chat member: %v", err)
+				}
+				continue
+			}
+
 			// handle spam reports from superusers
 			if update.Message.ReplyToMessage != nil && l.SuperUsers.IsSuper(update.Message.From.UserName) {
 				if strings.EqualFold(update.Message.Text, "/spam") || strings.EqualFold(update.Message.Text, "spam") {
@@ -187,6 +203,48 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (l *TelegramListener) procNewChatMemberMessage(update tbapi.Update) error {
+	fromChat := update.Message.Chat.ID
+	// ignore messages from other chats except the one we are monitor and ones from the test list
+	if !l.isChatAllowed(fromChat) {
+		return nil
+	}
+
+	errs := new(multierror.Error)
+
+	for _, member := range update.Message.NewChatMembers {
+		msg := fmt.Sprintf("new_%d_%d", fromChat, member.ID)
+		if err := l.Locator.AddMessage(msg, fromChat, member.ID, "", update.Message.MessageID); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("failed to add new chat member message to locator: %w", err))
+		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func (l *TelegramListener) procLeftChatMemberMessage(update tbapi.Update) error {
+	fromChat := update.Message.Chat.ID
+	// ignore messages from other chats except the one we are monitor and ones from the test list
+	if !l.isChatAllowed(fromChat) {
+		return nil
+	}
+
+	if update.Message.From.ID == update.Message.LeftChatMember.ID {
+		log.Printf("[DEBUG] left chat member is the same as the message sender, ignored")
+		return nil
+	}
+	msg, found := l.Locator.Message(fmt.Sprintf("new_%d_%d", fromChat, update.Message.LeftChatMember.ID))
+	if !found {
+		log.Printf("[DEBUG] no new chat member message found for %d in chat %d", update.Message.LeftChatMember.ID, fromChat)
+		return nil
+	}
+	if _, err := l.TbAPI.Request(tbapi.DeleteMessageConfig{ChatID: fromChat, MessageID: msg.MsgID}); err != nil {
+		return fmt.Errorf("failed to delete new chat member message %d: %w", msg.MsgID, err)
+	}
+
+	return nil
 }
 
 func (l *TelegramListener) procEvents(update tbapi.Update) error {

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -217,7 +217,6 @@ func (l *TelegramListener) procNewChatMemberMessage(update tbapi.Update) error {
 		return nil
 	}
 
-	// ignore multiple new chat members, because we can't delete this message if one of them kicked out
 	if len(update.Message.NewChatMembers) != 1 {
 		log.Printf("[DEBUG] we are expecting only one new chat member, got %d", len(update.Message.NewChatMembers))
 		return nil

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -218,18 +218,17 @@ func (l *TelegramListener) procNewChatMemberMessage(update tbapi.Update) error {
 	}
 
 	// ignore multiple new chat members, because we can't delete this message if one of them kicked out
-	if len(update.Message.NewChatMembers) > 1 {
-		log.Printf("[DEBUG] multiple new chat members, ignored")
+	if len(update.Message.NewChatMembers) != 1 {
+		log.Printf("[DEBUG] we are expecting only one new chat member, got %d", len(update.Message.NewChatMembers))
 		return nil
 	}
 
 	errs := new(multierror.Error)
 
-	for _, member := range update.Message.NewChatMembers {
-		msg := fmt.Sprintf("new_%d_%d", fromChat, member.ID)
-		if err := l.Locator.AddMessage(msg, fromChat, member.ID, "", update.Message.MessageID); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("failed to add new chat member message to locator: %w", err))
-		}
+	member := update.Message.NewChatMembers[0]
+	msg := fmt.Sprintf("new_%d_%d", fromChat, member.ID)
+	if err := l.Locator.AddMessage(msg, fromChat, member.ID, "", update.Message.MessageID); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("failed to add new chat member message to locator: %w", err))
 	}
 
 	return errs.ErrorOrNil()

--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -1218,6 +1219,203 @@ func TestTelegramListener_DoWithAdminShowInfo(t *testing.T) {
 	require.Equal(t, 0, len(b.AddApprovedUserCalls()))
 }
 
+func TestTelegramListener_DoWithProcNewChatMemberMessage(t *testing.T) {
+	mockAPI := &mocks.TbAPIMock{
+		GetChatFunc: func(config tbapi.ChatInfoConfig) (tbapi.Chat, error) {
+			return tbapi.Chat{ID: 123}, nil
+		},
+		SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+			return tbapi.Message{Text: c.(tbapi.MessageConfig).Text, From: &tbapi.User{UserName: "user"}}, nil
+		},
+		GetChatAdministratorsFunc: func(config tbapi.ChatAdministratorsConfig) ([]tbapi.ChatMember, error) {
+			return nil, nil
+		},
+	}
+	b := &mocks.BotMock{}
+
+	locator, teardown := prepTestLocator(t)
+	defer teardown()
+
+	l := TelegramListener{
+		TbAPI:      mockAPI,
+		Bot:        b,
+		SuperUsers: SuperUsers{"admin"},
+		Group:      "gr",
+		Locator:    locator,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Minute)
+	defer cancel()
+
+	updMsg := tbapi.Update{
+		Message: &tbapi.Message{
+			Chat:           &tbapi.Chat{ID: 123},
+			From:           &tbapi.User{UserName: "new_user", ID: 321},
+			NewChatMembers: []tbapi.User{{UserName: "new_user", ID: 321}},
+			MessageID:      22,
+		},
+	}
+
+	updChan := make(chan tbapi.Update, 1)
+	updChan <- updMsg
+	close(updChan)
+	mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+	err := l.Do(ctx)
+	assert.EqualError(t, err, "telegram update chan closed")
+
+	meta, found := l.Locator.Message("new_123_321")
+	assert.True(t, found)
+	assert.Equal(t, int64(321), meta.UserID)
+	assert.Equal(t, 22, meta.MsgID)
+	assert.Equal(t, "", meta.UserName)
+	assert.Equal(t, int64(123), meta.ChatID)
+
+}
+
+func TestTelegramListener_DoWithProcLeftChatMemberMessage(t *testing.T) {
+	mockAPI := &mocks.TbAPIMock{
+		GetChatFunc: func(config tbapi.ChatInfoConfig) (tbapi.Chat, error) {
+			return tbapi.Chat{ID: 123}, nil
+		},
+		SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+			return tbapi.Message{Text: c.(tbapi.MessageConfig).Text, From: &tbapi.User{UserName: "user"}}, nil
+		},
+		GetChatAdministratorsFunc: func(config tbapi.ChatAdministratorsConfig) ([]tbapi.ChatMember, error) {
+			return nil, nil
+		},
+		RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+			return &tbapi.APIResponse{}, nil
+		},
+	}
+	b := &mocks.BotMock{}
+
+	locator, teardown := prepTestLocator(t)
+	defer teardown()
+
+	l := TelegramListener{
+		TbAPI:      mockAPI,
+		Bot:        b,
+		SuperUsers: SuperUsers{"admin"},
+		Group:      "gr",
+		Locator:    locator,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Minute)
+	defer cancel()
+
+	//nolint
+	t.Run("user has left the chat by himself", func(t *testing.T) {
+		mockAPI.ResetCalls()
+		updMsg := tbapi.Update{
+			Message: &tbapi.Message{
+				Chat:           &tbapi.Chat{ID: 123},
+				From:           &tbapi.User{UserName: "new_user", ID: 321},
+				LeftChatMember: &tbapi.User{UserName: "new_user", ID: 321},
+				MessageID:      22,
+			},
+		}
+
+		updChan := make(chan tbapi.Update, 1)
+		updChan <- updMsg
+		close(updChan)
+		mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+		err := l.Do(ctx)
+		assert.EqualError(t, err, "telegram update chan closed")
+		assert.Equal(t, 0, len(mockAPI.SendCalls()))
+		require.Equal(t, 0, len(mockAPI.RequestCalls()))
+	})
+
+	//nolint
+	t.Run("user has left the chat by admin, we don't have a message about joining", func(t *testing.T) {
+		mockAPI.ResetCalls()
+		updMsg := tbapi.Update{
+			Message: &tbapi.Message{
+				Chat:           &tbapi.Chat{ID: 123},
+				From:           &tbapi.User{UserName: "new_user", ID: 999},
+				LeftChatMember: &tbapi.User{UserName: "new_user", ID: 321},
+				MessageID:      22,
+			},
+		}
+
+		updChan := make(chan tbapi.Update, 1)
+		updChan <- updMsg
+		close(updChan)
+		mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+		err := l.Do(ctx)
+		assert.EqualError(t, err, "telegram update chan closed")
+		assert.Equal(t, 0, len(mockAPI.SendCalls()))
+		require.Equal(t, 0, len(mockAPI.RequestCalls()))
+	})
+
+	//nolint
+	t.Run("user has left the chat by admin, we have a message about joining", func(t *testing.T) {
+		mockAPI.ResetCalls()
+		updMsg := tbapi.Update{
+			Message: &tbapi.Message{
+				Chat:           &tbapi.Chat{ID: 123},
+				From:           &tbapi.User{UserName: "new_user", ID: 999},
+				LeftChatMember: &tbapi.User{UserName: "new_user", ID: 321},
+				MessageID:      22,
+			},
+		}
+
+		err := locator.AddMessage("new_123_321", 123, 321, "", 21)
+		require.NoError(t, err)
+
+		updChan := make(chan tbapi.Update, 1)
+		updChan <- updMsg
+		close(updChan)
+		mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+		err = l.Do(ctx)
+		assert.EqualError(t, err, "telegram update chan closed")
+		assert.Equal(t, 0, len(mockAPI.SendCalls()))
+		require.Equal(t, 1, len(mockAPI.RequestCalls()))
+		assert.Equal(t, int64(123), mockAPI.RequestCalls()[0].C.(tbapi.DeleteMessageConfig).ChatID)
+		assert.Equal(t, 21, mockAPI.RequestCalls()[0].C.(tbapi.DeleteMessageConfig).MessageID)
+	})
+
+	//nolint
+	t.Run("error from procLeftChatMemberMessage", func(t *testing.T) {
+		mockAPI.ResetCalls()
+
+		updMsg := tbapi.Update{
+			Message: &tbapi.Message{
+				Chat:           &tbapi.Chat{ID: 123},
+				From:           &tbapi.User{UserName: "new_user", ID: 999},
+				LeftChatMember: &tbapi.User{UserName: "new_user", ID: 321},
+				MessageID:      22,
+			},
+		}
+
+		err := locator.AddMessage("new_123_321", 123, 321, "", 21)
+		require.NoError(t, err)
+
+		updChan := make(chan tbapi.Update, 1)
+		updChan <- updMsg
+		close(updChan)
+		mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+		oldRequestFunc := mockAPI.RequestFunc
+		mockAPI.RequestFunc = func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+			return nil, errors.New("some error")
+		}
+		defer func() {
+			mockAPI.RequestFunc = oldRequestFunc
+		}()
+
+		err = l.Do(ctx)
+		assert.EqualError(t, err, "telegram update chan closed")
+		assert.Equal(t, 0, len(mockAPI.SendCalls()))
+		require.Equal(t, 1, len(mockAPI.RequestCalls()))
+		assert.Equal(t, int64(123), mockAPI.RequestCalls()[0].C.(tbapi.DeleteMessageConfig).ChatID)
+		assert.Equal(t, 21, mockAPI.RequestCalls()[0].C.(tbapi.DeleteMessageConfig).MessageID)
+	})
+
+}
+
 func TestTelegramListener_isChatAllowed(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -1419,6 +1617,298 @@ func TestUpdateSupers(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.ElementsMatch(t, tt.expectedResult, l.SuperUsers)
+			}
+		})
+	}
+}
+
+func TestProcNewChatMemberMessage(t *testing.T) {
+	type addMessageArgs struct {
+		Msg      string
+		ChatID   int64
+		UserID   int64
+		UserName string
+		MsgID    int
+	}
+
+	tests := []struct {
+		name                    string
+		update                  tbapi.Update
+		expectedError           bool
+		expectedAddMessageArgs  []addMessageArgs
+		expectedAddMessageCalls int
+		AddMessageMockReturn    error
+	}{
+		{
+			name: "new chat member added by admin successfully",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat: &tbapi.Chat{ID: 123},
+					From: &tbapi.User{UserName: "superuser1", ID: 77},
+					NewChatMembers: []tbapi.User{
+						{ID: 88, UserName: "user1"},
+					},
+					MessageID: 22,
+				},
+			},
+			expectedError: false,
+			expectedAddMessageArgs: []addMessageArgs{
+				{
+					Msg:      "new_123_88",
+					ChatID:   123,
+					UserID:   88,
+					UserName: "",
+					MsgID:    22,
+				},
+			},
+			expectedAddMessageCalls: 1,
+		},
+		{
+			name: "new chat member self joined successfully",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat: &tbapi.Chat{ID: 123},
+					From: &tbapi.User{UserName: "user1", ID: 88},
+					NewChatMembers: []tbapi.User{
+						{ID: 88, UserName: "user1"},
+					},
+					MessageID: 22,
+				},
+			},
+			expectedError: false,
+			expectedAddMessageArgs: []addMessageArgs{
+				{
+					Msg:      "new_123_88",
+					ChatID:   123,
+					UserID:   88,
+					UserName: "",
+					MsgID:    22,
+				},
+			},
+			expectedAddMessageCalls: 1,
+		},
+		{
+			name: "2 new chat member added successfully",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat: &tbapi.Chat{ID: 123},
+					From: &tbapi.User{UserName: "superuser1", ID: 77},
+					NewChatMembers: []tbapi.User{
+						{ID: 88, UserName: "user1"},
+						{ID: 99, UserName: "user1"},
+					},
+					MessageID: 22,
+				},
+			},
+			expectedError: false,
+			expectedAddMessageArgs: []addMessageArgs{
+				{
+					Msg:      "new_123_88",
+					ChatID:   123,
+					UserID:   88,
+					UserName: "",
+					MsgID:    22,
+				},
+				{
+					Msg:      "new_123_99",
+					ChatID:   123,
+					UserID:   99,
+					UserName: "",
+					MsgID:    22,
+				},
+			},
+			expectedAddMessageCalls: 2,
+		},
+		{
+			name: "empty chat members in the message",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat:           &tbapi.Chat{ID: 123},
+					NewChatMembers: []tbapi.User{},
+				},
+			},
+			expectedError:           false,
+			expectedAddMessageArgs:  []addMessageArgs{},
+			expectedAddMessageCalls: 0,
+		},
+		{
+			name: "message from unauthorized chat",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat: &tbapi.Chat{ID: 999},
+					NewChatMembers: []tbapi.User{
+						{ID: 88, UserName: "user1"},
+					},
+				},
+			},
+			expectedError:           false,
+			expectedAddMessageArgs:  []addMessageArgs{},
+			expectedAddMessageCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			locator, teardown := prepTestLocator(t)
+			defer teardown()
+
+			l := &TelegramListener{
+				Locator: locator,
+				chatID:  123,
+			}
+
+			err := l.procNewChatMemberMessage(tt.update)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			for _, args := range tt.expectedAddMessageArgs {
+				msgMeta, found := l.Locator.Message(args.Msg)
+				assert.True(t, found)
+				assert.Equal(t, args.ChatID, msgMeta.ChatID)
+				assert.Equal(t, args.UserID, msgMeta.UserID)
+				assert.Equal(t, args.UserName, msgMeta.UserName)
+				assert.Equal(t, args.MsgID, msgMeta.MsgID)
+			}
+		})
+	}
+}
+
+func TestProcLeftChatMemberMessage(t *testing.T) {
+	type deleteMessageArgs struct {
+		ChatID int64
+		MsgID  int
+	}
+
+	tests := []struct {
+		name                       string
+		update                     tbapi.Update
+		expectedError              bool
+		expectedDeleteMessageArgs  deleteMessageArgs
+		expectedDeleteMessageCalls int
+		returnErrorInRequest       bool
+	}{
+		{
+			name: "new chat member kick by admin successfully",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat:           &tbapi.Chat{ID: 123},
+					From:           &tbapi.User{UserName: "superuser1", ID: 77},
+					LeftChatMember: &tbapi.User{ID: 88, UserName: "user1"},
+					MessageID:      22,
+				},
+			},
+			expectedError: false,
+			expectedDeleteMessageArgs: deleteMessageArgs{
+				ChatID: 123,
+				MsgID:  20,
+			},
+			expectedDeleteMessageCalls: 1,
+		},
+		{
+			name: "new chat member left self successfully",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat:           &tbapi.Chat{ID: 123},
+					From:           &tbapi.User{UserName: "user1", ID: 88},
+					LeftChatMember: &tbapi.User{ID: 88, UserName: "user1"},
+					MessageID:      22,
+				},
+			},
+			expectedError:              false,
+			expectedDeleteMessageArgs:  deleteMessageArgs{},
+			expectedDeleteMessageCalls: 0,
+		},
+		{
+			name: "message from unauthorized chat",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat:           &tbapi.Chat{ID: 999},
+					LeftChatMember: &tbapi.User{ID: 88, UserName: "user1"},
+				},
+			},
+			expectedError:              false,
+			expectedDeleteMessageArgs:  deleteMessageArgs{},
+			expectedDeleteMessageCalls: 0,
+		},
+		{
+			name: "no new message in the chat found",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat:           &tbapi.Chat{ID: 123},
+					LeftChatMember: &tbapi.User{ID: 88, UserName: "user1"},
+					From:           &tbapi.User{ID: 77, UserName: "superuser1"},
+				},
+			},
+			expectedError:              false,
+			expectedDeleteMessageArgs:  deleteMessageArgs{},
+			expectedDeleteMessageCalls: 0,
+		},
+		{
+			name: "failed to delete new chat member message",
+			update: tbapi.Update{
+				Message: &tbapi.Message{
+					Chat:           &tbapi.Chat{ID: 123},
+					LeftChatMember: &tbapi.User{ID: 88, UserName: "user1"},
+					From:           &tbapi.User{ID: 77, UserName: "superuser1"},
+				},
+			},
+			expectedError: true,
+			expectedDeleteMessageArgs: deleteMessageArgs{
+				ChatID: 123,
+				MsgID:  20,
+			},
+			expectedDeleteMessageCalls: 1,
+			returnErrorInRequest:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			mockAPI := &mocks.TbAPIMock{
+				GetChatFunc: func(config tbapi.ChatInfoConfig) (tbapi.Chat, error) {
+					return tbapi.Chat{ID: 123}, nil
+				},
+				SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+					return tbapi.Message{Text: c.(tbapi.MessageConfig).Text, From: &tbapi.User{UserName: "user"}}, nil
+				},
+				RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+					if tt.returnErrorInRequest {
+						return nil, errors.New("request error")
+					}
+					return &tbapi.APIResponse{}, nil
+				},
+			}
+
+			locator, teardown := prepTestLocator(t)
+			defer teardown()
+
+			l := &TelegramListener{
+				Locator: locator,
+				chatID:  123,
+				TbAPI:   mockAPI,
+			}
+
+			if tt.expectedDeleteMessageArgs.ChatID != 0 && tt.expectedDeleteMessageArgs.MsgID != 0 {
+				msg := fmt.Sprintf("new_%d_%d", tt.expectedDeleteMessageArgs.ChatID, tt.update.Message.LeftChatMember.ID)
+				err := l.Locator.AddMessage(msg, tt.expectedDeleteMessageArgs.ChatID, tt.update.Message.LeftChatMember.ID, "", tt.expectedDeleteMessageArgs.MsgID)
+				require.NoError(t, err)
+			}
+
+			err := l.procLeftChatMemberMessage(tt.update)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			require.Equal(t, tt.expectedDeleteMessageCalls, len(mockAPI.RequestCalls()))
+			if tt.expectedDeleteMessageCalls == 1 {
+				assert.Equal(t, tt.expectedDeleteMessageArgs.ChatID, mockAPI.RequestCalls()[0].C.(tbapi.DeleteMessageConfig).ChatID)
+				assert.Equal(t, tt.expectedDeleteMessageArgs.MsgID, mockAPI.RequestCalls()[0].C.(tbapi.DeleteMessageConfig).MessageID)
 			}
 		})
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -56,8 +56,9 @@ type options struct {
 		MaxBackups int    `long:"max-backups" env:"MAX_BACKUPS" default:"10" description:"maximum number of old log files to retain"`
 	} `group:"logger" namespace:"logger" env-namespace:"LOGGER"`
 
-	SuperUsers  events.SuperUsers `long:"super" env:"SUPER_USER" env-delim:"," description:"super-users"`
-	NoSpamReply bool              `long:"no-spam-reply" env:"NO_SPAM_REPLY" description:"do not reply to spam messages"`
+	SuperUsers          events.SuperUsers `long:"super" env:"SUPER_USER" env-delim:"," description:"super-users"`
+	NoSpamReply         bool              `long:"no-spam-reply" env:"NO_SPAM_REPLY" description:"do not reply to spam messages"`
+	SuppressJoinMessage bool              `long:"suppress-join-message" env:"SUPPRESS_JOIN_MESSAGE" description:"delete join message if user is kicked out"`
 
 	CAS struct {
 		API     string        `long:"api" env:"API" default:"https://api.cas.chat" description:"CAS API"`
@@ -267,6 +268,7 @@ func execute(ctx context.Context, opts options) error {
 		StartupMsg:              opts.Message.Startup,
 		WarnMsg:                 opts.Message.Warn,
 		NoSpamReply:             opts.NoSpamReply,
+		SuppressJoinMessage:     opts.SuppressJoinMessage,
 		SpamLogger:              spamLogger,
 		AdminGroup:              opts.AdminGroup,
 		TestingIDs:              opts.TestingIDs,
@@ -278,9 +280,10 @@ func execute(ctx context.Context, opts options) error {
 	}
 
 	log.Printf("[DEBUG] telegram listener config: {group: %s, idle: %v, super: %v, admin: %s, testing: %v, no-reply: %v,"+
-		" dry: %v, training: %v}",
+		" suppress: %v, dry: %v, training: %v}",
 		tgListener.Group, tgListener.IdleDuration, tgListener.SuperUsers, tgListener.AdminGroup,
-		tgListener.TestingIDs, tgListener.NoSpamReply, tgListener.Dry, tgListener.TrainingMode)
+		tgListener.TestingIDs, tgListener.NoSpamReply, tgListener.SuppressJoinMessage, tgListener.Dry,
+		tgListener.TrainingMode)
 
 	// run telegram listener and event processor loop
 	if err := tgListener.Do(ctx); err != nil {


### PR DESCRIPTION
Delete the system message about joining a group (issue #92) 

- add deletion of the group "new member" message when a user is kicked from the group (not self)
- add tests