### PR TITLE
Add keyboard detection to spam filters

### DIFF
--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -59,6 +59,7 @@ type Message struct {
 	WithVideoNote bool `json:",omitempty"`
 	WithForward   bool `json:",omitempty"`
 	WithAudio     bool `json:",omitempty"`
+	WithKeyboard  bool `json:",omitempty"`
 }
 
 // Entity represents one special entity in a text message.

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -91,6 +91,9 @@ func (s *SpamFilter) OnMessage(msg Message, checkOnly bool) (response Response) 
 	if msg.WithForward {
 		spamReq.Meta.HasForward = true
 	}
+	if msg.WithKeyboard {
+		spamReq.Meta.HasKeyboard = true
+	}
 	spamReq.Meta.Links = strings.Count(msg.Text, "http://") + strings.Count(msg.Text, "https://")
 	isSpam, checkResults := s.Check(spamReq)
 	crs := []string{}

--- a/app/events/events.go
+++ b/app/events/events.go
@@ -301,6 +301,9 @@ func transform(msg *tbapi.Message) *bot.Message {
 	if msg.ForwardOrigin != nil {
 		message.WithForward = true
 	}
+	if msg.ReplyMarkup != nil { // detect attached keyboards/buttons
+		message.WithKeyboard = true
+	}
 
 	// handle reply-to message if present
 	if msg.ReplyToMessage != nil {

--- a/app/main.go
+++ b/app/main.go
@@ -79,6 +79,7 @@ type options struct {
 		VideosOnly bool `long:"video-only" env:"VIDEO_ONLY" description:"enable video only check"`
 		AudiosOnly bool `long:"audio-only" env:"AUDIO_ONLY" description:"enable audio only check"`
 		Forward    bool `long:"forward" env:"FORWARD" description:"enable forward check"`
+		Keyboard   bool `long:"keyboard" env:"KEYBOARD" description:"enable keyboard check"`
 	} `group:"meta" namespace:"meta" env-namespace:"META"`
 
 	OpenAI struct {
@@ -431,13 +432,14 @@ func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *
 		StorageTimeout:          opts.StorageTimeout,
 		NoSpamReply:             opts.NoSpamReply,
 		CasEnabled:              opts.CAS.API != "",
-		MetaEnabled:             opts.Meta.ImageOnly || opts.Meta.LinksLimit >= 0 || opts.Meta.LinksOnly,
+		MetaEnabled:             opts.Meta.ImageOnly || opts.Meta.LinksLimit >= 0 || opts.Meta.LinksOnly || opts.Meta.VideosOnly || opts.Meta.AudiosOnly || opts.Meta.Forward || opts.Meta.Keyboard,
 		MetaLinksLimit:          opts.Meta.LinksLimit,
 		MetaLinksOnly:           opts.Meta.LinksOnly,
 		MetaImageOnly:           opts.Meta.ImageOnly,
 		MetaVideoOnly:           opts.Meta.VideosOnly,
 		MetaAudioOnly:           opts.Meta.AudiosOnly,
 		MetaForwarded:           opts.Meta.Forward,
+		MetaKeyboard:            opts.Meta.Keyboard,
 		MultiLangLimit:          opts.MultiLangWords,
 		OpenAIEnabled:           opts.OpenAI.Token != "" || opts.OpenAI.APIBase != "",
 		OpenAIVeto:              opts.OpenAI.Veto,
@@ -566,6 +568,10 @@ func makeDetector(opts options) *tgspam.Detector {
 	if opts.Meta.Forward {
 		log.Printf("[INFO] forward check enabled")
 		metaChecks = append(metaChecks, tgspam.ForwardedCheck())
+	}
+	if opts.Meta.Keyboard {
+		log.Printf("[INFO] keyboard check enabled")
+		metaChecks = append(metaChecks, tgspam.KeyboardCheck())
 	}
 	detector.WithMetaChecks(metaChecks...)
 

--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -82,6 +82,7 @@ type Settings struct {
 	MetaVideoOnly           bool          `json:"meta_video_only"`
 	MetaAudioOnly           bool          `json:"meta_audio_only"`
 	MetaForwarded           bool          `json:"meta_forwarded"`
+	MetaKeyboard            bool          `json:"meta_keyboard"`
 	MultiLangLimit          int           `json:"multi_lang_limit"`
 	OpenAIEnabled           bool          `json:"openai_enabled"`
 	SamplesDataPath         string        `json:"samples_data_path"`

--- a/lib/spamcheck/spamcheck.go
+++ b/lib/spamcheck/spamcheck.go
@@ -16,16 +16,17 @@ type Request struct {
 
 // MetaData is a meta-info about the message, provided by the client.
 type MetaData struct {
-	Images     int  `json:"images"`      // number of images in the message
-	Links      int  `json:"links"`       // number of links in the message
-	HasVideo   bool `json:"has_video"`   // true if the message has a video or video note
-	HasAudio   bool `json:"has_audio"`   // true if the message has an audio
-	HasForward bool `json:"has_forward"` // true if the message has a forward
+	Images      int  `json:"images"`       // number of images in the message
+	Links       int  `json:"links"`        // number of links in the message
+	HasVideo    bool `json:"has_video"`    // true if the message has a video or video note
+	HasAudio    bool `json:"has_audio"`    // true if the message has an audio
+	HasForward  bool `json:"has_forward"`  // true if the message has a forward
+	HasKeyboard bool `json:"has_keyboard"` // true if the message has a keyboard (buttons)
 }
 
 func (r *Request) String() string {
-	return fmt.Sprintf("msg:%q, user:%q, id:%s, images:%d, links:%d, has_video:%v, has_audio:%v, has_forward:%v",
-		r.Msg, r.UserName, r.UserID, r.Meta.Images, r.Meta.Links, r.Meta.HasVideo, r.Meta.HasAudio, r.Meta.HasForward)
+	return fmt.Sprintf("msg:%q, user:%q, id:%s, images:%d, links:%d, has_video:%v, has_audio:%v, has_forward:%v, has_keyboard:%v",
+		r.Msg, r.UserName, r.UserID, r.Meta.Images, r.Meta.Links, r.Meta.HasVideo, r.Meta.HasAudio, r.Meta.HasForward, r.Meta.HasKeyboard)
 }
 
 // Response is a result of spam check.

--- a/lib/spamcheck/spamcheck_test.go
+++ b/lib/spamcheck/spamcheck_test.go
@@ -49,19 +49,19 @@ func TestRequestString(t *testing.T) {
 		{
 			name: "Normal message",
 			request: Request{
-				Msg: "Hello, world!", UserID: "123", UserName: "Alice", Meta: MetaData{2, 1, false, false, false}, CheckOnly: false},
-			expected: `msg:"Hello, world!", user:"Alice", id:123, images:2, links:1, has_video:false, has_audio:false, has_forward:false`,
+				Msg: "Hello, world!", UserID: "123", UserName: "Alice", Meta: MetaData{2, 1, false, false, false, false}, CheckOnly: false},
+			expected: `msg:"Hello, world!", user:"Alice", id:123, images:2, links:1, has_video:false, has_audio:false, has_forward:false, has_keyboard:false`,
 		},
 		{
 			name: "Spam message",
 			request: Request{
-				Msg: "Spam message", UserID: "456", UserName: "Bob", Meta: MetaData{0, 3, true, false, false}, CheckOnly: true},
-			expected: `msg:"Spam message", user:"Bob", id:456, images:0, links:3, has_video:true, has_audio:false, has_forward:false`,
+				Msg: "Spam message", UserID: "456", UserName: "Bob", Meta: MetaData{0, 3, true, false, false, false}, CheckOnly: true},
+			expected: `msg:"Spam message", user:"Bob", id:456, images:0, links:3, has_video:true, has_audio:false, has_forward:false, has_keyboard:false`,
 		},
 		{
 			name:     "Empty fields",
 			request:  Request{Msg: "", UserID: "", UserName: "", Meta: MetaData{}, CheckOnly: false},
-			expected: `msg:"", user:"", id:, images:0, links:0, has_video:false, has_audio:false, has_forward:false`,
+			expected: `msg:"", user:"", id:, images:0, links:0, has_video:false, has_audio:false, has_forward:false, has_keyboard:false`,
 		},
 	}
 

--- a/lib/tgspam/metachecks.go
+++ b/lib/tgspam/metachecks.go
@@ -120,3 +120,22 @@ func ForwardedCheck() MetaCheck {
 		}
 	}
 }
+
+// KeyboardCheck is a function that returns a MetaCheck function.
+// It checks if the message has a keyboard (buttons).
+func KeyboardCheck() MetaCheck {
+	return func(req spamcheck.Request) spamcheck.Response {
+		if req.Meta.HasKeyboard {
+			return spamcheck.Response{
+				Name:    "keyboard",
+				Spam:    true,
+				Details: "message with keyboard",
+			}
+		}
+		return spamcheck.Response{
+			Name:    "keyboard",
+			Spam:    false,
+			Details: "no keyboard",
+		}
+	}
+}

--- a/lib/tgspam/metachecks_test.go
+++ b/lib/tgspam/metachecks_test.go
@@ -341,3 +341,57 @@ func TestAudioCheck(t *testing.T) {
 		})
 	}
 }
+
+func TestKeyboardCheck(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      spamcheck.Request
+		expected spamcheck.Response
+	}{
+		{
+			name: "No keyboard",
+			req: spamcheck.Request{
+				Msg: "This is a message with text.",
+				Meta: spamcheck.MetaData{
+					HasKeyboard: false,
+				},
+			},
+			expected: spamcheck.Response{Name: "keyboard", Spam: false, Details: "no keyboard"},
+		},
+		{
+			name: "Message with keyboard",
+			req: spamcheck.Request{
+				Msg: "This is a message with text and buttons.",
+				Meta: spamcheck.MetaData{
+					HasKeyboard: true,
+				},
+			},
+			expected: spamcheck.Response{
+				Name:    "keyboard",
+				Spam:    true,
+				Details: "message with keyboard",
+			},
+		},
+		{
+			name: "Empty message with keyboard",
+			req: spamcheck.Request{
+				Msg: "",
+				Meta: spamcheck.MetaData{
+					HasKeyboard: true,
+				},
+			},
+			expected: spamcheck.Response{
+				Name:    "keyboard",
+				Spam:    true,
+				Details: "message with keyboard",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := KeyboardCheck()
+			assert.Equal(t, tt.expected, check(tt.req))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add ability to detect and flag messages with attached keyboards (buttons) as spam
- Add --meta.keyboard configuration flag for enabling keyboard detection
- Implement KeyboardCheck meta check function
- Update internal data structures to track keyboards in messages

Fixes #258