### PR TITLE
fix CI workflow caching by reordering checkout and setup-go steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,14 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
+    - name: checkout
+      uses: actions/checkout@v4
 
-    - name: set up go 1.25
+    - name: set up go
       uses: actions/setup-go@v5
       with:
         go-version: "1.25"
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: free disk space
       run: |


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- Normalize step naming