### PR TITLE
Add username symbols check filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ This option is disabled by default. If `--meta.forward` set or `env:META_FORWARD
 
 This option is disabled by default. If `--meta.keyboard` set or `env:META_KEYBOARD` is `true`, the bot will check if the message contains a keyboard (buttons). If the message contains a keyboard, it will be marked as spam.
 
+**Username symbols check**
+
+This option is disabled by default. If `--meta.username-symbols` set or `env:META_USERNAME_SYMBOLS` is set to a string of prohibited symbols (e.g., "@#$"), the bot will check if the username contains any of these symbols. If the username contains any of the prohibited symbols, the message will be marked as spam.
+
 **Multi-language words**
 
 Using words that mix characters from multiple languages is a common spam technique. To detect such messages, the bot can check the message for the presence of such words. This option is disabled by default and can be enabled with the `--multi-lang=, [$MULTI_LANG]` parameter. Setting it to a number above `0` will enable this check, and the bot will mark the message as spam if it contains words with characters from more than one language in more than the specified number of words.
@@ -348,6 +352,7 @@ meta:
       --meta.audio-only                 enable audio only check [$META_AUDIO_ONLY]
       --meta.forward                    enable forward check [$META_FORWARD]
       --meta.keyboard                   enable keyboard check [$META_KEYBOARD]
+      --meta.username-symbols=          prohibited symbols in username, disabled by default [$META_USERNAME_SYMBOLS]
 
 openai:
       --openai.token=                   openai token, disabled if not set [$OPENAI_TOKEN]

--- a/app/main.go
+++ b/app/main.go
@@ -73,14 +73,15 @@ type options struct {
 	} `group:"cas" namespace:"cas" env-namespace:"CAS"`
 
 	Meta struct {
-		LinksLimit    int  `long:"links-limit" env:"LINKS_LIMIT" default:"-1" description:"max links in message, disabled by default"`
-		MentionsLimit int  `long:"mentions-limit" env:"MENTIONS_LIMIT" default:"-1" description:"max mentions in message, disabled by default"`
-		ImageOnly     bool `long:"image-only" env:"IMAGE_ONLY" description:"enable image only check"`
-		LinksOnly     bool `long:"links-only" env:"LINKS_ONLY" description:"enable links only check"`
-		VideosOnly    bool `long:"video-only" env:"VIDEO_ONLY" description:"enable video only check"`
-		AudiosOnly    bool `long:"audio-only" env:"AUDIO_ONLY" description:"enable audio only check"`
-		Forward       bool `long:"forward" env:"FORWARD" description:"enable forward check"`
-		Keyboard      bool `long:"keyboard" env:"KEYBOARD" description:"enable keyboard check"`
+		LinksLimit      int    `long:"links-limit" env:"LINKS_LIMIT" default:"-1" description:"max links in message, disabled by default"`
+		MentionsLimit   int    `long:"mentions-limit" env:"MENTIONS_LIMIT" default:"-1" description:"max mentions in message, disabled by default"`
+		ImageOnly       bool   `long:"image-only" env:"IMAGE_ONLY" description:"enable image only check"`
+		LinksOnly       bool   `long:"links-only" env:"LINKS_ONLY" description:"enable links only check"`
+		VideosOnly      bool   `long:"video-only" env:"VIDEO_ONLY" description:"enable video only check"`
+		AudiosOnly      bool   `long:"audio-only" env:"AUDIO_ONLY" description:"enable audio only check"`
+		Forward         bool   `long:"forward" env:"FORWARD" description:"enable forward check"`
+		Keyboard        bool   `long:"keyboard" env:"KEYBOARD" description:"enable keyboard check"`
+		UsernameSymbols string `long:"username-symbols" env:"USERNAME_SYMBOLS" description:"prohibited symbols in username, disabled by default"`
 	} `group:"meta" namespace:"meta" env-namespace:"META"`
 
 	OpenAI struct {
@@ -433,7 +434,7 @@ func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *
 		StorageTimeout:          opts.StorageTimeout,
 		NoSpamReply:             opts.NoSpamReply,
 		CasEnabled:              opts.CAS.API != "",
-		MetaEnabled:             opts.Meta.ImageOnly || opts.Meta.LinksLimit >= 0 || opts.Meta.MentionsLimit >= 0 || opts.Meta.LinksOnly || opts.Meta.VideosOnly || opts.Meta.AudiosOnly || opts.Meta.Forward || opts.Meta.Keyboard,
+		MetaEnabled:             opts.Meta.ImageOnly || opts.Meta.LinksLimit >= 0 || opts.Meta.MentionsLimit >= 0 || opts.Meta.LinksOnly || opts.Meta.VideosOnly || opts.Meta.AudiosOnly || opts.Meta.Forward || opts.Meta.Keyboard || opts.Meta.UsernameSymbols != "",
 		MetaLinksLimit:          opts.Meta.LinksLimit,
 		MetaMentionsLimit:       opts.Meta.MentionsLimit,
 		MetaLinksOnly:           opts.Meta.LinksOnly,
@@ -442,6 +443,7 @@ func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *
 		MetaAudioOnly:           opts.Meta.AudiosOnly,
 		MetaForwarded:           opts.Meta.Forward,
 		MetaKeyboard:            opts.Meta.Keyboard,
+		MetaUsernameSymbols:     opts.Meta.UsernameSymbols,
 		MultiLangLimit:          opts.MultiLangWords,
 		OpenAIEnabled:           opts.OpenAI.Token != "" || opts.OpenAI.APIBase != "",
 		OpenAIVeto:              opts.OpenAI.Veto,
@@ -578,6 +580,10 @@ func makeDetector(opts options) *tgspam.Detector {
 	if opts.Meta.Keyboard {
 		log.Printf("[INFO] keyboard check enabled")
 		metaChecks = append(metaChecks, tgspam.KeyboardCheck())
+	}
+	if opts.Meta.UsernameSymbols != "" {
+		log.Printf("[INFO] username symbols check enabled, prohibited symbols: %q", opts.Meta.UsernameSymbols)
+		metaChecks = append(metaChecks, tgspam.UsernameSymbolsCheck(opts.Meta.UsernameSymbols))
 	}
 	detector.WithMetaChecks(metaChecks...)
 

--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -156,6 +156,7 @@
                         <tr><th>Meta Video Only</th><td>{{.MetaVideoOnly}}</td></tr>
                         <tr><th>Meta Audio Only</th><td>{{.MetaAudioOnly}}</td></tr>
                         <tr><th>Meta Keyboard</th><td>{{.MetaKeyboard}}</td></tr>
+                        <tr><th>Meta Username Symbols</th><td>{{if eq .MetaUsernameSymbols ""}}disabled{{else}}{{.MetaUsernameSymbols}}{{end}}</td></tr>
                     </tbody>
                 </table>
             </div>

--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -85,6 +85,7 @@ type Settings struct {
 	MetaAudioOnly           bool          `json:"meta_audio_only"`
 	MetaForwarded           bool          `json:"meta_forwarded"`
 	MetaKeyboard            bool          `json:"meta_keyboard"`
+	MetaUsernameSymbols     string        `json:"meta_username_symbols"`
 	MultiLangLimit          int           `json:"multi_lang_limit"`
 	OpenAIEnabled           bool          `json:"openai_enabled"`
 	SamplesDataPath         string        `json:"samples_data_path"`

--- a/lib/tgspam/metachecks.go
+++ b/lib/tgspam/metachecks.go
@@ -166,3 +166,42 @@ func MentionsCheck(limit int) MetaCheck {
 		}
 	}
 }
+
+// UsernameSymbolsCheck is a function that returns a MetaCheck function.
+// It checks if the username contains any of the prohibited symbols.
+// If symbols is empty, the check is disabled.
+func UsernameSymbolsCheck(symbols string) MetaCheck {
+	return func(req spamcheck.Request) spamcheck.Response {
+		if symbols == "" {
+			return spamcheck.Response{
+				Name:    "username-symbols",
+				Spam:    false,
+				Details: "check disabled",
+			}
+		}
+
+		if req.UserName == "" {
+			return spamcheck.Response{
+				Name:    "username-symbols",
+				Spam:    false,
+				Details: "no username",
+			}
+		}
+
+		for _, symbol := range symbols {
+			if strings.ContainsRune(req.UserName, symbol) {
+				return spamcheck.Response{
+					Name:    "username-symbols",
+					Spam:    true,
+					Details: fmt.Sprintf("username contains prohibited symbol '%c'", symbol),
+				}
+			}
+		}
+
+		return spamcheck.Response{
+			Name:    "username-symbols",
+			Spam:    false,
+			Details: "no prohibited symbols in username",
+		}
+	}
+}

--- a/lib/tgspam/metachecks_test.go
+++ b/lib/tgspam/metachecks_test.go
@@ -497,3 +497,92 @@ func TestMentionsCheck(t *testing.T) {
 		})
 	}
 }
+
+func TestUsernameSymbolsCheck(t *testing.T) {
+	tests := []struct {
+		name            string
+		req             spamcheck.Request
+		prohibitedSymbols string
+		expected        spamcheck.Response
+	}{
+		{
+			name: "No username",
+			req: spamcheck.Request{
+				UserName: "",
+			},
+			prohibitedSymbols: "@",
+			expected: spamcheck.Response{
+				Name:    "username-symbols",
+				Spam:    false,
+				Details: "no username",
+			},
+		},
+		{
+			name: "Disabled check",
+			req: spamcheck.Request{
+				UserName: "user@name",
+			},
+			prohibitedSymbols: "",
+			expected: spamcheck.Response{
+				Name:    "username-symbols",
+				Spam:    false,
+				Details: "check disabled",
+			},
+		},
+		{
+			name: "Username contains prohibited symbol",
+			req: spamcheck.Request{
+				UserName: "user@name",
+			},
+			prohibitedSymbols: "@",
+			expected: spamcheck.Response{
+				Name:    "username-symbols",
+				Spam:    true,
+				Details: "username contains prohibited symbol '@'",
+			},
+		},
+		{
+			name: "Username contains one of multiple prohibited symbols",
+			req: spamcheck.Request{
+				UserName: "user#name",
+			},
+			prohibitedSymbols: "@#$",
+			expected: spamcheck.Response{
+				Name:    "username-symbols",
+				Spam:    true,
+				Details: "username contains prohibited symbol '#'",
+			},
+		},
+		{
+			name: "Username does not contain prohibited symbols",
+			req: spamcheck.Request{
+				UserName: "username",
+			},
+			prohibitedSymbols: "@#$",
+			expected: spamcheck.Response{
+				Name:    "username-symbols",
+				Spam:    false,
+				Details: "no prohibited symbols in username",
+			},
+		},
+		{
+			name: "Username with special characters but not prohibited",
+			req: spamcheck.Request{
+				UserName: "user-name_123",
+			},
+			prohibitedSymbols: "@#$",
+			expected: spamcheck.Response{
+				Name:    "username-symbols",
+				Spam:    false,
+				Details: "no prohibited symbols in username",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := UsernameSymbolsCheck(tt.prohibitedSymbols)
+			assert.Equal(t, tt.expected, check(tt.req))
+		})
+	}
+}


### PR DESCRIPTION
- Added new meta filter for detecting prohibited symbols in usernames
- Allows admins to specify symbols (like '@') that should trigger spam detection when present in usernames 
- Added comprehensive tests and documentation

The filter is disabled by default for backward compatibility, but can be enabled using  option or  environment variable with a string of prohibited symbols.