### PR TITLE
Fix manual spam reporting for image-only messages

### DIFF
--- a/app/events/admin.go
+++ b/app/events/admin.go
@@ -305,7 +305,7 @@ func (a *admin) directReport(update tbapi.Update, updateSamples bool) error {
 	}
 
 	// update spam samples
-	if updateSamples {
+	if updateSamples && msgTxt != "" {
 		if err := a.bot.UpdateSpam(msgTxt); err != nil {
 			return fmt.Errorf("failed to update spam for %q: %w", msgTxt, err)
 		}


### PR DESCRIPTION
## Summary
- Fixed issue where manual spam reporting fails for messages containing only images
- Modified `directReport` method to skip spam sample updates when message text is empty
- All other actions (delete message, ban user, notify admin) continue to work as expected

## Problem
When an admin tries to manually report spam for a message that contains only an image (no text), the system was failing with error: `failed to update spam for "": can't update spam samples: message can't be empty`

## Solution  
Added a check to skip `UpdateSpam` call when `msgTxt` is empty. This allows image-only spam to be properly handled without errors, while maintaining all other spam reporting functionality.

## Testing
- Added test case `TestAdmin_DirectSpamReport_ImageOnly` that verifies image-only spam can be reported without errors
- All existing tests pass
- Linter reports no issues

Related to #313