### PR TITLE
remove bot message in main group after admin action

### DIFF
--- a/app/events/admin_test.go
+++ b/app/events/admin_test.go
@@ -29,8 +29,8 @@ func TestAdmin_reportBan(t *testing.T) {
 		},
 		Text: "Test\n\n_message_",
 	}
-
-	adm.ReportBan("testUser", msg)
+	spamReplyID := 789
+	adm.ReportBan("testUser", msg, spamReplyID)
 
 	require.Equal(t, 1, len(mockAPI.SendCalls()))
 	t.Logf("sent text: %+v", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text)
@@ -128,29 +128,31 @@ func TestAdmin_parseCallbackData(t *testing.T) {
 		data       string
 		wantUserID int64
 		wantMsgID  int
+		wantSpamReplyID int
 		wantErr    bool
 	}{
-		{"Valid data", "12345:678", 12345, 678, false},
-		{"Data too short", "12", 0, 0, true},
-		{"No colon separator", "12345678", 0, 0, true},
-		{"Invalid userID", "abc:678", 0, 0, true},
-		{"Invalid msgID", "12345:xyz", 0, 0, true},
-		{"wrong prefix with valid data", "c12345:678", 0, 0, true},
-		{"valid prefix+ with valid data", "+12345:678", 12345, 678, false},
-		{"valid prefix! with valid data", "!12345:678", 12345, 678, false},
-		{"valid prefix? with valid data", "?12345:678", 12345, 678, false},
+		{"Valid data", "12345:678:90", 12345, 678, 90, false},
+		{"Data too short", "12", 0, 0, 0, true},
+		{"No colon separator", "12345678", 0, 0, 0, true},
+		{"Invalid userID", "abc:678", 0, 0, 0, true},
+		{"Invalid msgID", "12345:xyz", 0, 0, 0, true},
+		{"wrong prefix with valid data", "c12345:678", 0, 0, 0, true},
+		{"valid prefix+ with valid data", "+12345:678:90", 12345, 678, 90, false},
+		{"valid prefix! with valid data", "!12345:678:90", 12345, 678, 90, false},
+		{"valid prefix? with valid data", "?12345:678:90", 12345, 678, 90, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := admin{}
-			gotUserID, gotMsgID, err := a.parseCallbackData(tt.data)
+			gotUserID, gotMsgID, spamReplyID, err := a.parseCallbackData(tt.data)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.wantUserID, gotUserID)
 				assert.Equal(t, tt.wantMsgID, gotMsgID)
+				assert.Equal(t, tt.wantSpamReplyID, spamReplyID)
 			}
 		})
 	}
@@ -208,7 +210,7 @@ func TestAdmin_dryModeForwardMessage(t *testing.T) {
 	}
 	msg := &bot.Message{}
 
-	adm.ReportBan("testUser", msg)
+	adm.ReportBan("testUser", msg, 789)
 	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text, "would have permanently banned [testUser]")
 
 }

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -92,7 +92,7 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 
 	// send startup message if any set
 	if l.StartupMsg != "" && !l.TrainingMode && !l.Dry {
-		if err := l.sendBotResponse(bot.Response{Send: true, Text: l.StartupMsg}, l.chatID); err != nil {
+		if _, err := l.sendBotResponse(bot.Response{Send: true, Text: l.StartupMsg}, l.chatID); err != nil {
 			log.Printf("[WARN] failed to send startup message, %v", err)
 		}
 	}
@@ -129,7 +129,7 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 				}
 				if err := l.adminHandler.MsgHandler(update); err != nil {
 					log.Printf("[WARN] failed to process admin chat message: %v", err)
-					_ = l.sendBotResponse(bot.Response{Send: true, Text: "error: " + err.Error()}, l.adminChatID)
+					_, _ = l.sendBotResponse(bot.Response{Send: true, Text: "error: " + err.Error()}, l.adminChatID)
 				}
 				continue
 			}
@@ -138,7 +138,7 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 			if update.CallbackQuery != nil {
 				if err := l.adminHandler.InlineCallbackHandler(update.CallbackQuery); err != nil {
 					log.Printf("[WARN] failed to process callback: %v", err)
-					_ = l.sendBotResponse(bot.Response{Send: true, Text: "error: " + err.Error()}, l.adminChatID)
+					_, _ = l.sendBotResponse(bot.Response{Send: true, Text: "error: " + err.Error()}, l.adminChatID)
 				}
 				continue
 			}
@@ -202,7 +202,7 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 
 		case <-time.After(l.IdleDuration): // hit bots on idle timeout
 			resp := l.Bot.OnMessage(bot.Message{Text: "idle"})
-			if err := l.sendBotResponse(resp, l.chatID); err != nil {
+			if _, err := l.sendBotResponse(resp, l.chatID); err != nil {
 				log.Printf("[WARN] failed to respond on idle, %v", err)
 			}
 		}
@@ -288,10 +288,13 @@ func (l *TelegramListener) procEvents(update tbapi.Update) error {
 	}
 
 	// send response to the channel if allowed
+	spamReplyID := 0
 	if resp.Send && !l.NoSpamReply && !l.TrainingMode {
-		if err := l.sendBotResponse(resp, fromChat); err != nil {
+		var err error
+		if spamReplyID, err = l.sendBotResponse(resp, fromChat); err != nil {
 			log.Printf("[WARN] failed to respond on update, %v", err)
 		}
+		log.Printf("[DEBUG] response sent, spamReplyID: %d", spamReplyID)
 	}
 
 	errs := new(multierror.Error)
@@ -307,7 +310,7 @@ func (l *TelegramListener) procEvents(update tbapi.Update) error {
 
 		if l.SuperUsers.IsSuper(msg.From.Username, msg.From.ID) {
 			if l.TrainingMode {
-				l.adminHandler.ReportBan(banUserStr, msg)
+				l.adminHandler.ReportBan(banUserStr, msg, 0)
 			}
 			log.Printf("[DEBUG] superuser %s requested ban, ignored", banUserStr)
 			return nil
@@ -318,7 +321,7 @@ func (l *TelegramListener) procEvents(update tbapi.Update) error {
 		if err := banUserOrChannel(banReq); err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("failed to ban %s: %w", banUserStr, err))
 		} else if l.adminChatID != 0 && msg.From.ID != 0 {
-			l.adminHandler.ReportBan(banUserStr, msg)
+			l.adminHandler.ReportBan(banUserStr, msg, spamReplyID)
 		}
 	}
 
@@ -375,9 +378,9 @@ func (l *TelegramListener) getBanUsername(resp bot.Response, update tbapi.Update
 
 // sendBotResponse sends bot's answer to tg channel
 // actionText is a text for the button to unban user, optional
-func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) error {
+func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) (int, error) {
 	if !resp.Send {
-		return nil
+		return 0, nil
 	}
 
 	log.Printf("[DEBUG] bot response - %+v, reply-to:%d", strings.ReplaceAll(resp.Text, "\n", "\\n"), resp.ReplyTo)
@@ -386,11 +389,11 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) erro
 	tbMsg.DisableWebPagePreview = true
 	tbMsg.ReplyToMessageID = resp.ReplyTo
 
-	if err := send(tbMsg, l.TbAPI); err != nil {
-		return fmt.Errorf("can't send message to telegram %q: %w", resp.Text, err)
+	tbResp, err := l.TbAPI.Send(tbMsg)
+	if err != nil {
+		return 0, fmt.Errorf("can't send message to telegram %q: %w", resp.Text, err)
 	}
-
-	return nil
+	return tbResp.MessageID, nil
 }
 
 func (l *TelegramListener) getChatID(group string) (int64, error) {

--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -754,7 +754,7 @@ func TestTelegramListener_DoWithAdminUnBan(t *testing.T) {
 
 	updMsg := tbapi.Update{
 		CallbackQuery: &tbapi.CallbackQuery{
-			Data: "777:999",
+			Data: "777:999:88",
 			Message: &tbapi.Message{
 				MessageID:   987654,
 				Chat:        &tbapi.Chat{ID: 123},
@@ -772,9 +772,12 @@ func TestTelegramListener_DoWithAdminUnBan(t *testing.T) {
 
 	err := l.Do(ctx)
 	assert.EqualError(t, err, "telegram update chan closed")
-	require.Equal(t, 1, len(mockAPI.SendCalls()))
+	require.Equal(t, 2, len(mockAPI.SendCalls()))
 	assert.Equal(t, 987654, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).MessageID)
 	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).Text, "by admin in ")
+
+	assert.Equal(t, 88, mockAPI.SendCalls()[1].C.(tbapi.DeleteMessageConfig).MessageID)
+
 	require.Equal(t, 2, len(mockAPI.RequestCalls()))
 	assert.Equal(t, "accepted", mockAPI.RequestCalls()[0].C.(tbapi.CallbackConfig).Text)
 
@@ -828,7 +831,7 @@ func TestTelegramListener_DoWithAdminSoftUnBan(t *testing.T) {
 
 	updMsg := tbapi.Update{
 		CallbackQuery: &tbapi.CallbackQuery{
-			Data: "777:999",
+			Data: "777:999:88",
 			Message: &tbapi.Message{
 				MessageID:   987654,
 				Chat:        &tbapi.Chat{ID: 123},
@@ -846,9 +849,10 @@ func TestTelegramListener_DoWithAdminSoftUnBan(t *testing.T) {
 
 	err := l.Do(ctx)
 	assert.EqualError(t, err, "telegram update chan closed")
-	require.Equal(t, 1, len(mockAPI.SendCalls()))
+	require.Equal(t, 2, len(mockAPI.SendCalls()))
 	assert.Equal(t, 987654, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).MessageID)
 	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).Text, "by admin in ")
+	assert.Equal(t, 88, mockAPI.SendCalls()[1].C.(tbapi.DeleteMessageConfig).MessageID)
 	require.Equal(t, 2, len(mockAPI.RequestCalls()))
 	assert.Equal(t, "accepted", mockAPI.RequestCalls()[0].C.(tbapi.CallbackConfig).Text)
 
@@ -905,7 +909,7 @@ func TestTelegramListener_DoWithAdminUnBan_Training(t *testing.T) {
 
 	updMsg := tbapi.Update{
 		CallbackQuery: &tbapi.CallbackQuery{
-			Data: "777:999",
+			Data: "777:999:88",
 			Message: &tbapi.Message{
 				MessageID:   987654,
 				Chat:        &tbapi.Chat{ID: 123},
@@ -923,9 +927,10 @@ func TestTelegramListener_DoWithAdminUnBan_Training(t *testing.T) {
 
 	err := l.Do(ctx)
 	assert.EqualError(t, err, "telegram update chan closed")
-	require.Equal(t, 1, len(mockAPI.SendCalls()))
+	require.Equal(t, 2, len(mockAPI.SendCalls()))
 	assert.Equal(t, 987654, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).MessageID)
 	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.EditMessageTextConfig).Text, "by admin in ")
+	assert.Equal(t, 88, mockAPI.SendCalls()[1].C.(tbapi.DeleteMessageConfig).MessageID)
 	require.Equal(t, 1, len(mockAPI.RequestCalls()))
 	assert.Equal(t, "accepted", mockAPI.RequestCalls()[0].C.(tbapi.CallbackConfig).Text)
 	require.Equal(t, 1, len(b.UpdateHamCalls()))
@@ -1045,7 +1050,7 @@ func TestTelegramListener_DoWithAdminUnbanDecline(t *testing.T) {
 
 	updMsg := tbapi.Update{
 		CallbackQuery: &tbapi.CallbackQuery{
-			Data: "+999:987654", // + means unban declined
+			Data: "+999:987654:88", // + means unban declined
 			Message: &tbapi.Message{
 				MessageID:   987654,
 				Chat:        &tbapi.Chat{ID: 123},
@@ -1117,7 +1122,7 @@ func TestTelegramListener_DoWithAdminBanConfirmedTraining(t *testing.T) {
 
 	updMsg := tbapi.Update{
 		CallbackQuery: &tbapi.CallbackQuery{
-			Data: "+999:987654", // + means unban declined
+			Data: "+999:987654:88", // + means unban declined
 			Message: &tbapi.Message{
 				MessageID:   987654,
 				Chat:        &tbapi.Chat{ID: 123},
@@ -1187,7 +1192,7 @@ func TestTelegramListener_DoWithAdminShowInfo(t *testing.T) {
 
 	updMsg := tbapi.Update{
 		CallbackQuery: &tbapi.CallbackQuery{
-			Data: "!999:987654", // ! means we show info
+			Data: "!999:987654:88", // ! means we show info
 			Message: &tbapi.Message{
 				MessageID:   987654,
 				Chat:        &tbapi.Chat{ID: 123},


### PR DESCRIPTION
in case ban is confirmed or reverted by admin, we can safely remove bot reply to spam message in the main group if it was there