### PR TITLE
Make non-master CI build only for repo owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
             -t ghcr.io/${USERNAME}/tg-spam:${ref} -t ${USERNAME}/tg-spam:${ref} .
 
     - name: build and deploy non-master image to ghcr.io and dockerhub
-      if: ${{ github.ref != 'refs/heads/master' }}
+      if: ${{ github.ref != 'refs/heads/master' && github.actor == 'umputun' }}
       env:
         GITHUB_PACKAGE_TOKEN: ${{ secrets.PKG_TOKEN }}
         DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
It was introduced in #186.