### PR TITLE
Fix settings page formatting issues

### DIFF
--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -25,7 +25,7 @@
                                     <tr><th colspan="2" style="border-bottom: none;">Telegram Bot</th></tr>
                                 </thead>
                                 <tbody>
-                                    <tr><th style="width: 50%">Version</th><td>{{.Version}}</td></tr>
+                                    <tr><th style="width: 30%">Version</th><td>{{.Version}}</td></tr>
                                     <tr><th>Uptime</th><td>{{.System.Uptime}}</td></tr>
                                     <tr><th>Instance ID</th><td>{{.InstanceID}}</td></tr>
                                     <tr><th>Primary Group</th><td>{{.PrimaryGroup}}</td></tr>
@@ -39,7 +39,7 @@
                                     <tr><th colspan="2" style="border-bottom: none;">Database</th></tr>
                                 </thead>
                                 <tbody>
-                                    <tr><th style="width: 50%">Type</th><td>{{.Database.Type}}</td></tr>
+                                    <tr><th style="width: 30%">Type</th><td>{{.Database.Type}}</td></tr>
                                     <tr><th>Group ID</th><td>{{.Database.GID}}</td></tr>
                                     <tr><th>Status</th><td>
                                         {{if eq .Database.Status "Connected"}}

--- a/app/webapi/assets/styles.css
+++ b/app/webapi/assets/styles.css
@@ -8,6 +8,23 @@ body, #result{
     color: white;
 }
 
+/* Version display styling */
+.table td {
+    word-break: break-word;
+    vertical-align: middle;
+}
+
+/* Prevent table headers from breaking across lines */
+.table th {
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+/* Ensure consistent width for table cells */
+.table th[style*="width"] {
+    width: 30% !important;
+}
+
 
 .ds-timestamp {
     min-width: 50px;


### PR DESCRIPTION
This PR fixes formatting issues in the settings page:

- Standardizes table header widths to 30%
- Prevents table headers from breaking across lines with white-space: nowrap
- Allows table data cells to wrap with word-break: break-word
- Ensures consistent vertical alignment for all table cells

Before this fix, some labels like 'Primary Group' were breaking onto two lines, and the version information was not properly formatted in the table cell.

These changes ensure that all labels are displayed correctly on a single line, and long values like version strings wrap properly without breaking the layout.