### PR TITLE
don't mention spammer name or id in bot's reply

### DIFF
--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -99,7 +99,7 @@ func (s *SpamFilter) OnMessage(msg Message) (response Response) {
 		if s.params.Dry {
 			msgPrefix = s.params.SpamDryMsg
 		}
-		spamRespMsg := fmt.Sprintf("%s: %q (%d)", msgPrefix, displayUsername, msg.From.ID)
+		spamRespMsg := msgPrefix;
 		return Response{Text: spamRespMsg, Send: true, ReplyTo: msg.ID, BanInterval: PermanentBanDuration, CheckResults: checkResults,
 			DeleteReplyTo: true, User: User{Username: msg.From.Username, ID: msg.From.ID, DisplayName: msg.From.DisplayName},
 		}

--- a/app/bot/spam_test.go
+++ b/app/bot/spam_test.go
@@ -36,7 +36,7 @@ func TestSpamFilter_OnMessage(t *testing.T) {
 		det.ResetCalls()
 		s := NewSpamFilter(ctx, det, SpamConfig{SpamMsg: "detected", SpamDryMsg: "detected dry"})
 		resp := s.OnMessage(Message{Text: "spam", From: User{ID: 1, Username: "john"}, Image: &Image{FileID: "123"}})
-		assert.Equal(t, Response{Text: `detected: "john" (1)`, Send: true, BanInterval: PermanentBanDuration,
+		assert.Equal(t, Response{Text: `detected`, Send: true, BanInterval: PermanentBanDuration,
 			User: User{ID: 1, Username: "john"}, DeleteReplyTo: true,
 			CheckResults: []spamcheck.Response{{Name: "something", Spam: true, Details: "some spam"}}}, resp)
 		assert.Equal(t, 1, len(det.CheckCalls()))
@@ -48,7 +48,7 @@ func TestSpamFilter_OnMessage(t *testing.T) {
 	t.Run("spam detected, dry", func(t *testing.T) {
 		s := NewSpamFilter(ctx, det, SpamConfig{SpamMsg: "detected", SpamDryMsg: "detected dry", Dry: true})
 		resp := s.OnMessage(Message{Text: "spam", From: User{ID: 1, Username: "john"}})
-		assert.Equal(t, `detected dry: "john" (1)`, resp.Text)
+		assert.Equal(t, `detected dry`, resp.Text)
 		assert.True(t, resp.Send)
 		assert.Equal(t, []spamcheck.Response{{Name: "something", Spam: true, Details: "some spam"}}, resp.CheckResults)
 	})


### PR DESCRIPTION
Usernames can sometimes contain spam as well.
Also such a messages are distracting to other users and don't help much, since alleged spammer username can be easily found in recent actions or admin chat anyway.