### PR TITLE
fix: prevent message edits from triggering duplicate spam detection

### DIFF
--- a/lib/tgspam/duplicate.go
+++ b/lib/tgspam/duplicate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	cache "github.com/go-pkgz/expirable-cache/v3"
+
 	"github.com/umputun/tg-spam/lib/spamcheck"
 )
 
@@ -29,8 +30,9 @@ type userHistory struct {
 }
 
 type hashEntry struct {
-	hash string
-	time time.Time
+	hash      string
+	time      time.Time
+	messageID int
 }
 
 type hashTracker struct {
@@ -70,7 +72,12 @@ func (d *duplicateDetector) check(req spamcheck.Request) spamcheck.Response {
 		return spamcheck.Response{Name: "duplicate", Spam: false, Details: "invalid user id"}
 	}
 
-	count, extraIDs := d.trackMessage(userID, req.Msg, req.Meta.MessageID)
+	count, extraIDs, isEdit := d.trackMessage(userID, req.Msg, req.Meta.MessageID)
+
+	// if this is an edit of an already-handled message, don't re-trigger spam detection
+	if isEdit {
+		return spamcheck.Response{Name: "duplicate", Spam: false, Details: "message edit"}
+	}
 
 	if count >= d.threshold {
 		msgHash := d.hash(req.Msg)
@@ -85,8 +92,8 @@ func (d *duplicateDetector) check(req spamcheck.Request) spamcheck.Response {
 	return spamcheck.Response{Name: "duplicate", Spam: false, Details: "no duplicates found"}
 }
 
-// trackMessage tracks a message and returns the count of duplicates and extra message IDs to delete
-func (d *duplicateDetector) trackMessage(userID int64, msg string, messageID int) (count int, extraIDs []int) {
+// trackMessage tracks a message and returns the count of duplicates, extra message IDs to delete, and whether this is an edit
+func (d *duplicateDetector) trackMessage(userID int64, msg string, messageID int) (count int, extraIDs []int, isEdit bool) {
 	msgHash := d.hash(msg)
 	now := time.Now()
 
@@ -115,55 +122,40 @@ func (d *duplicateDetector) trackMessage(userID int64, msg string, messageID int
 		history.trackers = make(map[string]hashTracker)
 	}
 
-	// clean old entries
-	cutoff := now.Add(-d.window)
-	// create a new slice to avoid sharing underlying array
-	filtered := make([]hashEntry, 0, len(history.entries)+1)
-	newTrackers := make(map[string]hashTracker)
+	// rebuild trackers with only non-expired entries (including messageIDs from entries)
+	filtered, newTrackers := d.filterExpiredEntries(history.entries, now)
 
-	for _, entry := range history.entries {
-		if !entry.time.After(cutoff) {
-			continue
-		}
-		filtered = append(filtered, entry)
-		tracker := newTrackers[entry.hash]
-		tracker.count++
-		// preserve first seen timestamp
-		if tracker.firstSeen.IsZero() {
-			tracker.firstSeen = entry.time
-		}
-		tracker.lastSeen = entry.time
-		newTrackers[entry.hash] = tracker
-	}
-
-	// NOTE: We preserve messageIDs for a given hash but limit them to prevent unbounded growth.
-	// we keep at most (threshold-1) + current message IDs since that's all we need for deletion.
-	maxMessageIDs := d.threshold
-	if maxMessageIDs > 100 {
-		maxMessageIDs = 100 // cap at 100 to prevent excessive memory usage
-	}
-	for hash, oldTracker := range history.trackers {
-		if tracker, exists := newTrackers[hash]; exists {
-			tracker.messageIDs = oldTracker.messageIDs
-			// limit the number of message IDs we keep
-			if len(tracker.messageIDs) > maxMessageIDs {
-				// keep only the most recent IDs
-				tracker.messageIDs = tracker.messageIDs[len(tracker.messageIDs)-maxMessageIDs:]
-			}
-			// preserve timestamps from old tracker if not set
-			if tracker.firstSeen.IsZero() && !oldTracker.firstSeen.IsZero() {
-				tracker.firstSeen = oldTracker.firstSeen
-			}
-			newTrackers[hash] = tracker
-		}
-	}
-
-	// check if this messageID already exists for this hash (indicates an edit)
-	tracker := newTrackers[msgHash]
-	isEdit := false
+	// handle content-changing edits: find and remove the old entry with this messageID
+	// this ensures each messageID only belongs to one hash (current content)
 	if messageID > 0 {
-		for _, existingID := range tracker.messageIDs {
-			if existingID == messageID {
+		for i, entry := range filtered {
+			if entry.messageID == messageID && entry.hash != msgHash {
+				// found the old entry for this messageID with different content
+				oldHash := entry.hash
+				// remove this specific entry from filtered
+				filtered = append(filtered[:i], filtered[i+1:]...)
+				// update tracker for old hash
+				if t, exists := newTrackers[oldHash]; exists {
+					t.messageIDs = d.removeMessageID(t.messageIDs, messageID)
+					t.count--
+					if t.count == 0 {
+						delete(newTrackers, oldHash)
+					} else {
+						newTrackers[oldHash] = t
+					}
+				}
+				break
+			}
+		}
+	}
+
+	// detect same-content edit by scanning filtered entries (source of truth)
+	// don't rely on tracker.messageIDs as it may be capped and missing old IDs
+	tracker := newTrackers[msgHash]
+	isEdit = false
+	if messageID > 0 {
+		for _, entry := range filtered {
+			if entry.messageID == messageID && entry.hash == msgHash {
 				isEdit = true
 				break
 			}
@@ -172,20 +164,20 @@ func (d *duplicateDetector) trackMessage(userID int64, msg string, messageID int
 
 	// only count as duplicate if it's not an edit
 	if !isEdit {
-		// add new entry
-		filtered = append(filtered, hashEntry{hash: msgHash, time: now})
+		// add new entry with messageID
+		filtered = append(filtered, hashEntry{hash: msgHash, time: now, messageID: messageID})
 		tracker.count++
-		// only append valid message IDs
+		// messageID will be added to tracker when we rebuild from entries
+		// for now, add it directly since we haven't saved to cache yet
 		if messageID > 0 {
 			tracker.messageIDs = append(tracker.messageIDs, messageID)
-			// limit the number of message IDs after adding the new one
-			maxMessageIDs := d.threshold
-			if maxMessageIDs > 100 {
-				maxMessageIDs = 100 // cap at 100 to prevent excessive memory usage
+			// cap at min(maxEntriesPerUser, 100) to prevent excessive memory
+			maxIDs := d.maxEntriesPerUser
+			if maxIDs > 100 {
+				maxIDs = 100
 			}
-			if len(tracker.messageIDs) > maxMessageIDs {
-				// keep only the most recent IDs
-				tracker.messageIDs = tracker.messageIDs[len(tracker.messageIDs)-maxMessageIDs:]
+			if len(tracker.messageIDs) > maxIDs {
+				tracker.messageIDs = tracker.messageIDs[len(tracker.messageIDs)-maxIDs:]
 			}
 		}
 		// update timestamps
@@ -193,53 +185,26 @@ func (d *duplicateDetector) trackMessage(userID int64, msg string, messageID int
 			tracker.firstSeen = now
 		}
 	}
+
 	// always update lastSeen, even for edits
 	tracker.lastSeen = now
 	newTrackers[msgHash] = tracker
 
 	// limit entries per user to prevent memory exhaustion
-	if len(filtered) > d.maxEntriesPerUser {
-		// remove oldest entries, keeping only the most recent ones
-		startIdx := len(filtered) - d.maxEntriesPerUser
-		// update trackers for removed entries
-		for i := 0; i < startIdx; i++ {
-			if t, exists := newTrackers[filtered[i].hash]; exists {
-				t.count--
-				if t.count == 0 {
-					delete(newTrackers, filtered[i].hash)
-				} else {
-					newTrackers[filtered[i].hash] = t
-				}
-			}
-		}
-		filtered = filtered[startIdx:]
-
-		// recalculate firstSeen for remaining entries
-		seenHashes := make(map[string]bool)
-		for _, entry := range filtered {
-			if t, exists := newTrackers[entry.hash]; exists {
-				if !seenHashes[entry.hash] {
-					// this is the first occurrence of this hash in the trimmed entries
-					t.firstSeen = entry.time
-					newTrackers[entry.hash] = t
-					seenHashes[entry.hash] = true
-				}
-			}
-		}
-	}
+	filtered, newTrackers = d.limitEntriesPerUser(filtered, newTrackers)
 
 	tracker = newTrackers[msgHash]
 	count = tracker.count
 
 	// if threshold reached, prepare extra IDs for deletion (excluding current message)
-	if count >= d.threshold {
+	// skip if this is an edit - we already handled this message
+	if count >= d.threshold && !isEdit {
 		if len(tracker.messageIDs) > 1 {
 			// return all IDs except the current one (last in the list)
 			extraIDs = make([]int, len(tracker.messageIDs)-1)
 			copy(extraIDs, tracker.messageIDs[:len(tracker.messageIDs)-1])
-			// clear the IDs to prevent re-deletion
-			tracker.messageIDs = nil
-			newTrackers[msgHash] = tracker
+			// note: we don't clear messageIDs here as they're needed for edit detection
+			// the listener handles deletion errors gracefully if messages are already deleted
 		}
 	}
 
@@ -249,7 +214,87 @@ func (d *duplicateDetector) trackMessage(userID int64, msg string, messageID int
 	// update cache with modified history
 	d.cache.Set(userID, history, d.window*2)
 
-	return count, extraIDs
+	return count, extraIDs, isEdit
+}
+
+// filterExpiredEntries removes entries older than window and rebuilds trackers from entries
+func (d *duplicateDetector) filterExpiredEntries(entries []hashEntry, now time.Time) (filtered []hashEntry, trackers map[string]hashTracker) {
+	cutoff := now.Add(-d.window)
+	filtered = make([]hashEntry, 0, len(entries)+1)
+	trackers = make(map[string]hashTracker)
+
+	for _, entry := range entries {
+		if !entry.time.After(cutoff) {
+			continue
+		}
+		filtered = append(filtered, entry)
+		tracker := trackers[entry.hash]
+		tracker.count++
+		// build messageIDs from entries
+		if entry.messageID > 0 {
+			tracker.messageIDs = append(tracker.messageIDs, entry.messageID)
+		}
+		// preserve first seen timestamp
+		if tracker.firstSeen.IsZero() {
+			tracker.firstSeen = entry.time
+		}
+		tracker.lastSeen = entry.time
+		trackers[entry.hash] = tracker
+	}
+
+	return filtered, trackers
+}
+
+// removeMessageID removes messageID from slice if present
+func (d *duplicateDetector) removeMessageID(messageIDs []int, messageID int) []int {
+	for i, id := range messageIDs {
+		if id == messageID {
+			// remove by copying remaining elements
+			return append(messageIDs[:i], messageIDs[i+1:]...)
+		}
+	}
+	return messageIDs
+}
+
+// limitEntriesPerUser enforces maxEntriesPerUser limit by removing oldest entries
+func (d *duplicateDetector) limitEntriesPerUser(entries []hashEntry, trackers map[string]hashTracker) (filtered []hashEntry, updated map[string]hashTracker) {
+	if len(entries) <= d.maxEntriesPerUser {
+		return entries, trackers
+	}
+
+	// remove oldest entries, keeping only the most recent ones
+	startIdx := len(entries) - d.maxEntriesPerUser
+	// update trackers for removed entries and remove their messageIDs
+	for i := 0; i < startIdx; i++ {
+		if t, exists := trackers[entries[i].hash]; exists {
+			t.count--
+			// remove messageID from tracker to keep it aligned with entries
+			if entries[i].messageID > 0 {
+				t.messageIDs = d.removeMessageID(t.messageIDs, entries[i].messageID)
+			}
+			if t.count == 0 {
+				delete(trackers, entries[i].hash)
+			} else {
+				trackers[entries[i].hash] = t
+			}
+		}
+	}
+	entries = entries[startIdx:]
+
+	// recalculate firstSeen for remaining entries
+	seenHashes := make(map[string]bool)
+	for _, entry := range entries {
+		if t, exists := trackers[entry.hash]; exists {
+			if !seenHashes[entry.hash] {
+				// this is the first occurrence of this hash in the trimmed entries
+				t.firstSeen = entry.time
+				trackers[entry.hash] = t
+				seenHashes[entry.hash] = true
+			}
+		}
+	}
+
+	return entries, trackers
 }
 
 // hash calculates sha256 hash of a message
@@ -284,8 +329,6 @@ func (d *duplicateDetector) formatDuration(userID int64, msgHash string) string 
 func (d *duplicateDetector) performCleanup(now time.Time) {
 	// cache handles TTL-based eviction automatically
 	// we just need to clean expired entries within each user's history
-	cutoff := now.Add(-d.window)
-
 	keys := d.cache.Keys()
 	for _, userID := range keys {
 		history, found := d.cache.Get(userID)
@@ -293,38 +336,8 @@ func (d *duplicateDetector) performCleanup(now time.Time) {
 			continue
 		}
 
-		// clean old entries
-		// create a new slice to avoid sharing underlying array
-		filtered := make([]hashEntry, 0, len(history.entries))
-		newTrackers := make(map[string]hashTracker)
-
-		for _, entry := range history.entries {
-			if !entry.time.After(cutoff) {
-				continue
-			}
-			filtered = append(filtered, entry)
-			tracker := newTrackers[entry.hash]
-			tracker.count++
-			// preserve first seen timestamp
-			if tracker.firstSeen.IsZero() {
-				tracker.firstSeen = entry.time
-			}
-			tracker.lastSeen = entry.time
-			newTrackers[entry.hash] = tracker
-		}
-
-		// NOTE: Same rationale as above — keep all known messageIDs for a hash
-		// to allow deletion of all duplicates, beyond the time window.
-		for hash, oldTracker := range history.trackers {
-			if tracker, exists := newTrackers[hash]; exists {
-				tracker.messageIDs = oldTracker.messageIDs
-				// preserve timestamps from old tracker if not set
-				if tracker.firstSeen.IsZero() && !oldTracker.firstSeen.IsZero() {
-					tracker.firstSeen = oldTracker.firstSeen
-				}
-				newTrackers[hash] = tracker
-			}
-		}
+		// use shared filtering logic (rebuilds trackers with messageIDs from entries)
+		filtered, newTrackers := d.filterExpiredEntries(history.entries, now)
 
 		if len(filtered) == 0 {
 			// remove user from cache if no entries left


### PR DESCRIPTION
**Summary**
- fixes bug where users editing messages multiple times were incorrectly banned as duplicate spammers
- message edits now detected by checking if messageID already exists for a hash
- edits only update lastSeen timestamp without incrementing duplicate counter

**Changes**
- lib/tgspam/duplicate.go: add edit detection logic before incrementing duplicate count
- lib/tgspam/duplicate_test.go: add test case that reproduces the bug and verifies the fix

**Testing**
- added TestDuplicateDetector_EditedMessagesShouldNotTriggerSpam test case
- verified all existing tests still pass
- confirmed real duplicates (different messageIDs) still trigger spam detection correctly