### PR TITLE
fix a small issue with negative elapsed time

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - ineffassign
     - stylecheck
     - gochecknoinits
-    - exportloopref
+    - copyloopvar
     - gocritic
     - nakedret
     - gosimple

--- a/app/events/events.go
+++ b/app/events/events.go
@@ -255,10 +255,10 @@ func transform(msg *tbapi.Message) *bot.Message {
 	}
 
 	switch {
-	case msg.Entities != nil && len(msg.Entities) > 0:
+	case len(msg.Entities) > 0:
 		message.Entities = transformEntities(msg.Entities)
 
-	case msg.Photo != nil && len(msg.Photo) > 0:
+	case len(msg.Photo) > 0:
 		sizes := msg.Photo
 		lastSize := sizes[len(sizes)-1]
 		message.Image = &bot.Image{

--- a/app/main.go
+++ b/app/main.go
@@ -588,7 +588,7 @@ func makeSpamLogWriter(opts options) (accessLog io.WriteCloser, err error) {
 	log.Printf("[INFO] logger enabled for %s, max size %dM", opts.Logger.FileName, maxSize)
 	return &lumberjack.Logger{
 		Filename:   opts.Logger.FileName,
-		MaxSize:    int(maxSize), // in MB
+		MaxSize:    int(maxSize), //nolint:gosec // size in MB not that big to cause overflow
 		MaxBackups: opts.Logger.MaxBackups,
 		Compress:   true,
 		LocalTime:  true,


### PR DESCRIPTION
this is actually not a bug, but rather a situation with clocks on the local server not synced with a clock on tg message. In some cases, especially if action happened right away, even a small clock difference may cause negative elapsed time.

the change just reset it to 0, not much else we can do about it 

fix  #115