### PR TITLE
Classifier unlearn

### DIFF
--- a/app/bot/mocks/detector.go
+++ b/app/bot/mocks/detector.go
@@ -38,6 +38,12 @@ import (
 //			RemoveApprovedUserFunc: func(id string) error {
 //				panic("mock out the RemoveApprovedUser method")
 //			},
+//			RemoveHamFunc: func(msg string) error {
+//				panic("mock out the RemoveHam method")
+//			},
+//			RemoveSpamFunc: func(msg string) error {
+//				panic("mock out the RemoveSpam method")
+//			},
 //			UpdateHamFunc: func(msg string) error {
 //				panic("mock out the UpdateHam method")
 //			},
@@ -71,6 +77,12 @@ type DetectorMock struct {
 
 	// RemoveApprovedUserFunc mocks the RemoveApprovedUser method.
 	RemoveApprovedUserFunc func(id string) error
+
+	// RemoveHamFunc mocks the RemoveHam method.
+	RemoveHamFunc func(msg string) error
+
+	// RemoveSpamFunc mocks the RemoveSpam method.
+	RemoveSpamFunc func(msg string) error
 
 	// UpdateHamFunc mocks the UpdateHam method.
 	UpdateHamFunc func(msg string) error
@@ -117,6 +129,16 @@ type DetectorMock struct {
 			// ID is the id argument value.
 			ID string
 		}
+		// RemoveHam holds details about calls to the RemoveHam method.
+		RemoveHam []struct {
+			// Msg is the msg argument value.
+			Msg string
+		}
+		// RemoveSpam holds details about calls to the RemoveSpam method.
+		RemoveSpam []struct {
+			// Msg is the msg argument value.
+			Msg string
+		}
 		// UpdateHam holds details about calls to the UpdateHam method.
 		UpdateHam []struct {
 			// Msg is the msg argument value.
@@ -135,6 +157,8 @@ type DetectorMock struct {
 	lockLoadSamples        sync.RWMutex
 	lockLoadStopWords      sync.RWMutex
 	lockRemoveApprovedUser sync.RWMutex
+	lockRemoveHam          sync.RWMutex
+	lockRemoveSpam         sync.RWMutex
 	lockUpdateHam          sync.RWMutex
 	lockUpdateSpam         sync.RWMutex
 }
@@ -415,6 +439,84 @@ func (mock *DetectorMock) ResetRemoveApprovedUserCalls() {
 	mock.lockRemoveApprovedUser.Unlock()
 }
 
+// RemoveHam calls RemoveHamFunc.
+func (mock *DetectorMock) RemoveHam(msg string) error {
+	if mock.RemoveHamFunc == nil {
+		panic("DetectorMock.RemoveHamFunc: method is nil but Detector.RemoveHam was just called")
+	}
+	callInfo := struct {
+		Msg string
+	}{
+		Msg: msg,
+	}
+	mock.lockRemoveHam.Lock()
+	mock.calls.RemoveHam = append(mock.calls.RemoveHam, callInfo)
+	mock.lockRemoveHam.Unlock()
+	return mock.RemoveHamFunc(msg)
+}
+
+// RemoveHamCalls gets all the calls that were made to RemoveHam.
+// Check the length with:
+//
+//	len(mockedDetector.RemoveHamCalls())
+func (mock *DetectorMock) RemoveHamCalls() []struct {
+	Msg string
+} {
+	var calls []struct {
+		Msg string
+	}
+	mock.lockRemoveHam.RLock()
+	calls = mock.calls.RemoveHam
+	mock.lockRemoveHam.RUnlock()
+	return calls
+}
+
+// ResetRemoveHamCalls reset all the calls that were made to RemoveHam.
+func (mock *DetectorMock) ResetRemoveHamCalls() {
+	mock.lockRemoveHam.Lock()
+	mock.calls.RemoveHam = nil
+	mock.lockRemoveHam.Unlock()
+}
+
+// RemoveSpam calls RemoveSpamFunc.
+func (mock *DetectorMock) RemoveSpam(msg string) error {
+	if mock.RemoveSpamFunc == nil {
+		panic("DetectorMock.RemoveSpamFunc: method is nil but Detector.RemoveSpam was just called")
+	}
+	callInfo := struct {
+		Msg string
+	}{
+		Msg: msg,
+	}
+	mock.lockRemoveSpam.Lock()
+	mock.calls.RemoveSpam = append(mock.calls.RemoveSpam, callInfo)
+	mock.lockRemoveSpam.Unlock()
+	return mock.RemoveSpamFunc(msg)
+}
+
+// RemoveSpamCalls gets all the calls that were made to RemoveSpam.
+// Check the length with:
+//
+//	len(mockedDetector.RemoveSpamCalls())
+func (mock *DetectorMock) RemoveSpamCalls() []struct {
+	Msg string
+} {
+	var calls []struct {
+		Msg string
+	}
+	mock.lockRemoveSpam.RLock()
+	calls = mock.calls.RemoveSpam
+	mock.lockRemoveSpam.RUnlock()
+	return calls
+}
+
+// ResetRemoveSpamCalls reset all the calls that were made to RemoveSpam.
+func (mock *DetectorMock) ResetRemoveSpamCalls() {
+	mock.lockRemoveSpam.Lock()
+	mock.calls.RemoveSpam = nil
+	mock.lockRemoveSpam.Unlock()
+}
+
 // UpdateHam calls UpdateHamFunc.
 func (mock *DetectorMock) UpdateHam(msg string) error {
 	if mock.UpdateHamFunc == nil {
@@ -522,6 +624,14 @@ func (mock *DetectorMock) ResetCalls() {
 	mock.lockRemoveApprovedUser.Lock()
 	mock.calls.RemoveApprovedUser = nil
 	mock.lockRemoveApprovedUser.Unlock()
+
+	mock.lockRemoveHam.Lock()
+	mock.calls.RemoveHam = nil
+	mock.lockRemoveHam.Unlock()
+
+	mock.lockRemoveSpam.Lock()
+	mock.calls.RemoveSpam = nil
+	mock.lockRemoveSpam.Unlock()
 
 	mock.lockUpdateHam.Lock()
 	mock.calls.UpdateHam = nil

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -57,7 +57,6 @@ type Detector interface {
 type SamplesStore interface {
 	Read(ctx context.Context, t storage.SampleType, o storage.SampleOrigin) ([]string, error)
 	Reader(ctx context.Context, t storage.SampleType, o storage.SampleOrigin) (io.ReadCloser, error)
-	// DeleteMessage(ctx context.Context, message string) error
 	Stats(ctx context.Context) (*storage.SamplesStats, error)
 }
 
@@ -114,7 +113,7 @@ func (s *SpamFilter) OnMessage(msg Message, checkOnly bool) (response Response) 
 // UpdateSpam appends a message to the spam samples file and updates the classifier
 func (s *SpamFilter) UpdateSpam(msg string) error {
 	cleanMsg := strings.ReplaceAll(msg, "\n", " ")
-	log.Printf("[DEBUG] update spam samples with %q", cleanMsg)
+	log.Printf("[INFO] update spam samples with %q", cleanMsg)
 	if err := s.Detector.UpdateSpam(cleanMsg); err != nil {
 		return fmt.Errorf("can't update spam samples: %w", err)
 	}
@@ -124,7 +123,7 @@ func (s *SpamFilter) UpdateSpam(msg string) error {
 // UpdateHam appends a message to the ham samples file and updates the classifier
 func (s *SpamFilter) UpdateHam(msg string) error {
 	cleanMsg := strings.ReplaceAll(msg, "\n", " ")
-	log.Printf("[DEBUG] update ham samples with %q", cleanMsg)
+	log.Printf("[INFO] update ham samples with %q", cleanMsg)
 	if err := s.Detector.UpdateHam(cleanMsg); err != nil {
 		return fmt.Errorf("can't update ham samples: %w", err)
 	}
@@ -238,7 +237,7 @@ func (s *SpamFilter) DynamicSamples() (spam, ham []string, err error) {
 // RemoveDynamicSpamSample removes a sample from the spam dynamic samples file and reloads samples after this
 func (s *SpamFilter) RemoveDynamicSpamSample(sample string) error {
 	cleanMsg := strings.ReplaceAll(sample, "\n", " ")
-	log.Printf("[DEBUG] remove dynamic spam sample: %q", sample)
+	log.Printf("[INFO] remove dynamic spam sample: %q", sample)
 	if err := s.Detector.RemoveSpam(cleanMsg); err != nil {
 		return fmt.Errorf("can't remove spam sample %q: %w", sample, err)
 	}
@@ -248,7 +247,7 @@ func (s *SpamFilter) RemoveDynamicSpamSample(sample string) error {
 // RemoveDynamicHamSample removes a sample from the ham dynamic samples file and reloads samples after this
 func (s *SpamFilter) RemoveDynamicHamSample(sample string) error {
 	cleanMsg := strings.ReplaceAll(sample, "\n", " ")
-	log.Printf("[DEBUG] remove dynamic ham sample: %q", sample)
+	log.Printf("[INFO] remove dynamic ham sample: %q", sample)
 	if err := s.Detector.RemoveHam(cleanMsg); err != nil {
 		return fmt.Errorf("can't remove hma sample %q: %w", sample, err)
 	}

--- a/app/storage/samples.go
+++ b/app/storage/samples.go
@@ -64,6 +64,7 @@ func NewSamples(ctx context.Context, db *Engine) (*Samples, error) {
 		CREATE INDEX IF NOT EXISTS idx_samples_timestamp ON samples(timestamp);
 		CREATE INDEX IF NOT EXISTS idx_samples_type ON samples(type);
 		CREATE INDEX IF NOT EXISTS idx_samples_origin ON samples(origin);
+		CREATE INDEX IF NOT EXISTS idx_samples_message ON samples(message);
     `
 
 	if _, err = tx.ExecContext(ctx, schema); err != nil {
@@ -79,7 +80,11 @@ func NewSamples(ctx context.Context, db *Engine) (*Samples, error) {
 
 // Add adds a sample to the storage. Checks if the sample is already present and skips it if it is.
 func (s *Samples) Add(ctx context.Context, t SampleType, o SampleOrigin, message string) error {
-	log.Printf("[DEBUG] adding sample: %s, %s, %q", t, o, message)
+	dbgMsg := message
+	if len(dbgMsg) > 1024 {
+		dbgMsg = dbgMsg[:1024] + "..."
+	}
+	log.Printf("[DEBUG] adding sample: %s, %s, %q", t, o, dbgMsg)
 	if err := t.Validate(); err != nil {
 		return err
 	}

--- a/app/storage/samples.go
+++ b/app/storage/samples.go
@@ -79,6 +79,7 @@ func NewSamples(ctx context.Context, db *Engine) (*Samples, error) {
 
 // Add adds a sample to the storage. Checks if the sample is already present and skips it if it is.
 func (s *Samples) Add(ctx context.Context, t SampleType, o SampleOrigin, message string) error {
+	log.Printf("[DEBUG] adding sample: %s, %s, %q", t, o, message)
 	if err := t.Validate(); err != nil {
 		return err
 	}
@@ -107,6 +108,7 @@ func (s *Samples) Add(ctx context.Context, t SampleType, o SampleOrigin, message
 
 // Delete removes a sample from the storage by its ID
 func (s *Samples) Delete(ctx context.Context, id int64) error {
+	log.Printf("[DEBUG] deleting sample: %d", id)
 	s.Lock()
 	defer s.Unlock()
 
@@ -127,6 +129,7 @@ func (s *Samples) Delete(ctx context.Context, id int64) error {
 
 // DeleteMessage removes a sample from the storage by its message
 func (s *Samples) DeleteMessage(ctx context.Context, message string) error {
+	log.Printf("[DEBUG] deleting sample: %q", message)
 	s.Lock()
 	defer s.Unlock()
 
@@ -184,6 +187,7 @@ func (s *Samples) Read(ctx context.Context, t SampleType, o SampleOrigin) ([]str
 	if err := s.db.SelectContext(ctx, &samples, query, args...); err != nil {
 		return nil, fmt.Errorf("failed to get samples: %w", err)
 	}
+	log.Printf("[DEBUG] read %d samples: gid=%s, type=%s, origin=%s", len(samples), gid, t, o)
 	return samples, nil
 }
 

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -103,6 +103,16 @@ func (u *SampleUpdater) Append(msg string) error {
 	return u.samplesService.Add(ctx, u.sampleType, SampleOriginUser, msg)
 }
 
+// Remove a message from the samples
+func (u *SampleUpdater) Remove(msg string) error {
+	ctx, cancel := context.Background(), func() {}
+	if u.timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), u.timeout)
+	}
+	defer cancel()
+	return u.samplesService.DeleteMessage(ctx, msg)
+}
+
 // Reader returns a reader for the samples
 func (u *SampleUpdater) Reader() (io.ReadCloser, error) {
 	// we don't want to pass context with timeout here, as it's an async operation

--- a/lib/tgspam/classifier.go
+++ b/lib/tgspam/classifier.go
@@ -1,6 +1,9 @@
 package tgspam
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 // based on the code from https://github.com/RadhiFadlillah/go-bayesian/blob/master/classifier.go
 
@@ -62,6 +65,56 @@ func (c *classifier) learn(docs ...document) {
 	for class, nDocument := range c.nDocumentByClass {
 		c.priorProbabilities[class] = math.Log(float64(nDocument) / float64(c.nAllDocument))
 	}
+}
+
+// unlearn removes the learning results for given documents
+func (c *classifier) unlearn(docs ...document) error {
+	if len(docs) > c.nAllDocument {
+		return fmt.Errorf("trying to unlearn more documents than learned")
+	}
+
+	c.nAllDocument -= len(docs)
+
+	for _, doc := range docs {
+		if c.nDocumentByClass[doc.spamClass] <= 0 {
+			return fmt.Errorf("no documents of class %v to unlearn", doc.spamClass)
+		}
+
+		c.nDocumentByClass[doc.spamClass]--
+		tokens := c.removeDuplicate(doc.tokens...)
+
+		for _, token := range tokens {
+			if c.nFrequencyByClass[doc.spamClass] <= 0 {
+				return fmt.Errorf("no tokens of class %v to unlearn", doc.spamClass)
+			}
+			c.nFrequencyByClass[doc.spamClass]--
+
+			if c.learningResults[token][doc.spamClass] <= 0 {
+				return fmt.Errorf("token %q not found in class %v", token, doc.spamClass)
+			}
+			c.learningResults[token][doc.spamClass]--
+
+			// cleanup empty entries
+			if c.learningResults[token][doc.spamClass] == 0 {
+				delete(c.learningResults[token], doc.spamClass)
+			}
+			if len(c.learningResults[token]) == 0 {
+				delete(c.learningResults, token)
+			}
+		}
+
+		// cleanup empty class entries
+		if c.nDocumentByClass[doc.spamClass] == 0 {
+			delete(c.nDocumentByClass, doc.spamClass)
+			delete(c.nFrequencyByClass, doc.spamClass)
+			delete(c.priorProbabilities, doc.spamClass)
+		} else {
+			// update prior probability for the class
+			c.priorProbabilities[doc.spamClass] = math.Log(float64(c.nDocumentByClass[doc.spamClass]) / float64(c.nAllDocument))
+		}
+	}
+
+	return nil
 }
 
 // reset resets all learning results

--- a/lib/tgspam/classifier_test.go
+++ b/lib/tgspam/classifier_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -73,4 +74,154 @@ func TestClassifier_Classify(t *testing.T) {
 			assert.Equal(t, tt.expected, class, "class")
 		})
 	}
+}
+
+func TestClassifier_Unlearn(t *testing.T) {
+	assert := require.New(t)
+
+	t.Run("basic unlearn", func(t *testing.T) {
+		c := newClassifier()
+		doc := newDocument("spam", "bad", "words")
+
+		c.learn(doc)
+		assert.Equal(1, c.nAllDocument)
+		assert.Equal(1, c.nDocumentByClass["spam"])
+
+		err := c.unlearn(doc)
+		assert.NoError(err)
+		assert.Equal(0, c.nAllDocument)
+		assert.Empty(c.nDocumentByClass)
+		assert.Empty(c.learningResults)
+	})
+
+	t.Run("unlearn with multiple docs", func(t *testing.T) {
+		c := newClassifier()
+		docs := []document{
+			newDocument("spam", "bad", "words"),
+			newDocument("ham", "good", "words"),
+		}
+
+		c.learn(docs...)
+		err := c.unlearn(docs[0])
+		assert.NoError(err)
+		assert.Equal(1, c.nAllDocument)
+		assert.Equal(1, c.nDocumentByClass["ham"])
+		assert.Empty(c.nDocumentByClass["spam"])
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		c := newClassifier()
+		doc := newDocument("spam", "bad", "words")
+
+		err := c.unlearn(doc)
+		assert.Error(err)
+
+		c.learn(doc)
+		err = c.unlearn(doc, doc) // try to unlearn same doc twice
+		assert.Error(err)
+	})
+}
+
+func TestClassifier_LearnUnlearnIntegration(t *testing.T) {
+	assert := require.New(t)
+
+	t.Run("learn unlearn learn sequence", func(t *testing.T) {
+		c := newClassifier()
+		doc1 := newDocument(good, "nice", "friendly")
+		doc2 := newDocument(bad, "mean", "unfriendly")
+
+		// initial learning
+		c.learn(doc1, doc2)
+		class, prob, certain := c.classify("nice", "friendly")
+		assert.Equal(good, class)
+		assert.True(certain)
+		assert.InDelta(80., prob, 0.01)
+
+		// unlearn good class
+		err := c.unlearn(doc1)
+		assert.NoError(err)
+
+		// verify only bad class remains
+		class, prob, certain = c.classify("nice", "friendly")
+		assert.Equal(bad, class)
+		assert.True(certain)
+		assert.InDelta(100., prob, 0.01)
+
+		// learn good class again
+		c.learn(doc1)
+		class, prob, certain = c.classify("nice", "friendly")
+		assert.Equal(good, class)
+		assert.True(certain)
+		assert.InDelta(80., prob, 0.01)
+	})
+
+	t.Run("unlearn with duplicate tokens", func(t *testing.T) {
+		c := newClassifier()
+		doc := newDocument(good, "nice", "nice", "nice") // duplicate tokens
+
+		c.learn(doc)
+		err := c.unlearn(doc)
+		assert.NoError(err)
+		assert.Empty(c.learningResults)
+	})
+
+	t.Run("learn unlearn with empty tokens", func(t *testing.T) {
+		c := newClassifier()
+		doc := newDocument(good)
+
+		c.learn(doc)
+		assert.Equal(1, c.nAllDocument)
+		assert.Equal(1, c.nDocumentByClass[good])
+		assert.Empty(c.learningResults) // no tokens to learn
+
+		err := c.unlearn(doc)
+		assert.NoError(err)
+		assert.Empty(c.nDocumentByClass)
+	})
+}
+
+func TestClassifier_ProbabilityConsistency(t *testing.T) {
+	t.Run("probability is between 0 and 100", func(t *testing.T) {
+		c := newClassifier()
+		c.learn(
+			newDocument(good, "a", "b"),
+			newDocument(bad, "c", "d"),
+		)
+
+		// check good class tokens
+		_, prob, _ := c.classify("a", "b")
+		assert.Greater(t, prob, 50.0, "good class should have higher probability for its tokens")
+		assert.LessOrEqual(t, prob, 100.0, "probability should not exceed 100")
+
+		// check bad class tokens
+		_, prob, _ = c.classify("c", "d")
+		assert.Greater(t, prob, 50.0, "bad class should have higher probability for its tokens")
+		assert.LessOrEqual(t, prob, 100.0, "probability should not exceed 100")
+
+		// check mixed tokens
+		_, prob, _ = c.classify("a", "d")
+		assert.Greater(t, prob, 0.0, "probability should be positive")
+		assert.LessOrEqual(t, prob, 100.0, "probability should not exceed 100")
+	})
+}
+
+func TestClassifier_Reset(t *testing.T) {
+	t.Run("learn unlearn reset sequence", func(t *testing.T) {
+		c := newClassifier()
+		doc := newDocument(good, "test")
+
+		c.learn(doc)
+		assert.NotEmpty(t, c.learningResults)
+
+		c.reset()
+		assert.Empty(t, c.learningResults)
+		assert.Empty(t, c.priorProbabilities)
+		assert.Empty(t, c.nDocumentByClass)
+		assert.Empty(t, c.nFrequencyByClass)
+		assert.Zero(t, c.nAllDocument)
+
+		// should be able to learn again after reset
+		c.learn(doc)
+		assert.NotEmpty(t, c.learningResults)
+	})
 }


### PR DESCRIPTION
This is another optimization eliminating the need for a full sample reload on removal and instead applying "unlearn" as a part of the classifier. With this change, the only time a complete reload is needed is on startup.