### PR TITLE
Requests history and openai integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,21 @@ As long as theses two parameters are set, the bot will work. Don't forget to add
 
 There are some important customizations available:
 
-First of all - sample files, the bot is using some data files to detect spam. They are located in the `/srv/data` directory of the container and can be mounted from the host. The files are: `spam-samples.txt`, `ham-samples.txt`, `exclude-tokens.txt` and `stop-words.txt`.
-
-User can specify custom location for them with `--files.samples=, [$FILES_SAMPLES]` parameters. This should be a directory, where all the files are located.
-
-Second, are messages the bot is sending. There are three messages user may want to customize:
+First of all, are messages the bot is sending. There are three messages user may want to customize:
 
 - `--message.startup=, [$MESSAGE_STARTUP]` - message sent to the group when bot is started, can be empty
-- `--message.spam=, [$MESSAGE_SPAM]` - message sent to the group when spam detected
+- `--message.spam=, [$MESSAGE_SPAM]` - message sent to the group when spam detected, optional
 - `--message.dry=, [$MESSAGE_DRY]` - message sent to the group when spam detected in dry mode
 
 By default, the bot reports back to the group with the message `this is spam` and `this is spam (dry mode)` for dry mode. In non-dry mode, the bot will delete the spam message and ban the user permanently. It is possible to suppress those reports with `--no-spam-reply, [$NO_SPAM_REPLY]` parameter.
+
+Another useful feature is the ability to keep the list of approved users persistently and keep other meta-information about detected spam and received messages. The bot will not ban approved users and won't check their messages for spam because they have already passed the initial check. All this info is stored in the internal storage under `--files.dynamic =, [$FILES_DYNAMIC]` directory. User should mount this directory from the host to keep the data persistent. All the files in this directory are handled by bot automatically.
+
+### Legacy way of storing data in text files
+
+**Important**: Starting with version 1.16.0, the bot uses a database to store all the data. The database is created automatically on the first run inside the `$FILES_DYNAMIC` directory. The bot will also migrate all the data from the text files to the database. For more details, see the [Database Migration for samples (spam and ham), stop words, and exclude tokens, after version (v1.16.0+)](#database-migration-for-samples-spam-and-ham-stop-words-and-exclude-tokens-after-version-v1160) section below. This section is about the old way of storing data in text files.
+
+Another thing to customize is the sample files; the bot uses some data files to detect spam. They are located in the `/srv/data` directory of the container and can be mounted from the host. The files are: `spam-samples.txt`, `ham-samples.txt`, `exclude-tokens.txt`, and `stop-words.txt`. Users can specify a custom location for them with the `--files.samples=, [$FILES_SAMPLES]` parameters. This should be a directory where all the files are located.
 
 There are 4 files used by the bot to detect spam:
 
@@ -70,9 +74,7 @@ There are 4 files used by the bot to detect spam:
 - `exclude-tokens.txt` - list of tokens to exclude from spam detection, usually common words. Each line in this file is a single token (word), or a comma-separated list of words in dbl-quotes.
 - `stop-words.txt` - list of stop words to detect spam right away. Each line in this file is a single phrase (can be one or more words). The bot checks if any of those phrases are present in the message and if so, it marks the message as spam.
 
-_The bot dynamically reloads all 4 files, so user can change them on the fly without restarting the bot._
-
-Another useful feature is the ability to keep the list of approved users persistently and keep other meta-information about detected spam and received messages. The bot will not ban approved users and won't check their messages for spam because they have already passed the initial check. All this info is stored in the internal storage under `--files.dynamic =, [$FILES_DYNAMIC]` directory. User should mount this directory from the host to keep the data persistent. All the files in this directory are handled by bot automatically.
+The bot dynamically reloads all 4 files, so user can change them on the fly without restarting the bot.
 
 ### Configuring spam detection modules and parameters
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ Setting `--openai.token [$OPENAI_TOKEN]` enables OpenAI integration. All other p
 
 To keep the number of calls low and the price manageable, the bot uses the following approach:
 
-- Only the first message(s) from a given user is checked for spam. If `--paranoid` mode is enabled, openai will not be used at all.
-- OpenAI check is the last in the chain of checks. By default (if `--openai.veto` is not set), the bot will not even call OpenAI if any of the previous checks marked the message as spam. This default mode makes spam detection stricter, helping detect more spam messages that otherwise could have slipped through the cracks.
-- Setting `--openai.veto` changes the workflow. In veto mode, OpenAI is called *only* if the message is classified as spam by other checks. The message is considered spam only if OpenAI confirms the decision. This helps reduce the number of false positives, making spam detection more careful.
-- By default, OpenAI integration is disabled.
+- By default, the OpenAI integration is disabled. To enable it, set `--openai.token` to a valid OpenAI token.
+-  Only the initial message(s) from a specific user are examined for spam. If `--paranoid` mode is activated, OpenAI will not be utilized at all.
+-  The OpenAI check is the final step in the series of checks. By default (if `--openai.veto` is not configured), the bot will not invoke OpenAI if any preceding checks have classified the message as spam. This default setting enhances spam detection, allowing for the identification of more spam messages that might otherwise go unnoticed.
+-  Configuring `--openai.veto` alters the workflow. In veto mode, OpenAI is contacted *only* if the message is deemed spam by other checks. A message is classified as spam solely if OpenAI corroborates this determination. This approach minimizes the occurrence of false positives, resulting in a more meticulous spam detection process.
+-  Optionally, the OpenAI check can evaluate the message within the context of previous messages. This is beneficial for identifying spam patterns that may not be evident in the message itself or for avoiding false positives when the context provides additional insights, indicating that the message is not an isolated spam but rather a legitimate part of an ongoing conversation. To activate this feature, set `--openai.history-size=, [$OPENAI_HISTORY_SIZE]` to a positive integer, specifying the number of preceding messages to include. A range of 5-10 should suffice for most scenarios. By default, this feature is disabled.
+
 
 **Emoji Count**
 
@@ -137,7 +139,7 @@ This option is disabled by default. If `--meta.forward` set or `env:META_FORWARD
 
 Using words that mix characters from multiple languages is a common spam technique. To detect such messages, the bot can check the message for the presence of such words. This option is disabled by default and can be enabled with the `--multi-lang=, [$MULTI_LANG]` parameter. Setting it to a number above `0` will enable this check, and the bot will mark the message as spam if it contains words with characters from more than one language in more than the specified number of words.
 
-** Abnormal spacing check**
+**Abnormal spacing check**
 
 This option is disabled by default. If `--space.enabled` is set or `env:SPACE_ENABLED` is true, the bot will check if the message contains abnormal spacing. Such spacing is a common spam technique that tries to split the message into multiple shorter parts to avoid detection. The check calculates the ratio of the number of spaces to the total number of characters in the message, as well as the ratio of the short words. Thresholds for this check can be set with:
 - `--space.short-word` (default:3) - the maximum length of a short word
@@ -298,6 +300,7 @@ Success! The new status is: DISABLED. /help
       --first-messages-count=           number of first messages to check (default: 1) [$FIRST_MESSAGES_COUNT]
       --training                        training mode, passive spam detection only [$TRAINING]
       --soft-ban                        soft ban mode, restrict user actions but not ban [$SOFT_BAN]
+      --history-size=                   history size (default: 100) [$LAST_MSGS_HISTORY_SIZE]
       --convert=[only|enabled|disabled] convert mode for txt samples and other storage files to DB (default: enabled)
       --dry                             dry mode, no bans [$DRY]
       --dbg                             debug mode [$DEBUG]
@@ -336,6 +339,7 @@ openai:
       --openai.max-tokens-request=      openai max tokens in request (default: 2048) [$OPENAI_MAX_TOKENS_REQUEST]
       --openai.max-symbols-request=     openai max symbols in request, failback if tokenizer failed (default: 16000) [$OPENAI_MAX_SYMBOLS_REQUEST]
       --openai.retry-count=             openai retry count (default: 1) [$OPENAI_RETRY_COUNT]
+      --openai.history-size=            openai history size (default: 0) [$OPENAI_HISTORY_SIZE]
 
 space:
       --space.enabled                   enable abnormal words check [$SPACE_ENABLED]
@@ -353,8 +357,8 @@ message:
       --message.startup=                startup message [$MESSAGE_STARTUP]
       --message.spam=                   spam message (default: this is spam) [$MESSAGE_SPAM]
       --message.dry=                    spam dry message (default: this is spam (dry mode)) [$MESSAGE_DRY]
-      --message.warn=                   warning message (default: You've violated our rules and this is your first and last warning. Further violations will lead to permanent access denial.
-                                        Stay compliant or face the consequences!) [$MESSAGE_WARN]
+      --message.warn=                   warning message (default: You've violated our rules and this is your first and last warning. Further violations will lead to permanent access denial. Stay compliant or face the
+                                        consequences!) [$MESSAGE_WARN]
 
 server:
       --server.enabled                  enable web server [$SERVER_ENABLED]

--- a/app/main.go
+++ b/app/main.go
@@ -86,6 +86,7 @@ type options struct {
 		MaxTokensRequestMaxTokensRequest int    `long:"max-tokens-request" env:"MAX_TOKENS_REQUEST" default:"2048" description:"openai max tokens in request"`
 		MaxSymbolsRequest                int    `long:"max-symbols-request" env:"MAX_SYMBOLS_REQUEST" default:"16000" description:"openai max symbols in request, failback if tokenizer failed"`
 		RetryCount                       int    `long:"retry-count" env:"RETRY_COUNT" default:"1" description:"openai retry count"`
+		HistorySize                      int    `long:"history-size" env:"HISTORY_SIZE" default:"0" description:"openai history size"`
 	} `group:"openai" namespace:"openai" env-namespace:"OPENAI"`
 
 	AbnormalSpacing struct {
@@ -128,7 +129,8 @@ type options struct {
 	Training bool `long:"training" env:"TRAINING" description:"training mode, passive spam detection only"`
 	SoftBan  bool `long:"soft-ban" env:"SOFT_BAN" description:"soft ban mode, restrict user actions but not ban"`
 
-	Convert string `long:"convert" choice:"only" choice:"enabled" choice:"disabled" default:"enabled" description:"convert mode for txt samples and other storage files to DB"`
+	HistorySize int    `long:"history-size" env:"LAST_MSGS_HISTORY_SIZE" default:"100" description:"history size"`
+	Convert     string `long:"convert" choice:"only" choice:"enabled" choice:"disabled" default:"enabled" description:"convert mode for txt samples and other storage files to DB"`
 
 	Dry   bool `long:"dry" env:"DRY" description:"dry mode, no bans"`
 	Dbg   bool `long:"dbg" env:"DEBUG" description:"debug mode"`
@@ -441,7 +443,9 @@ func makeDetector(opts options) *tgspam.Detector {
 		FirstMessageOnly:    !opts.ParanoidMode,
 		FirstMessagesCount:  opts.FirstMessagesCount,
 		OpenAIVeto:          opts.OpenAI.Veto,
+		OpenAIHistorySize:   opts.OpenAI.HistorySize, // how many last requests sent to openai
 		MultiLangWords:      opts.MultiLangWords,
+		HistorySize:         opts.HistorySize, // how many last request stored in memory
 	}
 
 	// FirstMessagesCount and ParanoidMode are mutually exclusive.

--- a/lib/spamcheck/history.go
+++ b/lib/spamcheck/history.go
@@ -1,0 +1,67 @@
+package spamcheck
+
+import (
+	"container/ring"
+	"sync"
+)
+
+// LastRequests keeps track of last N requests globally
+type LastRequests struct {
+	requests *ring.Ring
+	size     int
+	lock     sync.RWMutex
+}
+
+// NewLastRequests creates new requests tracker
+func NewLastRequests(size int) *LastRequests {
+	// minimum size is 1
+	if size < 1 {
+		size = 1
+	}
+	return &LastRequests{
+		requests: ring.New(size),
+		size:     size,
+	}
+}
+
+// Push adds new request to the history
+func (h *LastRequests) Push(req Request) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	h.requests.Value = req
+	h.requests = h.requests.Next()
+}
+
+// Last returns up to n last requests in chronological order (oldest to newest)
+func (h *LastRequests) Last(n int) []Request {
+	if n < 1 {
+		return []Request{}
+	}
+
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+
+	if n > h.size {
+		n = h.size
+	}
+
+	result := make([]Request, 0, n)
+	h.requests.Do(func(v interface{}) {
+		if v != nil {
+			if req, ok := v.(Request); ok {
+				result = append(result, req)
+			}
+		}
+	})
+
+	if len(result) > n {
+		result = result[:n]
+	}
+	return result
+}
+
+// Size returns the size of request history
+func (h *LastRequests) Size() int {
+	return h.size
+}

--- a/lib/spamcheck/history.go
+++ b/lib/spamcheck/history.go
@@ -12,6 +12,8 @@ type LastRequests struct {
 	lock     sync.RWMutex
 }
 
+const maxMsgLen = 1024
+
 // NewLastRequests creates new requests tracker
 func NewLastRequests(size int) *LastRequests {
 	// minimum size is 1
@@ -28,6 +30,11 @@ func NewLastRequests(size int) *LastRequests {
 func (h *LastRequests) Push(req Request) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
+
+	if len(req.Msg) > maxMsgLen {
+		// truncate the message if it's too long to prevent memory exhaustion attacks
+		req.Msg = req.Msg[:maxMsgLen]
+	}
 
 	h.requests.Value = req
 	h.requests = h.requests.Next()

--- a/lib/spamcheck/history.go
+++ b/lib/spamcheck/history.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// LastRequests keeps track of last N requests globally
+// LastRequests keeps track of last N requests, thread-safe.
 type LastRequests struct {
 	requests *ring.Ring
 	size     int

--- a/lib/spamcheck/history_test.go
+++ b/lib/spamcheck/history_test.go
@@ -1,0 +1,110 @@
+package spamcheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLastRequestsBasicOps(t *testing.T) {
+	h := NewLastRequests(5)
+	req1 := Request{Msg: "msg1", UserID: "1", Meta: MetaData{Links: 1}}
+	req2 := Request{Msg: "msg2", UserID: "2", Meta: MetaData{Links: 2}}
+	req3 := Request{Msg: "msg3", UserID: "1", Meta: MetaData{Links: 3}}
+
+	h.Push(req1)
+	h.Push(req2)
+	h.Push(req3)
+
+	res := h.Last(3)
+	require.Equal(t, 3, len(res))
+	assert.Equal(t, req1, res[0])
+	assert.Equal(t, req2, res[1])
+	assert.Equal(t, req3, res[2])
+}
+
+func TestLastRequestsOverflow(t *testing.T) {
+	h := NewLastRequests(2)
+	req1 := Request{Msg: "msg1", UserID: "1"}
+	req2 := Request{Msg: "msg2", UserID: "2"}
+	req3 := Request{Msg: "msg3", UserID: "1"}
+
+	h.Push(req1)
+	h.Push(req2)
+	h.Push(req3)
+
+	res := h.Last(3)
+	require.Equal(t, 2, len(res))
+	assert.Equal(t, req2, res[0])
+	assert.Equal(t, req3, res[1])
+}
+
+func TestLastRequestsEmpty(t *testing.T) {
+	h := NewLastRequests(5)
+	assert.Empty(t, h.Last(1))
+}
+
+func TestLastRequestsSmallerRequest(t *testing.T) {
+	h := NewLastRequests(5)
+	req1 := Request{Msg: "msg1", UserID: "1"}
+	req2 := Request{Msg: "msg2", UserID: "2"}
+
+	h.Push(req1)
+	h.Push(req2)
+
+	res := h.Last(1)
+	require.Equal(t, 1, len(res))
+	assert.Equal(t, req1, res[0])
+}
+
+func TestLastRequestsConcurrent(t *testing.T) {
+	h := NewLastRequests(5)
+	done := make(chan bool)
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			h.Push(Request{Msg: "msg", UserID: "1"})
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			h.Last(5)
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+}
+
+func TestLastRequestsNegativeCount(t *testing.T) {
+	h := NewLastRequests(5)
+	req := Request{Msg: "msg1", UserID: "1"}
+	h.Push(req)
+	res := h.Last(-1)
+	assert.Empty(t, res)
+}
+
+func TestLastRequestsZeroSize(t *testing.T) {
+	h := NewLastRequests(0)
+	assert.Equal(t, 1, h.Size(), "zero size should be clamped to 1")
+	req := Request{Msg: "msg1", UserID: "1"}
+	h.Push(req)
+	res := h.Last(1)
+	require.Equal(t, 1, len(res))
+	assert.Equal(t, req, res[0])
+}
+
+func TestLastRequestsNilValues(t *testing.T) {
+	h := NewLastRequests(3)
+	h.requests.Value = nil // force nil value
+	h.requests = h.requests.Next()
+	req := Request{Msg: "msg1", UserID: "1"}
+	h.Push(req)
+	res := h.Last(2)
+	require.Equal(t, 1, len(res))
+	assert.Equal(t, req, res[0])
+}

--- a/lib/spamcheck/history_test.go
+++ b/lib/spamcheck/history_test.go
@@ -1,6 +1,7 @@
 package spamcheck
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,4 +108,24 @@ func TestLastRequestsNilValues(t *testing.T) {
 	res := h.Last(2)
 	require.Equal(t, 1, len(res))
 	assert.Equal(t, req, res[0])
+}
+
+func TestLastRequestsVeryLong(t *testing.T) {
+	history := NewLastRequests(1)
+
+	// create a very long message
+	longMessage := strings.Repeat("a", 2000)
+
+	req := Request{
+		Msg:      longMessage,
+		UserID:   "user5",
+		UserName: "Eve",
+	}
+
+	history.Push(req)
+
+	// Retrieve and verify
+	lastMsgs := history.Last(1)
+	require.Len(t, lastMsgs, 1)
+	assert.Len(t, lastMsgs[0].Msg, 1024, "Message should be truncated to max length")
 }

--- a/lib/spamcheck/spamcheck_test.go
+++ b/lib/spamcheck/spamcheck_test.go
@@ -47,18 +47,20 @@ func TestRequestString(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Normal message",
-			request:  Request{"Hello, world!", "123", "Alice", MetaData{2, 1, false, false}, false},
+			name: "Normal message",
+			request: Request{
+				Msg: "Hello, world!", UserID: "123", UserName: "Alice", Meta: MetaData{2, 1, false, false}, CheckOnly: false},
 			expected: `msg:"Hello, world!", user:"Alice", id:123, images:2, links:1, has_video:false`,
 		},
 		{
-			name:     "Spam message",
-			request:  Request{"Spam message", "456", "Bob", MetaData{0, 3, true, false}, true},
+			name: "Spam message",
+			request: Request{
+				Msg: "Spam message", UserID: "456", UserName: "Bob", Meta: MetaData{0, 3, true, false}, CheckOnly: true},
 			expected: `msg:"Spam message", user:"Bob", id:456, images:0, links:3, has_video:true`,
 		},
 		{
 			name:     "Empty fields",
-			request:  Request{"", "", "", MetaData{0, 0, false, false}, false},
+			request:  Request{Msg: "", UserID: "", UserName: "", Meta: MetaData{}, CheckOnly: false},
 			expected: `msg:"", user:"", id:, images:0, links:0, has_video:false`,
 		},
 	}

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -44,6 +44,11 @@ type Detector struct {
 	hamSamplesUpd  SampleUpdater
 	userStorage    UserStorage
 
+	// history of recent messages to keep in memory
+	// can be passed to checkers supporting history
+	hamHistory  *spamcheck.LastRequests
+	spamHistory *spamcheck.LastRequests
+
 	lock sync.RWMutex
 }
 
@@ -68,6 +73,7 @@ type Config struct {
 		ShortWordRatioThreshold float64 // the ratio of short words to all words in the message
 		SpaceRatioThreshold     float64 // the ratio of spaces to all characters in the message
 	}
+	HistorySize int // history of recent messages to keep in memory
 }
 
 // SampleUpdater is an interface for updating spam/ham samples on the fly.
@@ -104,6 +110,8 @@ func NewDetector(p Config) *Detector {
 		classifier:    newClassifier(),
 		approvedUsers: make(map[string]approved.UserInfo),
 		tokenizedSpam: []map[string]int{},
+		hamHistory:    spamcheck.NewLastRequests(p.HistorySize),
+		spamHistory:   spamcheck.NewLastRequests(p.HistorySize),
 	}
 	// if FirstMessagesCount is set, FirstMessageOnly enforced to true.
 	// this is to avoid confusion when FirstMessagesCount is set but FirstMessageOnly is false.
@@ -173,8 +181,10 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	if len([]rune(req.Msg)) < d.MinMsgLen {
 		cr = append(cr, spamcheck.Response{Name: "message length", Spam: false, Details: "too short"})
 		if isSpamDetected(cr) {
+			d.spamHistory.Push(req)
 			return true, cr // spam from the checks above
 		}
+		d.hamHistory.Push(req)
 		return false, cr
 	}
 
@@ -214,6 +224,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	}
 
 	if spamDetected {
+		d.spamHistory.Push(req)
 		return true, cr
 	}
 
@@ -228,6 +239,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 			_ = d.userStorage.Write(ctx, au) // ignore error, failed to write to storage is not critical here
 		}
 	}
+	d.hamHistory.Push(req)
 	return false, cr
 }
 

--- a/lib/tgspam/mocks/openai_client.go
+++ b/lib/tgspam/mocks/openai_client.go
@@ -76,3 +76,17 @@ func (mock *OpenAIClientMock) CreateChatCompletionCalls() []struct {
 	mock.lockCreateChatCompletion.RUnlock()
 	return calls
 }
+
+// ResetCreateChatCompletionCalls reset all the calls that were made to CreateChatCompletion.
+func (mock *OpenAIClientMock) ResetCreateChatCompletionCalls() {
+	mock.lockCreateChatCompletion.Lock()
+	mock.calls.CreateChatCompletion = nil
+	mock.lockCreateChatCompletion.Unlock()
+}
+
+// ResetCalls reset all the calls that were made to all mocked methods.
+func (mock *OpenAIClientMock) ResetCalls() {
+	mock.lockCreateChatCompletion.Lock()
+	mock.calls.CreateChatCompletion = nil
+	mock.lockCreateChatCompletion.Unlock()
+}

--- a/lib/tgspam/openai.go
+++ b/lib/tgspam/openai.go
@@ -36,7 +36,7 @@ type openAIClient interface {
 	CreateChatCompletion(context.Context, openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error)
 }
 
-const defaultPrompt = `I'll give you a text from the messaging application and you will return me a json with three fields: {"spam": true/false, "reason":"why this is spam", "confidence":1-100}. Set spam:true only of confidence above 80. Return JSON only with no extra formatting!`
+const defaultPrompt = `I'll give you a text from the messaging application and you will return me a json with three fields: {"spam": true/false, "reason":"why this is spam", "confidence":1-100}. Set spam:true only of confidence above 80. Return JSON only with no extra formatting!` + "\n" + `If history of previous messages provided, use them as extra context to make the decision.`
 
 type openAIResponse struct {
 	IsSpam     bool   `json:"spam"`

--- a/lib/tgspam/openai.go
+++ b/lib/tgspam/openai.go
@@ -12,7 +12,7 @@ import (
 	"github.com/umputun/tg-spam/lib/spamcheck"
 )
 
-//go:generate moq --out mocks/openai_client.go --pkg mocks --skip-ensure . openAIClient:OpenAIClientMock
+//go:generate moq --out mocks/openai_client.go --pkg mocks --with-resets --skip-ensure . openAIClient:OpenAIClientMock
 
 // openAIChecker is a wrapper for OpenAI API to check if a text is spam
 type openAIChecker struct {
@@ -67,10 +67,19 @@ func newOpenAIChecker(client openAIClient, params OpenAIConfig) *openAIChecker {
 	return &openAIChecker{client: client, params: params}
 }
 
-// check checks if a text is spam
-func (o *openAIChecker) check(msg string) (spam bool, cr spamcheck.Response) {
+// check checks if a text is spam using OpenAI API
+func (o *openAIChecker) check(msg string, history []spamcheck.Request) (spam bool, cr spamcheck.Response) {
 	if o.client == nil {
 		return false, spamcheck.Response{}
+	}
+
+	// update the message with the history
+	if len(history) > 0 {
+		hist := []string{"--------------------------------", "this is the history of previous messages from other users:", ""}
+		for _, h := range history {
+			hist = append(hist, fmt.Sprintf("%q: %q", h.UserName, h.Msg))
+		}
+		msg = msg + "\n" + strings.Join(hist, "\n")
 	}
 
 	// try to send a request several times if it fails
@@ -91,9 +100,9 @@ func (o *openAIChecker) check(msg string) (spam bool, cr spamcheck.Response) {
 }
 
 func (o *openAIChecker) sendRequest(msg string) (response openAIResponse, err error) {
-	// Reduce the request size with tokenizer and fallback to default reducer if it fails
-	// The API supports 4097 tokens ~16000 characters (<=4 per token) for request + result together
-	// The response is limited to 1000 tokens and OpenAI always reserved it for the result
+	// Reduce the request size with tokenizer and fallback to default reducer if it fails.
+	// The API supports 4097 tokens ~16000 characters (<=4 per token) for request + result together.
+	// The response is limited to 1000 tokens, and OpenAI always reserved it for the result.
 	// So the max length of the request should be 3000 tokens or ~12000 characters
 	reduceRequest := func(text string) (result string) {
 		// defaultReducer is a fallback if tokenizer fails

--- a/lib/tgspam/openai_test.go
+++ b/lib/tgspam/openai_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/umputun/tg-spam/lib/spamcheck"
 	"github.com/umputun/tg-spam/lib/tgspam/mocks"
 )
 
@@ -39,7 +40,7 @@ func TestOpenAIChecker_Check(t *testing.T) {
 				}},
 			}, nil
 		}
-		spam, details := checker.check("some text")
+		spam, details := checker.check("some text", nil)
 		t.Logf("spam: %v, details: %+v", spam, details)
 		assert.True(t, spam)
 		assert.Equal(t, "openai", details.Name)
@@ -56,7 +57,7 @@ func TestOpenAIChecker_Check(t *testing.T) {
 				}},
 			}, nil
 		}
-		spam, details := checker.check("some text")
+		spam, details := checker.check("some text", nil)
 		t.Logf("spam: %v, details: %+v", spam, details)
 		assert.False(t, spam)
 		assert.Equal(t, "openai", details.Name)
@@ -69,7 +70,7 @@ func TestOpenAIChecker_Check(t *testing.T) {
 			contextMoqParam context.Context, chatCompletionRequest openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
 			return openai.ChatCompletionResponse{}, assert.AnError
 		}
-		spam, details := checker.check("some text")
+		spam, details := checker.check("some text", nil)
 		t.Logf("spam: %v, details: %+v", spam, details)
 		assert.False(t, spam)
 		assert.Equal(t, "openai", details.Name)
@@ -86,7 +87,7 @@ func TestOpenAIChecker_Check(t *testing.T) {
 				}},
 			}, nil
 		}
-		spam, details := checker.check("some text")
+		spam, details := checker.check("some text", nil)
 		t.Logf("spam: %v, details: %+v", spam, details)
 		assert.False(t, spam)
 		assert.Equal(t, "openai", details.Name)
@@ -101,10 +102,109 @@ func TestOpenAIChecker_Check(t *testing.T) {
 			contextMoqParam context.Context, chatCompletionRequest openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
 			return openai.ChatCompletionResponse{}, nil
 		}
-		spam, details := checker.check("some text")
+		spam, details := checker.check("some text", nil)
 		t.Logf("spam: %v, details: %+v", spam, details)
 		assert.False(t, spam)
 		assert.Equal(t, "openai", details.Name)
 		assert.Equal(t, "OpenAI error: no choices in response", details.Details)
 	})
+}
+
+func TestOpenAIChecker_CheckWithHistory(t *testing.T) {
+	clientMock := &mocks.OpenAIClientMock{
+		CreateChatCompletionFunc: func(contextMoqParam context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+			// verify the request contains history
+			assert.Contains(t, req.Messages[1].Content, "history of previous messages")
+			assert.Contains(t, req.Messages[1].Content, `"user1": "first message"`)
+			assert.Contains(t, req.Messages[1].Content, `"user2": "second message"`)
+			assert.Contains(t, req.Messages[1].Content, `"user1": "third message"`)
+
+			return openai.ChatCompletionResponse{
+				Choices: []openai.ChatCompletionChoice{{
+					Message: openai.ChatCompletionMessage{Content: `{"spam": true, "reason":"suspicious pattern in history", "confidence":90}`},
+				}},
+			}, nil
+		},
+	}
+
+	checker := newOpenAIChecker(clientMock, OpenAIConfig{Model: "gpt-4o-mini"})
+	history := []spamcheck.Request{
+		{Msg: "first message", UserName: "user1"},
+		{Msg: "second message", UserName: "user2"},
+		{Msg: "third message", UserName: "user1"},
+	}
+
+	spam, details := checker.check("current message", history)
+	t.Logf("spam: %v, details: %+v", spam, details)
+	assert.True(t, spam)
+	assert.Equal(t, "openai", details.Name)
+	assert.Equal(t, "suspicious pattern in history, confidence: 90%", details.Details)
+	assert.NoError(t, details.Error)
+	assert.Equal(t, 1, len(clientMock.CreateChatCompletionCalls()))
+}
+
+func TestOpenAIChecker_FormatMessage(t *testing.T) {
+	var capturedMsg string
+	clientMock := &mocks.OpenAIClientMock{
+		CreateChatCompletionFunc: func(contextMoqParam context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+			capturedMsg = req.Messages[1].Content // capture the message being sent
+			return openai.ChatCompletionResponse{
+				Choices: []openai.ChatCompletionChoice{{
+					Message: openai.ChatCompletionMessage{Content: `{"spam": false, "reason":"test message", "confidence":90}`},
+				}},
+			}, nil
+		},
+	}
+
+	tests := []struct {
+		name            string
+		currentMsg      string
+		history         []spamcheck.Request
+		expectedMessage string
+	}{
+		{
+			name:            "message with no history",
+			currentMsg:      "hello world",
+			history:         []spamcheck.Request{},
+			expectedMessage: "hello world",
+		},
+		{
+			name:       "message with history",
+			currentMsg: "current message",
+			history: []spamcheck.Request{
+				{Msg: "first message", UserName: "user1"},
+				{Msg: "second message", UserName: "user2"},
+			},
+			expectedMessage: `current message
+--------------------------------
+this is the history of previous messages from other users:
+
+"user1": "first message"
+"user2": "second message"`,
+		},
+		{
+			name:       "message with empty username in history",
+			currentMsg: "current message",
+			history: []spamcheck.Request{
+				{Msg: "first message", UserName: ""},
+				{Msg: "second message", UserName: "user2"},
+			},
+			expectedMessage: `current message
+--------------------------------
+this is the history of previous messages from other users:
+
+"": "first message"
+"user2": "second message"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientMock.ResetCalls() // reset mock before each test case
+			checker := newOpenAIChecker(clientMock, OpenAIConfig{Model: "gpt-4o-mini"})
+			checker.check(tt.currentMsg, tt.history)
+			assert.Equal(t, tt.expectedMessage, capturedMsg, "message formatting mismatch")
+			assert.Equal(t, 1, len(clientMock.CreateChatCompletionCalls()))
+		})
+	}
 }


### PR DESCRIPTION
see #228 

This PR adds request history, managed on the library level. Implemened with the ring buffer, optionally passed to openai to be added to prompt. It keeps last N (default 100) messages in memory and send to openai a subset of this.