### PR TITLE
escape MD symbols in user-name for reported bans

### DIFF
--- a/app/events/admin.go
+++ b/app/events/admin.go
@@ -45,7 +45,9 @@ func (a *admin) ReportBan(banUserStr string, msg *bot.Message) {
 	if a.dry {
 		would = "would have "
 	}
-	forwardMsg := fmt.Sprintf("**%spermanently banned [%s](tg://user?id=%d)**\n\n%s\n\n", would, banUserStr, msg.From.ID, text)
+
+	forwardMsg := fmt.Sprintf("**%spermanently banned [%s](tg://user?id=%d)**\n\n%s\n\n",
+		would, escapeMarkDownV1Text(banUserStr), msg.From.ID, text)
 	if err := a.sendWithUnbanMarkup(forwardMsg, "change ban", msg.From, msg.ID, a.adminChatID); err != nil {
 		log.Printf("[WARN] failed to send admin message, %v", err)
 	}

--- a/app/events/admin_test.go
+++ b/app/events/admin_test.go
@@ -30,16 +30,33 @@ func TestAdmin_reportBan(t *testing.T) {
 		Text: "Test\n\n_message_",
 	}
 
-	adm.ReportBan("testUser", msg)
+	t.Run("normal user name", func(t *testing.T) {
+		mockAPI.ResetCalls()
+		adm.ReportBan("testUser", msg)
 
-	require.Equal(t, 1, len(mockAPI.SendCalls()))
-	t.Logf("sent text: %+v", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text)
-	assert.Equal(t, int64(123), mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ChatID)
-	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text, "permanently banned [testUser](tg://user?id=456)")
-	assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text, "Test  \\_message\\_")
-	assert.NotNil(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ReplyMarkup)
-	assert.Equal(t, "⛔︎ change ban",
-		mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ReplyMarkup.(tbapi.InlineKeyboardMarkup).InlineKeyboard[0][0].Text)
+		require.Equal(t, 1, len(mockAPI.SendCalls()))
+		t.Logf("sent text: %+v", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text)
+		assert.Equal(t, int64(123), mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ChatID)
+		assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text, "permanently banned [testUser](tg://user?id=456)")
+		assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text, "Test  \\_message\\_")
+		assert.NotNil(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ReplyMarkup)
+		assert.Equal(t, "⛔︎ change ban",
+			mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ReplyMarkup.(tbapi.InlineKeyboardMarkup).InlineKeyboard[0][0].Text)
+	})
+
+	t.Run("name with md chars", func(t *testing.T) {
+		mockAPI.ResetCalls()
+		adm.ReportBan("test_User", msg)
+
+		require.Equal(t, 1, len(mockAPI.SendCalls()))
+		t.Logf("sent text: %+v", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text)
+		assert.Equal(t, int64(123), mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ChatID)
+		assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text, "permanently banned [test\\_User](tg://user?id=456)")
+		assert.Contains(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text, "Test  \\_message\\_")
+		assert.NotNil(t, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ReplyMarkup)
+		assert.Equal(t, "⛔︎ change ban",
+			mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).ReplyMarkup.(tbapi.InlineKeyboardMarkup).InlineKeyboard[0][0].Text)
+	})
 }
 
 func TestAdmin_getCleanMessage(t *testing.T) {


### PR DESCRIPTION
Fix #174 