### PR TITLE
Add ability to limit message mentions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 - Run tests and linter after making significant changes to verify functionality
 - Go version: 1.24+
 - Don't add "Generated with Claude Code" or "Co-Authored-By: Claude" to commit messages or PRs
+- Do not include "Test plan" sections in PR descriptions
 - Do not add comments that describe changes, progress, or historical modifications. Avoid comments like “new function,” “added test,” “now we changed this,” or “previously used X, now using Y.” Comments should only describe the current state and purpose of the code, not its history or evolution.
 - Use `go:generate` for generating mocks, never modify generated files manually. Mocks are generated with `moq` and stored in the `mocks` package.
 - After important functionality added, update README.md accordingly

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ This is not a separate check, but rather a parameter to control the minimum mess
 
 This option is disabled by default. If set to a positive number, the bot will check the message for the number of links. If the number of links is greater than `--meta.links-limit=, [$META_LINKS_LIMIT]` (default is -1), the message will be marked as spam. Setting the limit to -1 will effectively disable this check.
 
+**Maximum mentions in message**
+
+This option is disabled by default. If set to a positive number, the bot will check the message for the number of mentions (@username). If the number of mentions is greater than `--meta.mentions-limit=, [$META_MENTIONS_LIMIT]` (default is -1), the message will be marked as spam. Setting the limit to -1 will effectively disable this check.
+
 **Links only check**
 
 This option is disabled by default. If set to `true`, the bot will check the message for the presence of any text. If the message contains links but no text, it will be marked as spam.
@@ -129,6 +133,10 @@ This option is disabled by default. If set to `true`, the bot will check the mes
 **Forward check**
 
 This option is disabled by default. If `--meta.forward` set or `env:META_FORWARD` is `true`, the bot will check if the message forwarded. If the message is a forward, it will be marked as spam.
+
+**Keyboard check**
+
+This option is disabled by default. If `--meta.keyboard` set or `env:META_KEYBOARD` is `true`, the bot will check if the message contains a keyboard (buttons). If the message contains a keyboard, it will be marked as spam.
 
 **Multi-language words**
 
@@ -333,11 +341,13 @@ cas:
 
 meta:
       --meta.links-limit=               max links in message, disabled by default (default: -1) [$META_LINKS_LIMIT]
+      --meta.mentions-limit=            max mentions in message, disabled by default (default: -1) [$META_MENTIONS_LIMIT]
       --meta.image-only                 enable image only check [$META_IMAGE_ONLY]
       --meta.links-only                 enable links only check [$META_LINKS_ONLY]
       --meta.video-only                 enable video only check [$META_VIDEO_ONLY]
       --meta.audio-only                 enable audio only check [$META_AUDIO_ONLY]
       --meta.forward                    enable forward check [$META_FORWARD]
+      --meta.keyboard                   enable keyboard check [$META_KEYBOARD]
 
 openai:
       --openai.token=                   openai token, disabled if not set [$OPENAI_TOKEN]

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -95,6 +95,15 @@ func (s *SpamFilter) OnMessage(msg Message, checkOnly bool) (response Response) 
 		spamReq.Meta.HasKeyboard = true
 	}
 	spamReq.Meta.Links = strings.Count(msg.Text, "http://") + strings.Count(msg.Text, "https://")
+
+	// count mentions from entities
+	if msg.Entities != nil {
+		for _, entity := range *msg.Entities {
+			if entity.Type == "mention" || entity.Type == "text_mention" {
+				spamReq.Meta.Mentions++
+			}
+		}
+	}
 	isSpam, checkResults := s.Check(spamReq)
 	crs := []string{}
 	for _, cr := range checkResults {

--- a/app/main.go
+++ b/app/main.go
@@ -73,13 +73,14 @@ type options struct {
 	} `group:"cas" namespace:"cas" env-namespace:"CAS"`
 
 	Meta struct {
-		LinksLimit int  `long:"links-limit" env:"LINKS_LIMIT" default:"-1" description:"max links in message, disabled by default"`
-		ImageOnly  bool `long:"image-only" env:"IMAGE_ONLY" description:"enable image only check"`
-		LinksOnly  bool `long:"links-only" env:"LINKS_ONLY" description:"enable links only check"`
-		VideosOnly bool `long:"video-only" env:"VIDEO_ONLY" description:"enable video only check"`
-		AudiosOnly bool `long:"audio-only" env:"AUDIO_ONLY" description:"enable audio only check"`
-		Forward    bool `long:"forward" env:"FORWARD" description:"enable forward check"`
-		Keyboard   bool `long:"keyboard" env:"KEYBOARD" description:"enable keyboard check"`
+		LinksLimit    int  `long:"links-limit" env:"LINKS_LIMIT" default:"-1" description:"max links in message, disabled by default"`
+		MentionsLimit int  `long:"mentions-limit" env:"MENTIONS_LIMIT" default:"-1" description:"max mentions in message, disabled by default"`
+		ImageOnly     bool `long:"image-only" env:"IMAGE_ONLY" description:"enable image only check"`
+		LinksOnly     bool `long:"links-only" env:"LINKS_ONLY" description:"enable links only check"`
+		VideosOnly    bool `long:"video-only" env:"VIDEO_ONLY" description:"enable video only check"`
+		AudiosOnly    bool `long:"audio-only" env:"AUDIO_ONLY" description:"enable audio only check"`
+		Forward       bool `long:"forward" env:"FORWARD" description:"enable forward check"`
+		Keyboard      bool `long:"keyboard" env:"KEYBOARD" description:"enable keyboard check"`
 	} `group:"meta" namespace:"meta" env-namespace:"META"`
 
 	OpenAI struct {
@@ -432,8 +433,9 @@ func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *
 		StorageTimeout:          opts.StorageTimeout,
 		NoSpamReply:             opts.NoSpamReply,
 		CasEnabled:              opts.CAS.API != "",
-		MetaEnabled:             opts.Meta.ImageOnly || opts.Meta.LinksLimit >= 0 || opts.Meta.LinksOnly || opts.Meta.VideosOnly || opts.Meta.AudiosOnly || opts.Meta.Forward || opts.Meta.Keyboard,
+		MetaEnabled:             opts.Meta.ImageOnly || opts.Meta.LinksLimit >= 0 || opts.Meta.MentionsLimit >= 0 || opts.Meta.LinksOnly || opts.Meta.VideosOnly || opts.Meta.AudiosOnly || opts.Meta.Forward || opts.Meta.Keyboard,
 		MetaLinksLimit:          opts.Meta.LinksLimit,
+		MetaMentionsLimit:       opts.Meta.MentionsLimit,
 		MetaLinksOnly:           opts.Meta.LinksOnly,
 		MetaImageOnly:           opts.Meta.ImageOnly,
 		MetaVideoOnly:           opts.Meta.VideosOnly,
@@ -560,6 +562,10 @@ func makeDetector(opts options) *tgspam.Detector {
 	if opts.Meta.LinksLimit >= 0 {
 		log.Printf("[INFO] links check enabled, limit: %d", opts.Meta.LinksLimit)
 		metaChecks = append(metaChecks, tgspam.LinksCheck(opts.Meta.LinksLimit))
+	}
+	if opts.Meta.MentionsLimit >= 0 {
+		log.Printf("[INFO] mentions check enabled, limit: %d", opts.Meta.MentionsLimit)
+		metaChecks = append(metaChecks, tgspam.MentionsCheck(opts.Meta.MentionsLimit))
 	}
 	if opts.Meta.LinksOnly {
 		log.Printf("[INFO] links only check enabled")

--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -150,6 +150,7 @@
                     <tbody>
                         <tr><th style="width: 30%">Meta Enabled</th><td>{{.MetaEnabled}}</td></tr>
                         <tr><th>Meta Links Limit</th><td>{{.MetaLinksLimit}}</td></tr>
+                        <tr><th>Meta Mentions Limit</th><td>{{.MetaMentionsLimit}}</td></tr>
                         <tr><th>Meta Links Only</th><td>{{.MetaLinksOnly}}</td></tr>
                         <tr><th>Meta Image Only</th><td>{{.MetaImageOnly}}</td></tr>
                         <tr><th>Meta Video Only</th><td>{{.MetaVideoOnly}}</td></tr>

--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -77,6 +77,7 @@ type Settings struct {
 	CasEnabled              bool          `json:"cas_enabled"`
 	MetaEnabled             bool          `json:"meta_enabled"`
 	MetaLinksLimit          int           `json:"meta_links_limit"`
+	MetaMentionsLimit       int           `json:"meta_mentions_limit"`
 	MetaLinksOnly           bool          `json:"meta_links_only"`
 	MetaImageOnly           bool          `json:"meta_image_only"`
 	MetaVideoOnly           bool          `json:"meta_video_only"`

--- a/lib/spamcheck/spamcheck.go
+++ b/lib/spamcheck/spamcheck.go
@@ -18,6 +18,7 @@ type Request struct {
 type MetaData struct {
 	Images      int  `json:"images"`       // number of images in the message
 	Links       int  `json:"links"`        // number of links in the message
+	Mentions    int  `json:"mentions"`     // number of mentions (@username) in the message
 	HasVideo    bool `json:"has_video"`    // true if the message has a video or video note
 	HasAudio    bool `json:"has_audio"`    // true if the message has an audio
 	HasForward  bool `json:"has_forward"`  // true if the message has a forward
@@ -25,8 +26,8 @@ type MetaData struct {
 }
 
 func (r *Request) String() string {
-	return fmt.Sprintf("msg:%q, user:%q, id:%s, images:%d, links:%d, has_video:%v, has_audio:%v, has_forward:%v, has_keyboard:%v",
-		r.Msg, r.UserName, r.UserID, r.Meta.Images, r.Meta.Links, r.Meta.HasVideo, r.Meta.HasAudio, r.Meta.HasForward, r.Meta.HasKeyboard)
+	return fmt.Sprintf("msg:%q, user:%q, id:%s, images:%d, links:%d, mentions:%d, has_video:%v, has_audio:%v, has_forward:%v, has_keyboard:%v",
+		r.Msg, r.UserName, r.UserID, r.Meta.Images, r.Meta.Links, r.Meta.Mentions, r.Meta.HasVideo, r.Meta.HasAudio, r.Meta.HasForward, r.Meta.HasKeyboard)
 }
 
 // Response is a result of spam check.

--- a/lib/spamcheck/spamcheck_test.go
+++ b/lib/spamcheck/spamcheck_test.go
@@ -49,19 +49,23 @@ func TestRequestString(t *testing.T) {
 		{
 			name: "Normal message",
 			request: Request{
-				Msg: "Hello, world!", UserID: "123", UserName: "Alice", Meta: MetaData{2, 1, false, false, false, false}, CheckOnly: false},
-			expected: `msg:"Hello, world!", user:"Alice", id:123, images:2, links:1, has_video:false, has_audio:false, has_forward:false, has_keyboard:false`,
+				Msg: "Hello, world!", UserID: "123", UserName: "Alice", Meta: MetaData{
+					Images: 2, Links: 1, Mentions: 0, HasVideo: false, HasAudio: false, HasForward: false, HasKeyboard: false,
+				}, CheckOnly: false},
+			expected: `msg:"Hello, world!", user:"Alice", id:123, images:2, links:1, mentions:0, has_video:false, has_audio:false, has_forward:false, has_keyboard:false`,
 		},
 		{
 			name: "Spam message",
 			request: Request{
-				Msg: "Spam message", UserID: "456", UserName: "Bob", Meta: MetaData{0, 3, true, false, false, false}, CheckOnly: true},
-			expected: `msg:"Spam message", user:"Bob", id:456, images:0, links:3, has_video:true, has_audio:false, has_forward:false, has_keyboard:false`,
+				Msg: "Spam message", UserID: "456", UserName: "Bob", Meta: MetaData{
+					Images: 0, Links: 3, Mentions: 2, HasVideo: true, HasAudio: false, HasForward: false, HasKeyboard: false,
+				}, CheckOnly: true},
+			expected: `msg:"Spam message", user:"Bob", id:456, images:0, links:3, mentions:2, has_video:true, has_audio:false, has_forward:false, has_keyboard:false`,
 		},
 		{
 			name:     "Empty fields",
 			request:  Request{Msg: "", UserID: "", UserName: "", Meta: MetaData{}, CheckOnly: false},
-			expected: `msg:"", user:"", id:, images:0, links:0, has_video:false, has_audio:false, has_forward:false, has_keyboard:false`,
+			expected: `msg:"", user:"", id:, images:0, links:0, mentions:0, has_video:false, has_audio:false, has_forward:false, has_keyboard:false`,
 		},
 	}
 

--- a/lib/tgspam/metachecks.go
+++ b/lib/tgspam/metachecks.go
@@ -139,3 +139,30 @@ func KeyboardCheck() MetaCheck {
 		}
 	}
 }
+
+// MentionsCheck is a function that returns a MetaCheck function.
+// It checks if the number of mentions in the message exceeds the specified limit.
+// If limit is negative, the check is disabled.
+func MentionsCheck(limit int) MetaCheck {
+	return func(req spamcheck.Request) spamcheck.Response {
+		if limit < 0 {
+			return spamcheck.Response{
+				Name:    "mentions",
+				Spam:    false,
+				Details: "check disabled",
+			}
+		}
+		if req.Meta.Mentions > limit {
+			return spamcheck.Response{
+				Name:    "mentions",
+				Spam:    true,
+				Details: fmt.Sprintf("too many mentions %d/%d", req.Meta.Mentions, limit),
+			}
+		}
+		return spamcheck.Response{
+			Name:    "mentions",
+			Spam:    false,
+			Details: fmt.Sprintf("mentions %d/%d", req.Meta.Mentions, limit),
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add ability to limit the number of mentions (@username) in a message
- Add command-line option '--meta.mentions-limit' with '-1' as default (disabled)
- Count both 'mention' and 'text_mention' entity types from Telegram

Fixes #222