### PR TITLE
handle openai failure in vetting mode

### DIFF
--- a/lib/spamcheck/spamcheck.go
+++ b/lib/spamcheck/spamcheck.go
@@ -26,6 +26,7 @@ type Response struct {
 	Name    string `json:"name"`    // name of the check
 	Spam    bool   `json:"spam"`    // true if spam
 	Details string `json:"details"` // details of the check
+	Error   error  `json:"-"`       // error message, if any. Do not serialize it
 }
 
 func (r *Response) String() string {

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -177,7 +177,12 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 		if !spamDetected && !d.OpenAIVeto || spamDetected && d.OpenAIVeto {
 			spam, details := d.openaiChecker.check(req.Msg)
 			cr = append(cr, details)
-			spamDetected = spam
+			if spamDetected && details.Error != nil {
+				// spam detected with other checks, but openai failed. in this case, we still return spam, but log the error
+				log.Printf("[WARN] openai error: %v", details.Error)
+			} else {
+				spamDetected = spam
+			}
 		}
 	}
 

--- a/lib/tgspam/openai.go
+++ b/lib/tgspam/openai.go
@@ -82,7 +82,8 @@ func (o *openAIChecker) check(msg string) (spam bool, cr spamcheck.Response) {
 		}
 	}
 	if err != nil {
-		return false, spamcheck.Response{Spam: false, Name: "openai", Details: fmt.Sprintf("OpenAI error: %v", err)}
+		return false, spamcheck.Response{
+			Spam: false, Name: "openai", Details: fmt.Sprintf("OpenAI error: %v", err), Error: err}
 	}
 
 	return resp.IsSpam, spamcheck.Response{Spam: resp.IsSpam, Name: "openai",

--- a/lib/tgspam/openai_test.go
+++ b/lib/tgspam/openai_test.go
@@ -44,6 +44,7 @@ func TestOpenAIChecker_Check(t *testing.T) {
 		assert.True(t, spam)
 		assert.Equal(t, "openai", details.Name)
 		assert.Equal(t, "bad text, confidence: 100%", details.Details)
+		assert.NoError(t, details.Error)
 	})
 
 	t.Run("not spam response", func(t *testing.T) {
@@ -60,6 +61,7 @@ func TestOpenAIChecker_Check(t *testing.T) {
 		assert.False(t, spam)
 		assert.Equal(t, "openai", details.Name)
 		assert.Equal(t, "good text, confidence: 99%", details.Details)
+		assert.NoError(t, details.Error)
 	})
 
 	t.Run("error response", func(t *testing.T) {
@@ -72,6 +74,7 @@ func TestOpenAIChecker_Check(t *testing.T) {
 		assert.False(t, spam)
 		assert.Equal(t, "openai", details.Name)
 		assert.Equal(t, "OpenAI error: assert.AnError general error for testing", details.Details)
+		assert.Equal(t, "assert.AnError general error for testing", details.Error.Error())
 	})
 
 	t.Run("bad encoding", func(t *testing.T) {
@@ -88,6 +91,7 @@ func TestOpenAIChecker_Check(t *testing.T) {
 		assert.False(t, spam)
 		assert.Equal(t, "openai", details.Name)
 		assert.Equal(t, "OpenAI error: can't unmarshal response: invalid character 'b' looking for beginning of value", details.Details)
+		assert.Equal(t, "can't unmarshal response: invalid character 'b' looking for beginning of value", details.Error.Error())
 	})
 
 	t.Run("no choices", func(t *testing.T) {


### PR DESCRIPTION
see #138

The PR changes the vetting logic. If OpenAI fails on a message detected as spam by another check, this failure is not translated as a ham signal anymore.