### PR TITLE
allow empty text messages if video part is present

### DIFF
--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -269,8 +269,8 @@ func (l *TelegramListener) procEvents(update tbapi.Update) error {
 	log.Printf("[DEBUG] %s", string(msgJSON))
 	msg := transform(update.Message)
 
-	// ignore empty messages
-	if strings.TrimSpace(msg.Text) == "" && msg.Image == nil {
+	// ignore messages with empty text, no media, no video, no video note
+	if strings.TrimSpace(msg.Text) == "" && msg.Image == nil && !msg.WithVideoNote && !msg.WithVideo {
 		return nil
 	}
 


### PR DESCRIPTION
This pr fixes an error preventing running checks on video-only and vide-note-only messages #176