### PR TITLE
Fix #295: Process empty forwarded giveaway messages

### DIFF
--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -214,8 +214,8 @@ func (l *TelegramListener) procEvents(update tbapi.Update) error {
 	log.Printf("[DEBUG] %s", string(msgJSON))
 	msg := transform(update.Message)
 
-	// ignore messages with empty text, no media, no video, no video note
-	if strings.TrimSpace(msg.Text) == "" && msg.Image == nil && !msg.WithVideoNote && !msg.WithVideo {
+	// ignore messages with empty text, no media, no video, no video note, no forward
+	if strings.TrimSpace(msg.Text) == "" && msg.Image == nil && !msg.WithVideoNote && !msg.WithVideo && !msg.WithForward {
 		return nil
 	}
 	ctx := context.TODO()

--- a/lib/tgspam/plugin/helpers.go
+++ b/lib/tgspam/plugin/helpers.go
@@ -184,7 +184,7 @@ func endsWith(l *lua.LState) int {
 // Lua usage: response, status_code, err = http_request(url, [method="GET"], [headers={...}], [body=""], [timeout=5])
 // Example: response, status, err = http_request("https://example.com/api", "POST", {["Content-Type"]="application/json"}, '{"key":"value"}', 10)
 func httpRequest(l *lua.LState) int {
-	url := l.CheckString(1)
+	urlStr := l.CheckString(1)
 
 	// optional parameters with defaults
 	method := "GET"
@@ -210,7 +210,7 @@ func httpRequest(l *lua.LState) int {
 	}
 
 	// create the request with context for proper cancellation
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequest(method, urlStr, body)
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.LNumber(0))


### PR DESCRIPTION
## Summary
- Modified message filtering to check for forwarded messages even when they have no text or media content
- Added test case for forwarded giveaway messages that validates the fix
- Fixed linter issue in plugin helpers.go (renamed shadowed url variable)

This fix addresses issue #295 where forwarded giveaway spam messages were not being detected because they have no text, image, or video content, but still have the WithForward flag set.

The changes ensure that the bot processes forwarded messages even when they have no text or media content, which allows it to detect and handle forwarded giveaway spam messages correctly.