### PR TITLE
[WIP] DigitalOcean App Platform deployment button

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,22 @@
+spec:
+  name: tg-spam
+  services:
+    - name: tg-spam
+      image:
+        registry_type: DOCKER_HUB
+        registry: umputun
+        repository: tg-spam
+        tag: master
+      instance_size_slug: basic-xxs
+      health_check:
+        http_path: /ping
+      envs:
+        - key: TELEGRAM_TOKEN
+          scope: RUN_TIME
+          value: "Replace with your Telegram token"
+        - key: TELEGRAM_GROUP
+          scope: RUN_TIME
+          value: "Replace with your Telegram group name (without @) or id"
+        - key: SERVER_ENABLED
+          scope: RUN_TIME
+          value: "true"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ TG-Spam can also run as a server, providing a simple HTTP API to check messages 
 - Binary releases are also available on the [releases page](https://github.com/umputun/tg-spam/releases/latest).
 - TG-Spam can be installed by cloning the repository and building the binary from source by running `make build`.
 - It can also be installed using `brew tap umputun/apps && brew install umputun/apps/tg-spam` on macOS.
+- Deploy TG-Spam to the DigitalOcean App Platform with just one click:
+  [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/slyapustin/tg-spam/tree/do-deployment-button&refcode=08ce1ee690de)
 
 **Install guide for non-technical users is available [here](/INSTALL.md)**
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ TG-Spam can also run as a server, providing a simple HTTP API to check messages 
 - TG-Spam can be installed by cloning the repository and building the binary from source by running `make build`.
 - It can also be installed using `brew tap umputun/apps && brew install umputun/apps/tg-spam` on macOS.
 - Deploy TG-Spam to the DigitalOcean App Platform with just one click:
+
   [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/slyapustin/tg-spam/tree/do-deployment-button&refcode=08ce1ee690de)
 
 **Install guide for non-technical users is available [here](/INSTALL.md)**


### PR DESCRIPTION
@umputun Here is Draft PR for adding DO deployment button.

Some things to clarify/confirm:
 - [ ] Decide on where to put deployment button in the documentation (it's currently in the README.md).
 - [ ] This deployment is more suitable for Demo purpose (since App Platform does not provide persistent storage and changes will be lost on the instance restart).  It should be fine for OpenAI integration AFAIK, since it should not store additional info on the disk.

Update things before merging:
 - [ ] Update DO referral code 
 - [ ] Update link in the button to link to the main repo

Closes #205