### PR TITLE
fix unexpected storage update during spam info retrieval #183

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
     - name: available platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
 
-    - name: build and deploy master image to ghcr.io and dockerhub
-      if: ${{ github.ref == 'refs/heads/master' }}
+    - name: build and deploy non-master image to ghcr.io and dockerhub
+      if: ${{ github.ref != 'refs/heads/master' }}
       env:
         GITHUB_PACKAGE_TOKEN: ${{ secrets.PKG_TOKEN }}
         DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,24 @@ jobs:
     - name: available platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
 
+    - name: build and deploy master image to ghcr.io and dockerhub
+      if: ${{ github.ref == 'refs/heads/master' }}
+      env:
+        GITHUB_PACKAGE_TOKEN: ${{ secrets.PKG_TOKEN }}
+        DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+        USERNAME: ${{ github.actor }}
+        GITHUB_SHA: ${{ github.sha}}
+        GITHUB_REF: ${{ github.ref}}
+      run: |
+        ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
+        echo GITHUB_REF - $ref
+        echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
+        echo ${DOCKER_HUB_TOKEN} | docker login -u ${USERNAME} --password-stdin
+        docker buildx build --push \
+            --build-arg CI=github --build-arg GITHUB_SHA=${GITHUB_SHA} --build-arg GIT_BRANCH=${ref} \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 \
+            -t ghcr.io/${USERNAME}/tg-spam:${ref} -t ${USERNAME}/tg-spam:${ref} .
+
     - name: build and deploy non-master image to ghcr.io and dockerhub
       if: ${{ github.ref != 'refs/heads/master' }}
       env:

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -73,13 +73,14 @@ func NewSpamFilter(ctx context.Context, detector Detector, params SpamConfig) *S
 }
 
 // OnMessage checks if user already approved and if not checks if user is a spammer
-func (s *SpamFilter) OnMessage(msg Message) (response Response) {
+func (s *SpamFilter) OnMessage(msg Message, checkOnly bool) (response Response) {
 	if msg.From.ID == 0 { // don't check system messages
 		return Response{}
 	}
 	displayUsername := DisplayName(msg)
 
-	spamReq := spamcheck.Request{Msg: msg.Text, UserID: strconv.FormatInt(msg.From.ID, 10), UserName: msg.From.Username}
+	spamReq := spamcheck.Request{Msg: msg.Text, CheckOnly: checkOnly,
+		UserID: strconv.FormatInt(msg.From.ID, 10), UserName: msg.From.Username}
 	if msg.Image != nil {
 		spamReq.Meta.Images = 1
 	}

--- a/app/bot/spam_test.go
+++ b/app/bot/spam_test.go
@@ -35,7 +35,7 @@ func TestSpamFilter_OnMessage(t *testing.T) {
 	t.Run("spam detected", func(t *testing.T) {
 		det.ResetCalls()
 		s := NewSpamFilter(ctx, det, SpamConfig{SpamMsg: "detected", SpamDryMsg: "detected dry"})
-		resp := s.OnMessage(Message{Text: "spam", From: User{ID: 1, Username: "john"}, Image: &Image{FileID: "123"}})
+		resp := s.OnMessage(Message{Text: "spam", From: User{ID: 1, Username: "john"}, Image: &Image{FileID: "123"}}, false)
 		assert.Equal(t, Response{Text: `detected: "john" (1)`, Send: true, BanInterval: PermanentBanDuration,
 			User: User{ID: 1, Username: "john"}, DeleteReplyTo: true,
 			CheckResults: []spamcheck.Response{{Name: "something", Spam: true, Details: "some spam"}}}, resp)
@@ -47,7 +47,7 @@ func TestSpamFilter_OnMessage(t *testing.T) {
 
 	t.Run("spam detected, dry", func(t *testing.T) {
 		s := NewSpamFilter(ctx, det, SpamConfig{SpamMsg: "detected", SpamDryMsg: "detected dry", Dry: true})
-		resp := s.OnMessage(Message{Text: "spam", From: User{ID: 1, Username: "john"}})
+		resp := s.OnMessage(Message{Text: "spam", From: User{ID: 1, Username: "john"}}, false)
 		assert.Equal(t, `detected dry: "john" (1)`, resp.Text)
 		assert.True(t, resp.Send)
 		assert.Equal(t, []spamcheck.Response{{Name: "something", Spam: true, Details: "some spam"}}, resp.CheckResults)
@@ -55,7 +55,7 @@ func TestSpamFilter_OnMessage(t *testing.T) {
 
 	t.Run("ham detected", func(t *testing.T) {
 		s := NewSpamFilter(ctx, det, SpamConfig{SpamMsg: "detected", SpamDryMsg: "detected dry"})
-		resp := s.OnMessage(Message{Text: "good", From: User{ID: 1, Username: "john"}})
+		resp := s.OnMessage(Message{Text: "good", From: User{ID: 1, Username: "john"}}, false)
 		assert.Equal(t, Response{CheckResults: []spamcheck.Response{{Name: "already approved", Spam: false, Details: "some ham"}}}, resp)
 	})
 

--- a/app/events/admin.go
+++ b/app/events/admin.go
@@ -108,7 +108,8 @@ func (a *admin) MsgHandler(update tbapi.Update) error {
 
 	// make a message with spam info and send to admin chat
 	spamInfo := []string{}
-	// check only, don't update the storage
+	// check only, don't update the storage, as all we care here is to get checks results.
+	// without checkOnly flag, it may add approved user to the storage after we removed it above.
 	resp := a.bot.OnMessage(bot.Message{Text: update.Message.Text, From: bot.User{ID: info.UserID}}, true)
 	spamInfoText := "**can't get spam info**"
 	for _, check := range resp.CheckResults {
@@ -265,7 +266,7 @@ func (a *admin) directReport(update tbapi.Update, updateSamples bool) error {
 
 	// make a message with spam info and send to admin chat
 	spamInfo := []string{}
-	// check only, don't update the storage
+	// check only, don't update the storage with the new approved user as all we care here is to get checks results
 	resp := a.bot.OnMessage(bot.Message{Text: msgTxt, From: bot.User{ID: origMsg.From.ID}}, true)
 	spamInfoText := "**can't get spam info**"
 	for _, check := range resp.CheckResults {

--- a/app/events/admin.go
+++ b/app/events/admin.go
@@ -108,7 +108,8 @@ func (a *admin) MsgHandler(update tbapi.Update) error {
 
 	// make a message with spam info and send to admin chat
 	spamInfo := []string{}
-	resp := a.bot.OnMessage(bot.Message{Text: update.Message.Text, From: bot.User{ID: info.UserID}})
+	// check only, don't update the storage
+	resp := a.bot.OnMessage(bot.Message{Text: update.Message.Text, From: bot.User{ID: info.UserID}}, true)
 	spamInfoText := "**can't get spam info**"
 	for _, check := range resp.CheckResults {
 		spamInfo = append(spamInfo, "- "+escapeMarkDownV1Text(check.String()))
@@ -264,7 +265,8 @@ func (a *admin) directReport(update tbapi.Update, updateSamples bool) error {
 
 	// make a message with spam info and send to admin chat
 	spamInfo := []string{}
-	resp := a.bot.OnMessage(bot.Message{Text: msgTxt, From: bot.User{ID: origMsg.From.ID}})
+	// check only, don't update the storage
+	resp := a.bot.OnMessage(bot.Message{Text: msgTxt, From: bot.User{ID: origMsg.From.ID}}, true)
 	spamInfoText := "**can't get spam info**"
 	for _, check := range resp.CheckResults {
 		spamInfo = append(spamInfo, "- "+escapeMarkDownV1Text(check.String()))

--- a/app/events/events.go
+++ b/app/events/events.go
@@ -51,7 +51,7 @@ type Locator interface {
 
 // Bot is an interface for bot events.
 type Bot interface {
-	OnMessage(msg bot.Message) (response bot.Response)
+	OnMessage(msg bot.Message, checkOnly bool) (response bot.Response)
 	UpdateSpam(msg string) error
 	UpdateHam(msg string) error
 	AddApprovedUser(id int64, name string) error

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -197,7 +197,7 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 			}
 
 		case <-time.After(l.IdleDuration): // hit bots on idle timeout
-			resp := l.Bot.OnMessage(bot.Message{Text: "idle"})
+			resp := l.Bot.OnMessage(bot.Message{Text: "idle"}, false)
 			if err := l.sendBotResponse(resp, l.chatID); err != nil {
 				log.Printf("[WARN] failed to respond on idle, %v", err)
 			}
@@ -279,7 +279,7 @@ func (l *TelegramListener) procEvents(update tbapi.Update) error {
 	if err := l.Locator.AddMessage(msg.Text, fromChat, msg.From.ID, msg.From.Username, msg.ID); err != nil {
 		log.Printf("[WARN] failed to add message to locator: %v", err)
 	}
-	resp := l.Bot.OnMessage(*msg)
+	resp := l.Bot.OnMessage(*msg, false)
 
 	if !resp.Send { // not spam
 		return nil

--- a/app/events/mocks/bot.go
+++ b/app/events/mocks/bot.go
@@ -20,7 +20,7 @@ import (
 //			IsApprovedUserFunc: func(userID int64) bool {
 //				panic("mock out the IsApprovedUser method")
 //			},
-//			OnMessageFunc: func(msg bot.Message) bot.Response {
+//			OnMessageFunc: func(msg bot.Message, checkOnly bool) bot.Response {
 //				panic("mock out the OnMessage method")
 //			},
 //			RemoveApprovedUserFunc: func(id int64) error {
@@ -46,7 +46,7 @@ type BotMock struct {
 	IsApprovedUserFunc func(userID int64) bool
 
 	// OnMessageFunc mocks the OnMessage method.
-	OnMessageFunc func(msg bot.Message) bot.Response
+	OnMessageFunc func(msg bot.Message, checkOnly bool) bot.Response
 
 	// RemoveApprovedUserFunc mocks the RemoveApprovedUser method.
 	RemoveApprovedUserFunc func(id int64) error
@@ -75,6 +75,8 @@ type BotMock struct {
 		OnMessage []struct {
 			// Msg is the msg argument value.
 			Msg bot.Message
+			// CheckOnly is the checkOnly argument value.
+			CheckOnly bool
 		}
 		// RemoveApprovedUser holds details about calls to the RemoveApprovedUser method.
 		RemoveApprovedUser []struct {
@@ -183,19 +185,21 @@ func (mock *BotMock) ResetIsApprovedUserCalls() {
 }
 
 // OnMessage calls OnMessageFunc.
-func (mock *BotMock) OnMessage(msg bot.Message) bot.Response {
+func (mock *BotMock) OnMessage(msg bot.Message, checkOnly bool) bot.Response {
 	if mock.OnMessageFunc == nil {
 		panic("BotMock.OnMessageFunc: method is nil but Bot.OnMessage was just called")
 	}
 	callInfo := struct {
-		Msg bot.Message
+		Msg       bot.Message
+		CheckOnly bool
 	}{
-		Msg: msg,
+		Msg:       msg,
+		CheckOnly: checkOnly,
 	}
 	mock.lockOnMessage.Lock()
 	mock.calls.OnMessage = append(mock.calls.OnMessage, callInfo)
 	mock.lockOnMessage.Unlock()
-	return mock.OnMessageFunc(msg)
+	return mock.OnMessageFunc(msg, checkOnly)
 }
 
 // OnMessageCalls gets all the calls that were made to OnMessage.
@@ -203,10 +207,12 @@ func (mock *BotMock) OnMessage(msg bot.Message) bot.Response {
 //
 //	len(mockedBot.OnMessageCalls())
 func (mock *BotMock) OnMessageCalls() []struct {
-	Msg bot.Message
+	Msg       bot.Message
+	CheckOnly bool
 } {
 	var calls []struct {
-		Msg bot.Message
+		Msg       bot.Message
+		CheckOnly bool
 	}
 	mock.lockOnMessage.RLock()
 	calls = mock.calls.OnMessage

--- a/lib/spamcheck/spamcheck.go
+++ b/lib/spamcheck/spamcheck.go
@@ -8,7 +8,7 @@ type Request struct {
 	UserID    string   `json:"user_id"`    // user id
 	UserName  string   `json:"user_name"`  // user name
 	Meta      MetaData `json:"meta"`       // meta-info, provided by the client
-	CheckOnly bool     `json:"check_only"` // if true, only check the message, do not update the storage state
+	CheckOnly bool     `json:"check_only"` // if true, only check the message, do not write newly approved user to the database
 }
 
 // MetaData is a meta-info about the message, provided by the client.

--- a/lib/spamcheck/spamcheck.go
+++ b/lib/spamcheck/spamcheck.go
@@ -4,10 +4,11 @@ import "fmt"
 
 // Request is a request to check a message for spam.
 type Request struct {
-	Msg      string   `json:"msg"`       // message to check
-	UserID   string   `json:"user_id"`   // user id
-	UserName string   `json:"user_name"` // user name
-	Meta     MetaData `json:"meta"`      // meta-info, provided by the client
+	Msg       string   `json:"msg"`        // message to check
+	UserID    string   `json:"user_id"`    // user id
+	UserName  string   `json:"user_name"`  // user name
+	Meta      MetaData `json:"meta"`       // meta-info, provided by the client
+	CheckOnly bool     `json:"check_only"` // if true, only check the message, do not update the storage state
 }
 
 // MetaData is a meta-info about the message, provided by the client.

--- a/lib/spamcheck/spamcheck_test.go
+++ b/lib/spamcheck/spamcheck_test.go
@@ -48,17 +48,17 @@ func TestRequestString(t *testing.T) {
 	}{
 		{
 			name:     "Normal message",
-			request:  Request{"Hello, world!", "123", "Alice", MetaData{2, 1, false}},
+			request:  Request{"Hello, world!", "123", "Alice", MetaData{2, 1, false}, false},
 			expected: `msg:"Hello, world!", user:"Alice", id:123, images:2, links:1, has_video:false`,
 		},
 		{
 			name:     "Spam message",
-			request:  Request{"Spam message", "456", "Bob", MetaData{0, 3, true}},
+			request:  Request{"Spam message", "456", "Bob", MetaData{0, 3, true}, true},
 			expected: `msg:"Spam message", user:"Bob", id:456, images:0, links:3, has_video:true`,
 		},
 		{
 			name:     "Empty fields",
-			request:  Request{"", "", "", MetaData{0, 0, false}},
+			request:  Request{"", "", "", MetaData{0, 0, false}, false},
 			expected: `msg:"", user:"", id:, images:0, links:0, has_video:false`,
 		},
 	}

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -198,8 +198,8 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 		au := approved.UserInfo{Count: d.approvedUsers[req.UserID].Count + 1, UserID: req.UserID,
 			UserName: req.UserName, Timestamp: time.Now()}
 		d.approvedUsers[req.UserID] = au
-		if d.userStorage != nil {
-			_ = d.userStorage.Write(au) // ignore error, failed to write to storage is not critical
+		if d.userStorage != nil && !req.CheckOnly {
+			_ = d.userStorage.Write(au) // ignore error, failed to write to storage is not critical here
 		}
 	}
 	return false, cr

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -284,7 +284,7 @@ func TestDetector_CheckSimilarity(t *testing.T) {
 	}
 }
 
-func TestDetector_CheckClassificator(t *testing.T) {
+func TestDetector_CheckClassifier(t *testing.T) {
 	d := NewDetector(Config{MaxAllowedEmoji: -1, MinSpamProbability: 60})
 	spamSamples := strings.NewReader("win free iPhone\nlottery prize xyz")
 	hamsSamples := strings.NewReader("hello world\nhow are you\nhave a good day")
@@ -333,7 +333,7 @@ func TestDetector_CheckClassificator(t *testing.T) {
 	})
 }
 
-func TestDetector_CheckClassificatorNoHam(t *testing.T) {
+func TestDetector_CheckClassifierNoHam(t *testing.T) {
 	d := NewDetector(Config{MaxAllowedEmoji: -1, MinSpamProbability: 60})
 	spamSamples := strings.NewReader("win free iPhone\nlottery prize xyz")
 	lr, err := d.LoadSamples(strings.NewReader("xyz"), []io.Reader{spamSamples}, nil)


### PR DESCRIPTION
The issue it fixes occurred when the admin performed a message check with the bot's OnMessage call. The call returns the status of all checks, but in addition, it also updates the approved users table.

I added a new `Request.CheckOnly` and propagated it to false from the admin's info-only calls.