### PR TITLE
feat: Add support for detecting spam in edited messages

### DIFF
--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -157,8 +157,9 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 				log.Printf("[INFO] processing edited message, id: %d", update.EditedMessage.MessageID)
 				// we need to process an edited message as a new message, so we create a new update object
 				// and copy the edited message to the message field.
-				editedUpdate := update
-				editedUpdate.Message = update.EditedMessage
+				editedUpdate := tbapi.Update{
+					Message: update.EditedMessage,
+				}
 				if err := l.procEvents(editedUpdate); err != nil {
 					log.Printf("[WARN] failed to process edited message update: %v", err)
 				}

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -152,6 +152,19 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 				continue
 			}
 
+			// handle edited messages
+			if update.EditedMessage != nil {
+				log.Printf("[INFO] processing edited message, id: %d", update.EditedMessage.MessageID)
+				// we need to process an edited message as a new message, so we create a new update object
+				// and copy the edited message to the message field.
+				editedUpdate := update
+				editedUpdate.Message = update.EditedMessage
+				if err := l.procEvents(editedUpdate); err != nil {
+					log.Printf("[WARN] failed to process edited message update: %v", err)
+				}
+				continue
+			}
+
 			if update.Message == nil {
 				continue
 			}


### PR DESCRIPTION
This PR adds support for detecting spam in edited messages. All edited messages are now processed by the spam detection logic, regardless of their age. A new test case has been added to cover this functionality.

References #308