### PR TITLE
Make user ID optional in message checker UI

### DIFF
--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -302,9 +302,9 @@ func (s *Server) checkMsgHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Msg == "" || req.UserID == "" || req.UserID == "0" {
+	if req.Msg == "" {
 		w.Header().Set("HX-Retarget", "#error-message")
-		fmt.Fprintln(w, "<div class='alert alert-danger'>userid and valid message required.</div>")
+		fmt.Fprintln(w, "<div class='alert alert-danger'>Valid message required.</div>")
 		return
 	}
 

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -143,7 +143,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	defer d.lock.RUnlock()
 
 	// approved user don't need to be checked
-	if d.FirstMessageOnly && d.approvedUsers[req.UserID].Count >= d.FirstMessagesCount {
+	if req.UserID != "" && d.FirstMessageOnly && d.approvedUsers[req.UserID].Count >= d.FirstMessagesCount {
 		return false, []spamcheck.Response{{Name: "pre-approved", Spam: false, Details: "user already approved"}}
 	}
 
@@ -609,6 +609,9 @@ func (d *Detector) cosineSimilarity(a, b map[string]int) float64 {
 
 // isCasSpam checks if a given user ID is a spammer with CAS API.
 func (d *Detector) isCasSpam(msgID string) spamcheck.Response {
+	if msgID == "" {
+		return spamcheck.Response{Spam: false, Name: "cas", Details: "check disabled"}
+	}
 	if _, err := strconv.ParseInt(msgID, 10, 64); err != nil {
 		return spamcheck.Response{Spam: false, Name: "cas", Details: fmt.Sprintf("invalid user id %q", msgID)}
 	}


### PR DESCRIPTION
## Summary
- Removed user ID validation in message checker handler
- Added handling for empty user ID in CAS check
- Display 'check disabled' when user ID is not provided
- Added tests to verify behavior with empty user ID