### PR TITLE
fix +1 issue with first message check

### DIFF
--- a/app/events/admin.go
+++ b/app/events/admin.go
@@ -55,11 +55,11 @@ func (a *admin) ReportBan(banUserStr string, msg *bot.Message) {
 // to be detected by the bot. we need to update spam filter with this message and ban the user.
 // the user will be baned even in training mode, but not in the dry mode.
 func (a *admin) MsgHandler(update tbapi.Update) error {
-	shrink := func(inp string, max int) string {
-		if utf8.RuneCountInString(inp) <= max {
+	shrink := func(inp string, maxLen int) string {
+		if utf8.RuneCountInString(inp) <= maxLen {
 			return inp
 		}
-		return string([]rune(inp)[:max]) + "..."
+		return string([]rune(inp)[:maxLen]) + "..."
 	}
 
 	// try to get the forwarded user ID, this is just for logging

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -98,6 +98,9 @@ func NewDetector(p Config) *Detector {
 	if p.FirstMessagesCount > 0 {
 		res.FirstMessageOnly = true
 	}
+	if p.FirstMessageOnly && p.FirstMessagesCount == 0 {
+		res.FirstMessagesCount = 1 // default value for FirstMessagesCount if FirstMessageOnly is set
+	}
 	return res
 }
 
@@ -117,7 +120,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	defer d.lock.RUnlock()
 
 	// approved user don't need to be checked
-	if d.FirstMessageOnly && d.approvedUsers[req.UserID].Count > d.FirstMessagesCount {
+	if d.FirstMessageOnly && d.approvedUsers[req.UserID].Count >= d.FirstMessagesCount {
 		return false, []spamcheck.Response{{Name: "pre-approved", Spam: false, Details: "user already approved"}}
 	}
 

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -816,7 +816,7 @@ func TestDetector_FirstMessagesCount(t *testing.T) {
 		assert.Equal(t, true, spam)
 	})
 	t.Run("first messages are ham, third is spam", func(t *testing.T) {
-		d := NewDetector(Config{MaxAllowedEmoji: 1, MinMsgLen: 5, FirstMessagesCount: 2, FirstMessageOnly: true})
+		d := NewDetector(Config{MaxAllowedEmoji: 1, MinMsgLen: 5, FirstMessagesCount: 3, FirstMessageOnly: true})
 
 		// first ham
 		spam, _ := d.Check(spamcheck.Request{Msg: "ham, no emojis", UserID: "123"})


### PR DESCRIPTION
The issue leads to checking the first two messages even if the first-only option is set. As a result, it created the impression described in #167.

In fact, a user on the whitelist was blocked due to the count (2) of approved messages instead of the expected 1.