### PR TITLE
Optimize sample loader

### DIFF
--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -116,9 +116,6 @@ func (s *SpamFilter) UpdateSpam(msg string) error {
 	if err := s.Detector.UpdateSpam(cleanMsg); err != nil {
 		return fmt.Errorf("can't update spam samples: %w", err)
 	}
-	if err := s.ReloadSamples(); err != nil {
-		return fmt.Errorf("can't reload samples: %w", err)
-	}
 	return nil
 }
 
@@ -128,9 +125,6 @@ func (s *SpamFilter) UpdateHam(msg string) error {
 	log.Printf("[DEBUG] update ham samples with %q", cleanMsg)
 	if err := s.Detector.UpdateHam(cleanMsg); err != nil {
 		return fmt.Errorf("can't update ham samples: %w", err)
-	}
-	if err := s.ReloadSamples(); err != nil {
-		return fmt.Errorf("can't reload samples: %w", err)
 	}
 	return nil
 }
@@ -146,9 +140,6 @@ func (s *SpamFilter) AddApprovedUser(id int64, name string) error {
 	if err := s.Detector.AddApprovedUser(approved.UserInfo{UserID: fmt.Sprintf("%d", id), UserName: name}); err != nil {
 		return fmt.Errorf("failed to write approved user to storage: %w", err)
 	}
-	if err := s.ReloadSamples(); err != nil {
-		return fmt.Errorf("failed to reload samples: %w", err)
-	}
 	return nil
 }
 
@@ -157,9 +148,6 @@ func (s *SpamFilter) RemoveApprovedUser(id int64) error {
 	log.Printf("[INFO] remove aproved user: %d", id)
 	if err := s.Detector.RemoveApprovedUser(fmt.Sprintf("%d", id)); err != nil {
 		return fmt.Errorf("failed to delete approved user from storage: %w", err)
-	}
-	if err := s.ReloadSamples(); err != nil {
-		return fmt.Errorf("failed to reload samples: %w", err)
 	}
 	return nil
 }

--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -366,7 +366,7 @@ func (s *Server) deleteSampleHandler(delFn func(msg string) error) func(w http.R
 	}
 }
 
-// reloadDynamicSamplesHandler handles PUT /samples request. It reloads dynamic samples from files
+// reloadDynamicSamplesHandler handles PUT /samples request. It reloads dynamic samples from db storage.
 func (s *Server) reloadDynamicSamplesHandler(w http.ResponseWriter, _ *http.Request) {
 	if err := s.SpamFilter.ReloadSamples(); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
_Continuation of optimization efforts started in #217_

This one switches the tokenizer reader from channel-based to iterator-based. It also eliminates unnecessary ReloadSamples calls on sample's ham/spam add (write) activity.

The first part saves about 20% of the time spent in the samples loader, and the second one drops relatively heavy reloads from the places where we don't need to have them.