### PR TITLE
Add ExtraDeleteIDs support for bulk message deletion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,13 @@
 - Documentation: All exported functions and types must be documented with standard Go comments
 - Interfaces: Define interfaces in consumer packages
 - Mocks: Generate with github.com/matryer/moq and store in mocks package
+
+## Spam Detection Architecture
+
+### ExtraDeleteIDs Feature
+- `spamcheck.Response` includes `ExtraDeleteIDs []int` field for additional message IDs to delete when spam is detected
+- Any spam checker can populate this field to request deletion of related messages
+- Currently used by duplicate detector to delete all previous duplicates when threshold is reached
+- The listener handles these deletions with rate limiting (35ms between deletions) to respect Telegram API limits
+- Deletion errors are logged but don't fail the operation (messages might be already deleted or too old)
+- Design principle: When a spammer is detected, aggressively clean up ALL their spam messages, not just the triggering one

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -96,6 +96,7 @@ func (s *SpamFilter) OnMessage(msg Message, checkOnly bool) (response Response) 
 		spamReq.Meta.HasKeyboard = true
 	}
 	spamReq.Meta.Links = strings.Count(msg.Text, "http://") + strings.Count(msg.Text, "https://")
+	spamReq.Meta.MessageID = msg.ID
 
 	// count mentions from entities
 	if msg.Entities != nil {

--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -635,6 +635,92 @@ func TestTelegramListener_DoWithExtraDeleteIDs(t *testing.T) {
 	assert.Equal(t, 3, len(mockAPI.RequestCalls()), "should have 1 ban + 2 delete requests")
 }
 
+func TestTelegramListener_DoWithExtraDeleteIDs_SuperUser(t *testing.T) {
+	mockLogger := &mocks.SpamLoggerMock{SaveFunc: func(msg *bot.Message, response *bot.Response) {}}
+
+	deletedMessages := []int{}
+	mockAPI := &mocks.TbAPIMock{
+		GetChatFunc: func(config tbapi.ChatInfoConfig) (tbapi.ChatFullInfo, error) {
+			return tbapi.ChatFullInfo{Chat: tbapi.Chat{ID: 123}}, nil
+		},
+		SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+			return tbapi.Message{Text: c.(tbapi.MessageConfig).Text, From: &tbapi.User{UserName: "user"}}, nil
+		},
+		RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+			// track deleted messages (should be none for superuser)
+			if delConfig, ok := c.(tbapi.DeleteMessageConfig); ok {
+				deletedMessages = append(deletedMessages, delConfig.MessageID)
+			}
+			return &tbapi.APIResponse{Ok: true}, nil
+		},
+		GetChatAdministratorsFunc: func(config tbapi.ChatAdministratorsConfig) ([]tbapi.ChatMember, error) {
+			return nil, nil
+		},
+	}
+
+	b := &mocks.BotMock{
+		OnMessageFunc: func(msg bot.Message, checkOnly bool) bot.Response {
+			if msg.Text == "spam spam spam" {
+				// simulate duplicate detector response with extra IDs
+				return bot.Response{
+					Send:        true,
+					Text:        "duplicate spam detected",
+					BanInterval: time.Hour,
+					User:        bot.User{Username: "user", ID: 1},
+					CheckResults: []spamcheck.Response{
+						{
+							Name:           "duplicate",
+							Spam:           true,
+							Details:        "message repeated 3 times",
+							ExtraDeleteIDs: []int{100, 101},
+						},
+					},
+				}
+			}
+			return bot.Response{}
+		},
+	}
+
+	locator, teardown := prepTestLocator(t)
+	defer teardown()
+
+	l := TelegramListener{
+		SpamLogger: mockLogger,
+		TbAPI:      mockAPI,
+		Bot:        b,
+		Group:      "gr",
+		Locator:    locator,
+		SuperUsers: SuperUsers{"1"}, // user ID 1 is superuser
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	updMsg := tbapi.Update{
+		Message: &tbapi.Message{
+			MessageID: 102,
+			Chat:      tbapi.Chat{ID: 123},
+			Text:      "spam spam spam",
+			From:      &tbapi.User{UserName: "user", ID: 1},
+			Date:      int(time.Now().Unix()),
+		},
+	}
+
+	updChan := make(chan tbapi.Update, 1)
+	updChan <- updMsg
+	close(updChan)
+	mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+	err := l.Do(ctx)
+	assert.EqualError(t, err, "telegram update chan closed")
+
+	// verify that no extra messages were deleted for superuser
+	assert.Len(t, deletedMessages, 0, "superuser extra deletions should be skipped")
+
+	// verify no ban/delete requests were issued for superuser
+	assert.Equal(t, 0, len(mockAPI.RequestCalls()), "should not call Request for superuser")
+}
+
 func TestTelegramListener_DoWithForwarded(t *testing.T) {
 	mockLogger := &mocks.SpamLoggerMock{SaveFunc: func(msg *bot.Message, response *bot.Response) {}}
 	mockAPI := &mocks.TbAPIMock{

--- a/lib/spamcheck/spamcheck.go
+++ b/lib/spamcheck/spamcheck.go
@@ -23,6 +23,7 @@ type MetaData struct {
 	HasAudio    bool `json:"has_audio"`    // true if the message has an audio
 	HasForward  bool `json:"has_forward"`  // true if the message has a forward
 	HasKeyboard bool `json:"has_keyboard"` // true if the message has a keyboard (buttons)
+	MessageID   int  `json:"message_id"`   // telegram message ID
 }
 
 func (r *Request) String() string {
@@ -32,10 +33,11 @@ func (r *Request) String() string {
 
 // Response is a result of spam check.
 type Response struct {
-	Name    string `json:"name"`    // name of the check
-	Spam    bool   `json:"spam"`    // true if spam
-	Details string `json:"details"` // details of the check
-	Error   error  `json:"-"`       // error message, if any. Do not serialize it
+	Name           string `json:"name"`                       // name of the check
+	Spam           bool   `json:"spam"`                       // true if spam
+	Details        string `json:"details"`                    // details of the check
+	Error          error  `json:"-"`                          // error message, if any. Do not serialize it
+	ExtraDeleteIDs []int  `json:"extra_delete_ids,omitempty"` // additional message IDs to delete when spam detected
 }
 
 func (r *Response) String() string {

--- a/lib/tgspam/duplicate.go
+++ b/lib/tgspam/duplicate.go
@@ -127,7 +127,10 @@ func (d *duplicateDetector) trackMessage(userID int64, msg string, messageID int
 		}
 	}
 
-	// preserve message IDs for entries still in window
+	// NOTE: We intentionally preserve all known messageIDs for a given hash,
+	// not just those still in the time window. This allows bulk deletion of
+	// all duplicates detected historically once the threshold is reached.
+	// do not filter messageIDs here by the time window.
 	for hash, oldTracker := range history.trackers {
 		if tracker, exists := newTrackers[hash]; exists {
 			tracker.messageIDs = oldTracker.messageIDs
@@ -216,7 +219,8 @@ func (d *duplicateDetector) performCleanup(now time.Time) {
 			}
 		}
 
-		// preserve message IDs for entries still in window
+		// NOTE: Same rationale as above — keep all known messageIDs for a hash
+		// to allow deletion of all duplicates, beyond the time window.
 		for hash, oldTracker := range history.trackers {
 			if tracker, exists := newTrackers[hash]; exists {
 				tracker.messageIDs = oldTracker.messageIDs

--- a/lib/tgspam/duplicate_test.go
+++ b/lib/tgspam/duplicate_test.go
@@ -106,19 +106,19 @@ func TestDuplicateDetector_Check(t *testing.T) {
 				if resp.Spam {
 					assert.Contains(t, resp.Details, "repeated")
 				}
-				
+
 				if !resp.Spam && tt.threshold > 0 {
 					// when check is enabled and no spam detected
 					if msg.UserID == "" {
 						assert.Equal(t, "check disabled", resp.Details)
 						continue
 					}
-					
+
 					if _, err := strconv.ParseInt(msg.UserID, 10, 64); err != nil {
 						assert.Equal(t, "invalid user id", resp.Details)
 						continue
 					}
-					
+
 					assert.Equal(t, "no duplicates found", resp.Details)
 				}
 			}
@@ -130,19 +130,62 @@ func TestDuplicateDetector_TimeWindow(t *testing.T) {
 	d := newDuplicateDetector(2, 100*time.Millisecond)
 
 	// send first message
-	resp := d.check(spamcheck.Request{Msg: "test", UserID: "123"})
+	resp := d.check(spamcheck.Request{Msg: "test", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1001}})
 	assert.False(t, resp.Spam)
 
 	// send second message - should trigger
-	resp = d.check(spamcheck.Request{Msg: "test", UserID: "123"})
+	resp = d.check(spamcheck.Request{Msg: "test", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1002}})
 	assert.True(t, resp.Spam)
 
 	// wait for window to expire
 	time.Sleep(150 * time.Millisecond)
 
 	// send third message - should not trigger as previous ones expired
-	resp = d.check(spamcheck.Request{Msg: "test", UserID: "123"})
+	resp = d.check(spamcheck.Request{Msg: "test", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1003}})
 	assert.False(t, resp.Spam)
+}
+
+func TestDuplicateDetector_ExtraDeleteIDs(t *testing.T) {
+	d := newDuplicateDetector(3, time.Hour) // long window to avoid expiry
+
+	// send first message
+	resp := d.check(spamcheck.Request{Msg: "spam", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1001}})
+	assert.False(t, resp.Spam)
+	assert.Nil(t, resp.ExtraDeleteIDs)
+
+	// send second message - still not spam
+	resp = d.check(spamcheck.Request{Msg: "spam", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1002}})
+	assert.False(t, resp.Spam)
+	assert.Nil(t, resp.ExtraDeleteIDs)
+
+	// send third message - should trigger spam with extra IDs
+	resp = d.check(spamcheck.Request{Msg: "spam", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1003}})
+	assert.True(t, resp.Spam)
+	assert.Equal(t, []int{1001, 1002}, resp.ExtraDeleteIDs, "should return first two message IDs")
+
+	// send fourth message - should still trigger but IDs were cleared
+	resp = d.check(spamcheck.Request{Msg: "spam", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1004}})
+	assert.True(t, resp.Spam)
+	assert.Nil(t, resp.ExtraDeleteIDs, "IDs should be cleared after first spam detection")
+}
+
+func TestDuplicateDetector_ExtraDeleteIDs_DifferentMessages(t *testing.T) {
+	d := newDuplicateDetector(2, time.Hour) // threshold of 2
+
+	// send different messages from same user - should not collect IDs
+	resp := d.check(spamcheck.Request{Msg: "hello", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1001}})
+	assert.False(t, resp.Spam)
+
+	resp = d.check(spamcheck.Request{Msg: "world", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1002}})
+	assert.False(t, resp.Spam)
+
+	// now send duplicates
+	resp = d.check(spamcheck.Request{Msg: "spam", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1003}})
+	assert.False(t, resp.Spam)
+
+	resp = d.check(spamcheck.Request{Msg: "spam", UserID: "123", Meta: spamcheck.MetaData{MessageID: 1004}})
+	assert.True(t, resp.Spam)
+	assert.Equal(t, []int{1003}, resp.ExtraDeleteIDs, "should only include duplicate message ID")
 }
 
 func TestDuplicateDetector_AutomaticCleanup(t *testing.T) {

--- a/lib/tgspam/duplicate_test.go
+++ b/lib/tgspam/duplicate_test.go
@@ -271,8 +271,8 @@ func TestDuplicateDetector_ConcurrentAccess(t *testing.T) {
 		history, found := d.cache.Get(userID)
 		require.True(t, found)
 		require.NotNil(t, history)
-		assert.LessOrEqual(t, len(history.entries), 10)
-		assert.LessOrEqual(t, len(history.hashCounts), 3) // only 3 different messages
+		assert.Equal(t, 10, len(history.entries)) // exactly 10 messages sent per user
+		assert.Equal(t, 3, len(history.trackers)) // exactly 3 different messages (msg0, msg1, msg2)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Implements ExtraDeleteIDs feature allowing spam checkers to specify additional messages for deletion
- Duplicate detector now tracks and returns all duplicate message IDs when spam threshold is reached
- Listener handles bulk deletion with rate limiting to respect Telegram API limits

## Implementation Details

**Core Changes:**
- Added `ExtraDeleteIDs []int` field to `spamcheck.Response` for any checker to specify related messages to delete
- Added `MessageID int` to `spamcheck.MetaData` to pass message IDs through the detection pipeline
- Updated duplicate detector to track message IDs alongside duplicate counts
- Modified listener to delete extra messages with 35ms delay between deletions for rate limiting

**Duplicate Detector Behavior:**
- Tracks all message IDs for each duplicate message hash
- When spam threshold is reached, returns all previous duplicate IDs (excluding current)
- Clears tracked IDs after spam detection to prevent memory bloat
- Intentionally deletes ALL instances of duplicate messages, even those outside detection window

**Safety Features:**
- Deletion errors are logged but don't fail the operation
- Handles "message not found" errors gracefully (already deleted or too old)
- Rate limiting prevents Telegram API throttling

## Testing
- Added comprehensive tests for message ID tracking in duplicate detector
- Added tests for ExtraDeleteIDs handling in listener
- All existing tests pass
- Linting clean