### PR TITLE
Add abnormal spacing detection for spam messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ This option is disabled by default. If `--meta.forward` set or `env:META_FORWARD
 
 Using words that mix characters from multiple languages is a common spam technique. To detect such messages, the bot can check the message for the presence of such words. This option is disabled by default and can be enabled with the `--multi-lang=, [$MULTI_LANG]` parameter. Setting it to a number above `0` will enable this check, and the bot will mark the message as spam if it contains words with characters from more than one language in more than the specified number of words.
 
+** Abnormal spacing check**
+
+This option is disabled by default. If `--space.enabled` is set or `env:SPACE_ENABLED` is true, the bot will check if the message contains abnormal spacing. Such spacing is a common spam technique that tries to split the message into multiple shorter parts to avoid detection. The check calculates the ratio of the number of spaces to the total number of characters in the message, as well as the ratio of the short words. Thresholds for this check can be set with:
+- `--space.short-word` (default:3) - the maximum length of a short word
+- `--space.ratio` (default:0.3) -  the ratio of spaces to all characters in the message
+- `--space.short-ratio` (default:0.7) - the ratio of short words to all words in the message
 
 ### Admin chat/group
 
@@ -239,7 +245,7 @@ Success! The new status is: DISABLED. /help
 ## All Application Options
 
 ```
-      --admin.group=                admin group name, or channel id [$ADMIN_GROUP]
+       --admin.group=                admin group name, or channel id [$ADMIN_GROUP]
       --disable-admin-spam-forward  disable handling messages forwarded to admin group as spam [$DISABLE_ADMIN_SPAM_FORWARD]
       --testing-id=                 testing ids, allow bot to reply to them [$TESTING_ID]
       --history-duration=           history duration (default: 24h) [$HISTORY_DURATION]
@@ -293,6 +299,12 @@ openai:
       --openai.max-tokens-request=  openai max tokens in request (default: 2048) [$OPENAI_MAX_TOKENS_REQUEST]
       --openai.max-symbols-request= openai max symbols in request, failback if tokenizer failed (default: 16000) [$OPENAI_MAX_SYMBOLS_REQUEST]
       --openai.retry-count=         openai retry count (default: 1) [$OPENAI_RETRY_COUNT]
+
+space:
+      --space.enabled               enable abnormal words check [$SPACE_ENABLED]
+      --space.short-word=           the length of the word to be considered short (default: 3) [$SPACE_SHORT_WORD]
+      --space.short-ratio=          the ratio of short words to all words in the message (default: 0.7) [$SPACE_SHORT_RATIO]
+      --space.ratio=                the ratio of spaces to all characters in the message (default: 0.3) [$SPACE_RATIO]
 
 files:
       --files.samples=              samples data path (default: data) [$FILES_SAMPLES]

--- a/app/main.go
+++ b/app/main.go
@@ -86,11 +86,11 @@ type options struct {
 		RetryCount                       int    `long:"retry-count" env:"RETRY_COUNT" default:"1" description:"openai retry count"`
 	} `group:"openai" namespace:"openai" env-namespace:"OPENAI"`
 
-	AbnormalWords struct {
+	AbnormalSpacing struct {
 		Enabled                 bool    `long:"enabled" env:"ENABLED" description:"enable abnormal words check"`
 		SpaceRatioThreshold     float64 `long:"ratio" env:"RATIO" default:"0.3" description:"the ratio of spaces to all characters in the message"`
-		ShortWordThreshold      int     `long:"short-word" env:"SHORT_WORD" default:"3" description:"the length of the word to be considered short"`
 		ShortWordRatioThreshold float64 `long:"short-ratio" env:"SHORT_RATIO" default:"0.7" description:"the ratio of short words to all words in the message"`
+		ShortWordLen            int     `long:"short-word" env:"SHORT_WORD" default:"3" description:"the length of the word to be considered short"`
 	} `group:"space" namespace:"space" env-namespace:"SPACE"`
 
 	Files struct {
@@ -467,12 +467,12 @@ func makeDetector(opts options) *tgspam.Detector {
 		detector.WithOpenAIChecker(openai.NewClientWithConfig(config), openAIConfig)
 	}
 
-	if opts.AbnormalWords.Enabled {
+	if opts.AbnormalSpacing.Enabled {
 		log.Printf("[INFO] words spacing check enabled")
 		detector.AbnormalSpacing.Enabled = true
-		detector.AbnormalSpacing.ShortWordThreshold = opts.AbnormalWords.ShortWordThreshold
-		detector.AbnormalSpacing.ShortWordRatioThreshold = opts.AbnormalWords.ShortWordRatioThreshold
-		detector.AbnormalSpacing.SpaceRatioThreshold = opts.AbnormalWords.SpaceRatioThreshold
+		detector.AbnormalSpacing.ShortWordLen = opts.AbnormalSpacing.ShortWordLen
+		detector.AbnormalSpacing.ShortWordRatioThreshold = opts.AbnormalSpacing.ShortWordRatioThreshold
+		detector.AbnormalSpacing.SpaceRatioThreshold = opts.AbnormalSpacing.SpaceRatioThreshold
 	}
 
 	metaChecks := []tgspam.MetaCheck{}

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -56,6 +56,13 @@ type Config struct {
 	MinSpamProbability  float64    // minimum spam probability to consider a message spam with classifier, if 0 - ignored
 	OpenAIVeto          bool       // if true, openai will be used to veto spam messages, otherwise it will be used to veto ham messages
 	MultiLangWords      int        // if true, check for number of multi-lingual words
+
+	AbnormalSpacing struct {
+		Enabled                 bool    // if true, enable check for abnormal spacing
+		ShortWordThreshold      int     // the length of the word to be considered short (in rune characters)
+		ShortWordRatioThreshold float64 // the ratio of short words to all words in the message
+		SpaceRatioThreshold     float64 // the ratio of spaces to all characters in the message
+	}
 }
 
 // SampleUpdater is an interface for updating spam/ham samples on the fly.
@@ -149,6 +156,10 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 
 	if d.MultiLangWords > 0 {
 		cr = append(cr, d.isMultiLang(req.Msg))
+	}
+
+	if d.AbnormalSpacing.Enabled {
+		cr = append(cr, d.isAbnormalSpacing(req.Msg))
 	}
 
 	// check for message length exceed the minimum size, if min message length is set.
@@ -651,6 +662,70 @@ func (d *Detector) isMultiLang(msg string) spamcheck.Response {
 		return spamcheck.Response{Name: "multi-lingual", Spam: true, Details: fmt.Sprintf("%d/%d", count, d.MultiLangWords)}
 	}
 	return spamcheck.Response{Name: "multi-lingual", Spam: false, Details: fmt.Sprintf("%d/%d", count, d.MultiLangWords)}
+}
+
+// isAbnormalSpacing detects abnormal spacing patterns used to evade filters
+// things like this: "w o r d s p a c i n g some thing he re blah blah"
+func (d *Detector) isAbnormalSpacing(msg string) spamcheck.Response {
+	text := strings.ToUpper(msg)
+
+	// quick check for empty or very short text
+	if len(text) < 10 {
+		return spamcheck.Response{
+			Name:    "word-spacing",
+			Spam:    false,
+			Details: "too short",
+		}
+	}
+
+	words := strings.Fields(text)
+
+	// count letters and spaces in original text
+	var totalChars, spaces int
+	for _, r := range text {
+		if unicode.IsLetter(r) {
+			totalChars++
+		} else if unicode.IsSpace(r) {
+			spaces++
+		}
+	}
+
+	// look for suspicious word lengths and spacing patterns
+	shortWords := 0
+	if d.AbnormalSpacing.ShortWordThreshold > 0 { // if ShortWordThreshold is 0, skip short word detection
+		for _, word := range words {
+			wordRunes := []rune(word)
+			if len(wordRunes) <= d.AbnormalSpacing.ShortWordThreshold && len(wordRunes) > 0 {
+				shortWords++
+			}
+		}
+	}
+
+	// safety check
+	if spaces == 0 || totalChars == 0 {
+		return spamcheck.Response{
+			Name:    "word-spacing",
+			Spam:    false,
+			Details: "no spaces or letters",
+		}
+	}
+
+	// calculate ratios
+	spaceRatio := float64(spaces) / float64(totalChars)
+	shortWordRatio := float64(shortWords) / float64(len(words))
+	if shortWordRatio > d.AbnormalSpacing.ShortWordRatioThreshold || spaceRatio > d.AbnormalSpacing.SpaceRatioThreshold {
+		return spamcheck.Response{
+			Name:    "word-spacing",
+			Spam:    true,
+			Details: fmt.Sprintf("abnormal spacing (ratio: %.2f, short words: %.0f%%)", spaceRatio, shortWordRatio*100),
+		}
+	}
+
+	return spamcheck.Response{
+		Name:    "word-spacing",
+		Spam:    false,
+		Details: fmt.Sprintf("normal spacing (ratio: %.2f, short words: %.0f%%)", spaceRatio, shortWordRatio*100),
+	}
 }
 
 // cleanText removes control and format characters from a given text

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -59,7 +59,7 @@ type Config struct {
 
 	AbnormalSpacing struct {
 		Enabled                 bool    // if true, enable check for abnormal spacing
-		ShortWordThreshold      int     // the length of the word to be considered short (in rune characters)
+		ShortWordLen            int     // the length of the word to be considered short (in rune characters)
 		ShortWordRatioThreshold float64 // the ratio of short words to all words in the message
 		SpaceRatioThreshold     float64 // the ratio of spaces to all characters in the message
 	}
@@ -692,10 +692,10 @@ func (d *Detector) isAbnormalSpacing(msg string) spamcheck.Response {
 
 	// look for suspicious word lengths and spacing patterns
 	shortWords := 0
-	if d.AbnormalSpacing.ShortWordThreshold > 0 { // if ShortWordThreshold is 0, skip short word detection
+	if d.AbnormalSpacing.ShortWordLen > 0 { // if ShortWordLen is 0, skip short word detection
 		for _, word := range words {
 			wordRunes := []rune(word)
-			if len(wordRunes) <= d.AbnormalSpacing.ShortWordThreshold && len(wordRunes) > 0 {
+			if len(wordRunes) <= d.AbnormalSpacing.ShortWordLen && len(wordRunes) > 0 {
 				shortWords++
 			}
 		}

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -692,6 +692,116 @@ func TestDetector_CheckMultiLang(t *testing.T) {
 	}
 }
 
+func TestDetector_CheckWithAbnormalSpacing(t *testing.T) {
+	d := NewDetector(Config{MaxAllowedEmoji: -1})
+	d.Config.AbnormalSpacing.Enabled = true
+	d.Config.AbnormalSpacing.ShortWordThreshold = 3
+	d.Config.AbnormalSpacing.ShortWordRatioThreshold = 0.7
+	d.Config.AbnormalSpacing.SpaceRatioThreshold = 0.3
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+		details  string
+	}{
+		{
+			name:     "normal text",
+			input:    "This is a normal message with regular spacing between words",
+			expected: false,
+			details:  "normal spacing (ratio: 0.18, short words: 20%)",
+		},
+		{
+			name:     "another normal text",
+			input:    "For structured content, like code or tables, the ratio can vary significantly based on formatting and indentation",
+			expected: false,
+			details:  "normal spacing (ratio: 0.17, short words: 35%)",
+		},
+		{
+			name: "normal text, cyrillic",
+			input: "Если продолжать этот парад благородного безумия, я бы предложил базу имеющихся примеров спама" +
+				" сконвертировать в эмбеддинги и проверять через них после байеса, но до gpt4. Эмбеддинги должны быть" +
+				" устойчивы к разделенным словам и даже переформулировкам, при этом они гораздо дешевле большой модели.",
+			expected: false,
+			details:  "normal spacing (ratio: 0.17, short words: 26%)",
+		},
+		{
+			name:     "suspicious spacing cyrillic",
+			input:    "СРО ЧНО ЭТО КАСА ЕТСЯ КАЖ ДОГО В ЭТ ОЙ ГРУ ППЕ",
+			expected: true,
+			details:  "abnormal spacing (ratio: 0.31, short words: 75%)",
+		},
+		{
+			name:     "very suspicious spacing cyrillic",
+			input:    "н а р к о т и к о в, и н в е с т и ц и й",
+			expected: true,
+			details:  "abnormal spacing (ratio: 0.95, short words: 100%)",
+		},
+		{
+			name:     "mixed normal and suspicious",
+			input:    "Hello there к а ж д о г о в э т о й г р у п п е",
+			expected: true,
+			details:  "abnormal spacing (ratio: 0.68, short words: 90%)",
+		},
+		{
+			name:     "short spaced text",
+			input:    "a b c d",
+			expected: false, // too short overall
+			details:  "too short",
+		},
+		{
+			name:     "text with some extra spaces",
+			input:    "This   is    a    message    with    some    extra    spaces",
+			expected: true,
+			details:  "abnormal spacing (ratio: 0.82, short words: 25%)",
+		},
+		{
+			name: "real spam example",
+			input: "СРО ЧНО ЭТО КАСА ЕТСЯ КАЖ ДОГО В ЭТ ОЙ ГРУ ППЕ  Строго 20+ В данный момент про ходит обуч ение " +
+				"для нови чков  Сразу говорю - без н а р к о т и к о в, и н в е с т и ц и й и прочей еру нды.  Быстрый старт, " +
+				"при быль вы полу чите уже в пе рвый день раб   Все легально  Для раб оты нужен смарт фон и всего 1 час твоего " +
+				"врем ени в день  Дове дём вас за ру чку до при были Не бер ём н и к а к и х о п л а т от вас, мы ра60таем " +
+				"на % (вы зараба тываете и  только потом делитесь с нами) Кому действ ительно инте ресно " +
+				"пишите в и я обязат ельно тебе отвечу",
+			expected: true,
+			details:  "abnormal spacing (ratio: 0.36, short words: 63%)",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+			details:  "too short",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spam, resp := d.Check(spamcheck.Request{Msg: tt.input})
+			t.Logf("Response: %+v", resp)
+			require.Len(t, resp, 1)
+			assert.Equal(t, tt.expected, spam, "spam detection mismatch")
+			assert.Equal(t, tt.details, resp[0].Details, "details mismatch")
+		})
+	}
+
+	t.Run("disabled short word threshold", func(t *testing.T) {
+		d.Config.AbnormalSpacing.ShortWordThreshold = 0
+		spam, resp := d.Check(spamcheck.Request{Msg: "СРО ЧНО ЭТО КАС АЕТ СЯ КАЖ ДОГО В ЭТ ОЙ ГРУ ППЕ something else"})
+		t.Logf("Response: %+v", resp)
+		assert.False(t, spam)
+		assert.Equal(t, "normal spacing (ratio: 0.29, short words: 0%)", resp[0].Details)
+	})
+
+	t.Run("enabled short word threshold", func(t *testing.T) {
+		d.Config.AbnormalSpacing.ShortWordThreshold = 3
+		spam, resp := d.Check(spamcheck.Request{Msg: "СРО ЧНО ЭТО КАС АЕТ СЯ КАЖ ДОГО В ЭТ ОЙ ГРУ ППЕ something else"})
+		t.Logf("Response: %+v", resp)
+		assert.True(t, spam)
+		assert.Equal(t, "abnormal spacing (ratio: 0.29, short words: 80%)", resp[0].Details)
+	})
+
+}
+
 func TestDetector_UpdateSpam(t *testing.T) {
 	upd := &mocks.SampleUpdaterMock{
 		AppendFunc: func(msg string) error {

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -695,7 +695,7 @@ func TestDetector_CheckMultiLang(t *testing.T) {
 func TestDetector_CheckWithAbnormalSpacing(t *testing.T) {
 	d := NewDetector(Config{MaxAllowedEmoji: -1})
 	d.Config.AbnormalSpacing.Enabled = true
-	d.Config.AbnormalSpacing.ShortWordThreshold = 3
+	d.Config.AbnormalSpacing.ShortWordLen = 3
 	d.Config.AbnormalSpacing.ShortWordRatioThreshold = 0.7
 	d.Config.AbnormalSpacing.SpaceRatioThreshold = 0.3
 
@@ -785,7 +785,7 @@ func TestDetector_CheckWithAbnormalSpacing(t *testing.T) {
 	}
 
 	t.Run("disabled short word threshold", func(t *testing.T) {
-		d.Config.AbnormalSpacing.ShortWordThreshold = 0
+		d.Config.AbnormalSpacing.ShortWordLen = 0
 		spam, resp := d.Check(spamcheck.Request{Msg: "СРО ЧНО ЭТО КАС АЕТ СЯ КАЖ ДОГО В ЭТ ОЙ ГРУ ППЕ something else"})
 		t.Logf("Response: %+v", resp)
 		assert.False(t, spam)
@@ -793,7 +793,7 @@ func TestDetector_CheckWithAbnormalSpacing(t *testing.T) {
 	})
 
 	t.Run("enabled short word threshold", func(t *testing.T) {
-		d.Config.AbnormalSpacing.ShortWordThreshold = 3
+		d.Config.AbnormalSpacing.ShortWordLen = 3
 		spam, resp := d.Check(spamcheck.Request{Msg: "СРО ЧНО ЭТО КАС АЕТ СЯ КАЖ ДОГО В ЭТ ОЙ ГРУ ППЕ something else"})
 		t.Logf("Response: %+v", resp)
 		assert.True(t, spam)


### PR DESCRIPTION
Introduced a new checker to detect abnormal spacing patterns in messages, a common spam evasion technique. It calculates both ratios of short words vs total words as well as ratio of spaces.

The goal is to detect "broken with space" words, i.e. "Th is an exa mple of such cr ap" . The checker configured with this set of options and disabled by default

```go
	AbnormalWords struct {
		Enabled                 bool    `long:"enabled" env:"ENABLED" description:"enable abnormal words check"`
		SpaceRatioThreshold     float64 `long:"ratio" env:"RATIO" default:"0.3" description:"the ratio of spaces to all characters in the message"`
		ShortWordThreshold      int     `long:"short-word" env:"SHORT_WORD" default:"3" description:"the length of the word to be considered short"`
		ShortWordRatioThreshold float64 `long:"short-ratio" env:"SHORT_RATIO" default:"0.7" description:"the ratio of short words to all words in the message"`
	} `group:"space" namespace:"space" env-namespace:"SPACE"`
```