### PR TITLE
Handle empty message text in admin handler

### DIFF
--- a/app/events/admin.go
+++ b/app/events/admin.go
@@ -84,6 +84,11 @@ func (a *admin) MsgHandler(update tbapi.Update) error {
 		m := transform(update.Message)
 		msgTxt = m.Text
 	}
+
+	if msgTxt == "" {
+		return errors.New("empty message text")
+	}
+
 	log.Printf("[DEBUG] forwarded message from superuser %q (%d) to admin chat %d: %q",
 		update.Message.From.UserName, update.Message.From.ID, a.adminChatID, msgTxt)
 


### PR DESCRIPTION
This PR adds a check for empty message text in the admin handler, returning an error if the text is empty. It also includes tests for various message types without text content.

fix #233 