### PR TITLE
Send bot messages to main group without sound

### DIFF
--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -759,6 +759,7 @@ func TestTelegramListener_DoWithDirectWarnReport(t *testing.T) {
 
 	require.Equal(t, 2, len(mockAPI.SendCalls()))
 	assert.Equal(t, "startup", mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).Text)
+	assert.Equal(t, true, mockAPI.SendCalls()[0].C.(tbapi.MessageConfig).DisableNotification)
 	assert.Contains(t, mockAPI.SendCalls()[1].C.(tbapi.MessageConfig).Text, "warning from superuser1")
 	assert.Contains(t, mockAPI.SendCalls()[1].C.(tbapi.MessageConfig).Text, `@user You've violated our rules`)
 


### PR DESCRIPTION
## Summary
- Added NotificationType enum to replace boolean flag for better code readability
- Implemented silent notifications for bot messages sent to the main group
- This addresses issue #172 to allow sending messages without sound notifications
- Based on original PR #172 by @evgeny-boger but reimplemented with enum approach for better clarity