### PR TITLE
Fix the failed migration if FILES_SAMPLES is not set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /srv
 
 RUN \
  /srv/tg-spam --convert=only --files.dynamic=/srv/preset --files.samples=/srv/preset && \
- rm -vf /srv/preset/*.loaded && \
+ sh -c 'for f in /srv/preset/*.txt.loaded; do mv -vf "$f" "${f%.loaded}"; done' && \
  echo "preset files converted" && \
  ls -la /srv/preset && \
  ls -la /srv/data

--- a/app/main.go
+++ b/app/main.go
@@ -101,7 +101,7 @@ type options struct {
 	} `group:"space" namespace:"space" env-namespace:"SPACE"`
 
 	Files struct {
-		SamplesDataPath string        `long:"samples" env:"SAMPLES" default:"data" description:"samples data path, deprecated"`
+		SamplesDataPath string        `long:"samples" env:"SAMPLES" default:"preset" description:"samples data path, deprecated"`
 		DynamicDataPath string        `long:"dynamic" env:"DYNAMIC" default:"data" description:"dynamic data path"`
 		WatchInterval   time.Duration `long:"watch-interval" env:"WATCH_INTERVAL" default:"5s" description:"watch interval for dynamic files, deprecated"`
 	} `group:"files" namespace:"files" env-namespace:"FILES"`

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -65,6 +65,7 @@ func setSqlitePragma(db *sqlx.DB) error {
 	// Set pragmas for SQLite. Commented out pragmas as they are not used in the code yet because we need
 	// to make sure if it is worth having 2 more DB-related files for WAL and SHM.
 	pragmas := map[string]string{
+		"journal_mode": "DELETE", // explicitly set to DELETE mode to prevent WAL files
 		// "journal_mode": "WAL",
 		// "synchronous":  "NORMAL",
 		// "busy_timeout": "5000",


### PR DESCRIPTION
_it should address #246 and #245_

The issue is the lack of the mounted samples volume, and the default set of samples in this case is not available for migration. To address it, the default location of samples has changed to `/srv/preset`, and the `Dockerfile` has been modified to keep them available in runtime.

This fix causes the re-import of preset samples every time the container is recreated. This is fine practically, but It's not the most elegant solution. However, since this situation is temporary until migrations are done, we can live with this for the time being.