### PR TITLE
Update Docker image references to use GitHub Container Registry

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,7 +110,7 @@ sudo systemctl enable docker
 ```yaml
 services:
   tg-spam:
-    image: umputun/tg-spam:latest
+    image: ghcr.io/umputun/tg-spam:latest
     restart: always
     environment:
       - TELEGRAM_TOKEN=YOUR_BOT_TOKEN_HERE

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ This is an example of a docker-compose.yml file to run the bot. It is using the 
 services:
   
   tg-spam:
-    image: umputun/tg-spam:latest
+    image: ghcr.io/umputun/tg-spam:latest
     hostname: tg-spam
     restart: always
     container_name: tg-spam

--- a/docker-compose-minimal.yml
+++ b/docker-compose-minimal.yml
@@ -1,7 +1,7 @@
 # example of a minimal compose file to run tg-spam
 services:
   tg-spam:
-    image: umputun/tg-spam:master # use :latest tag for production
+    image: ghcr.io/umputun/tg-spam:master # use :latest tag for production
     hostname: tg-spam
     restart: always
     container_name: tg-spam

--- a/docker-compose-with-psql.yml
+++ b/docker-compose-with-psql.yml
@@ -1,7 +1,7 @@
 # example of a compose file with psql storage, server enabled and logging turned on
 services:
   tg-spam:
-    image: umputun/tg-spam:latest # use :master tag for latest (unstable) version
+    image: ghcr.io/umputun/tg-spam:latest # use :master tag for latest (unstable) version
     hostname: tg-spam
     restart: always
     container_name: tg-spam

--- a/docker-compose-with-server.yml
+++ b/docker-compose-with-server.yml
@@ -1,7 +1,7 @@
 # example of a compose file with server enabled, logging turned on and samples on named volume
 services:
   tg-spam:
-    image: umputun/tg-spam:latest # use :master tag for latest (unstable) version
+    image: ghcr.io/umputun/tg-spam:latest # use :master tag for latest (unstable) version
     hostname: tg-spam
     restart: always
     container_name: tg-spam
@@ -34,7 +34,7 @@ services:
   # reproxy is a reverse proxy to run multiple services on the same port, see https://reproxy.io for details
   # setup with automatic SSL certificates from Let's Encrypt
   reproxy:
-    image: umputun/reproxy:latest
+    image: ghcr.io/umputun/reproxy:latest
     hostname: reproxy
     container_name: reproxy
     restart: always

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -550,7 +550,7 @@ This is an example of a docker-compose.yml file to run the bot. It is using the 
 services:
   
   tg-spam:
-    image: umputun/tg-spam:latest
+    image: ghcr.io/umputun/tg-spam:latest
     hostname: tg-spam
     restart: always
     container_name: tg-spam

--- a/updater/docker-compose.yml
+++ b/updater/docker-compose.yml
@@ -2,7 +2,7 @@
 # updater gets samples from github repo "https://github.com/radio-t/tg-spam-samples.git and updates tg-spam samples
 services:
   tg-spam:
-    image: umputun/tg-spam:latest # use :master tag for latest (unstable) version
+    image: ghcr.io/umputun/tg-spam:latest # use :master tag for latest (unstable) version
     hostname: tg-spam
     restart: always
     container_name: tg-spam


### PR DESCRIPTION
DockerHub is heading in the weird direction, better rely on GitHub here.