### PR TITLE
retry openai request

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ openai:
       --openai.max-tokens-response= openai max tokens in response (default: 1024) [$OPENAI_MAX_TOKENS_RESPONSE]
       --openai.max-tokens-request=  openai max tokens in request (default: 2048) [$OPENAI_MAX_TOKENS_REQUEST]
       --openai.max-symbols-request= openai max symbols in request, failback if tokenizer failed (default: 16000) [$OPENAI_MAX_SYMBOLS_REQUEST]
+      --openai.retry-count=         openai retry count (default: 1) [$OPENAI_RETRY_COUNT]
 
 files:
       --files.samples=              samples data path (default: data) [$FILES_SAMPLES]

--- a/app/main.go
+++ b/app/main.go
@@ -79,6 +79,7 @@ type options struct {
 		MaxTokensResponse                int    `long:"max-tokens-response" env:"MAX_TOKENS_RESPONSE" default:"1024" description:"openai max tokens in response"`
 		MaxTokensRequestMaxTokensRequest int    `long:"max-tokens-request" env:"MAX_TOKENS_REQUEST" default:"2048" description:"openai max tokens in request"`
 		MaxSymbolsRequest                int    `long:"max-symbols-request" env:"MAX_SYMBOLS_REQUEST" default:"16000" description:"openai max symbols in request, failback if tokenizer failed"`
+		RetryCount                       int    `long:"retry-count" env:"RETRY_COUNT" default:"1" description:"openai retry count"`
 	} `group:"openai" namespace:"openai" env-namespace:"OPENAI"`
 
 	Files struct {
@@ -431,6 +432,7 @@ func makeDetector(opts options) *tgspam.Detector {
 			MaxTokensResponse: opts.OpenAI.MaxTokensResponse,
 			MaxTokensRequest:  opts.OpenAI.MaxTokensRequestMaxTokensRequest,
 			MaxSymbolsRequest: opts.OpenAI.MaxSymbolsRequest,
+			RetryCount:        opts.OpenAI.RetryCount,
 		}
 		log.Printf("[DEBUG] openai  config: %+v", openAIConfig)
 		detector.WithOpenAIChecker(openai.NewClient(opts.OpenAI.Token), openAIConfig)


### PR DESCRIPTION
Sometimes openai get confused with the json response and returns invalid one. Having optional retry parameter allow to try it again and hopefully get a proper response.

See #138 