### PR TITLE
fix: delete orphaned /report commands to keep chat clean

### DIFF
--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -403,7 +403,15 @@ func (l *TelegramListener) procSuperReply(update tbapi.Update) (handled bool) {
 // isReportCommand checks if message text is a /report command variant
 func isReportCommand(text string) bool {
 	lower := strings.ToLower(text)
-	return strings.HasPrefix(lower, "/report") || strings.HasPrefix(lower, "report")
+	// exact match for "report" or "/report"
+	if lower == "report" || lower == "/report" {
+		return true
+	}
+	// match "/report@botname" syntax (command with @ must have something after @)
+	if strings.HasPrefix(lower, "/report@") && len(lower) > 8 {
+		return true
+	}
+	return false
 }
 
 // procUserReply processes regular user commands (reply) /report.


### PR DESCRIPTION
**related to #343**

bot now deletes `/report` command messages when sent without replying to another message (sent by mistake, during testing, or by clicking `/report` in another message).

**changes:**

- added `isReportCommand()` helper to detect `/report`, `report`, and `/report@botname` variants using prefix matching
- orphaned `/report` commands from regular users are deleted immediately before routing to spam detection
- uses `update.Message.Chat.ID` to delete from the correct chat (not just primary chat)
- superuser orphaned reports are NOT auto-deleted (intentional - superusers may use `/report` for other purposes)
- added comprehensive test coverage for all command variants

**behavior:**
- orphaned `/report` from regular users → deleted immediately ✓
- orphaned `/report` from superusers → NOT deleted (left as is) ✓
- valid `/report` with reply → works as before (processes report) ✓
- `/report@botname` syntax → handled correctly ✓

**verification:**
- all tests pass
- linter passes (0 issues)
- formatter applied