### PR TITLE
Fix #304: Don't send reasoning_effort parameter when set to 'none'

### DIFF
--- a/lib/tgspam/openai.go
+++ b/lib/tgspam/openai.go
@@ -173,8 +173,8 @@ func (o *openAIChecker) sendRequest(msg string) (response openAIResponse, err er
 		ResponseFormat: &openai.ChatCompletionResponseFormat{Type: "json_object"},
 	}
 
-	// add reasoning_effort parameter if set
-	if o.params.ReasoningEffort != "" {
+	// add reasoning_effort parameter if set and not "none"
+	if o.params.ReasoningEffort != "" && o.params.ReasoningEffort != "none" {
 		request.ReasoningEffort = o.params.ReasoningEffort
 	}
 

--- a/lib/tgspam/openai_test.go
+++ b/lib/tgspam/openai_test.go
@@ -268,8 +268,7 @@ func TestReasoningEffortInRequest(t *testing.T) {
 		{
 			name:            "none reasoning effort",
 			reasoningEffort: "none",
-			expectInRequest: true,
-			expectedEffort:  "none",
+			expectInRequest: false,
 		},
 		{
 			name:            "low reasoning effort",


### PR DESCRIPTION
## Summary
- Fixed OpenAI API error when using non-reasoning models (like gpt-4o-mini) by not sending the `reasoning_effort` parameter when it's set to "none"
- The issue was that all models were receiving the `reasoning_effort` parameter, but only reasoning models (o1, o3-mini) support it

## Changes
- Modified `openai.go` to check for both empty string and "none" value before adding `reasoning_effort` to the request
- Updated test to reflect that "none" value should not be sent in the request

## Testing
- All existing tests pass
- The specific test `TestReasoningEffortInRequest` was updated to verify the fix

Fixes #304