### PR TITLE
softmax underflow on large negative input values

### DIFF
--- a/lib/tgspam/classifier.go
+++ b/lib/tgspam/classifier.go
@@ -185,19 +185,31 @@ func (c *classifier) removeDuplicate(tokens ...string) []string {
 }
 
 // softmax converts log probabilities to normalized probabilities
-func softmax(logProbs map[spamClass]float64) map[spamClass]float64 {
-	sum := 0.0
+func softmax(scores map[spamClass]float64) map[spamClass]float64 {
+	if len(scores) == 0 {
+		return nil
+	}
+
+	// Step 1: Find the max value to subtract (prevents overflow)
+	maxVal := math.Inf(-1) // Start with negative infinity
+	for _, v := range scores {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+
+	// Step 2: Compute exp(x - maxVal) and sum for normalization
+	expSum := 0.0
+	exps := make(map[spamClass]float64)
+	for cat, v := range scores {
+		exps[cat] = math.Exp(v - maxVal) // Shift by maxVal keeps exp safe
+		expSum += exps[cat]
+	}
+
+	// Step 3: Normalize to get probabilities
 	probs := make(map[spamClass]float64)
-
-	// convert log probabilities to standard probabilities
-	for _, logProb := range logProbs {
-		sum += math.Exp(logProb)
+	for cat, v := range exps {
+		probs[cat] = v / expSum // expSum > 0 since exp(x) > 0
 	}
-
-	// normalize probabilities
-	for class, logProb := range logProbs {
-		probs[class] = math.Exp(logProb) / sum
-	}
-
 	return probs
 }

--- a/lib/tgspam/classifier.go
+++ b/lib/tgspam/classifier.go
@@ -185,14 +185,14 @@ func (c *classifier) removeDuplicate(tokens ...string) []string {
 }
 
 // softmax converts log probabilities to normalized probabilities
-func softmax(scores map[spamClass]float64) map[spamClass]float64 {
-	if len(scores) == 0 {
+func softmax(logProbs map[spamClass]float64) map[spamClass]float64 {
+	if len(logProbs) == 0 {
 		return nil
 	}
 
 	// Step 1: Find the max value to subtract (prevents overflow)
 	maxVal := math.Inf(-1) // Start with negative infinity
-	for _, v := range scores {
+	for _, v := range logProbs {
 		if v > maxVal {
 			maxVal = v
 		}
@@ -201,7 +201,7 @@ func softmax(scores map[spamClass]float64) map[spamClass]float64 {
 	// Step 2: Compute exp(x - maxVal) and sum for normalization
 	expSum := 0.0
 	exps := make(map[spamClass]float64)
-	for cat, v := range scores {
+	for cat, v := range logProbs {
 		exps[cat] = math.Exp(v - maxVal) // Shift by maxVal keeps exp safe
 		expSum += exps[cat]
 	}


### PR DESCRIPTION
I've stumbled upon this by accident, receiving NaNs from `classifier.classify`.
Turned out that whenever `posteriorProbabilities` contain large negative (or positive for that matter) values - the softmax exponents calculation under/overflows.

This PR is a fixed implementation of softmax resistant to such effects.
It should never spit out NaN or Inf, given finite inputs.

Full disclosure - the code was generated with Grok3, minor human edits.

Edge Cases assessment
- Huge Scores: `map[ham:1e308 spam:1e308]` → `probs[ham:0.5 spam:0.5]`, no `Inf`.
- Tiny Scores: `map[ham:-745 spam:-744]` → `probs[ham:~0.268 spam:~0.732]`, no `NaN`.
- Mixed: `map[ham:-1e308 spam:1e308]` → `probs[ham:0 spam:1.0]`, clean underflow.