### PR TITLE
feat(meta): add contact-only spam check

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ This option is disabled by default. If `--meta.video-only` set or `env:META_VIDE
 
 This option is disabled by default. If `--meta.audio-only` set or `env:META_AUDIO_ONLY` is `true`, the bot will check the message for the presence of any audio files. If the message contains audio files but no text, it will be marked as spam.
 
+**Contact only check**
+
+This option is disabled by default. If `--meta.contact-only` set or `env:META_CONTACT_ONLY` is `true`, the bot will check the message for the presence of shared contacts (vCards). If the message contains a shared contact but no text, it will be marked as spam.
+
 **Forward check**
 
 This option is disabled by default. If `--meta.forward` set or `env:META_FORWARD` is `true`, the bot will check if the message forwarded. If the message is a forward, it will be marked as spam.
@@ -480,6 +484,7 @@ meta:
       --meta.links-only                 enable links only check [$META_LINKS_ONLY]
       --meta.video-only                 enable video only check [$META_VIDEO_ONLY]
       --meta.audio-only                 enable audio only check [$META_AUDIO_ONLY]
+      --meta.contact-only               enable contact only check [$META_CONTACT_ONLY]
       --meta.forward                    enable forward check [$META_FORWARD]
       --meta.keyboard                   enable keyboard check [$META_KEYBOARD]
       --meta.username-symbols=          prohibited symbols in username, disabled by default [$META_USERNAME_SYMBOLS]

--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -60,6 +60,7 @@ type Message struct {
 	WithForward   bool `json:",omitempty"`
 	WithAudio     bool `json:",omitempty"`
 	WithKeyboard  bool `json:",omitempty"`
+	WithContact   bool `json:",omitempty"`
 }
 
 // Entity represents one special entity in a text message.

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -95,6 +95,9 @@ func (s *SpamFilter) OnMessage(msg Message, checkOnly bool) (response Response) 
 	if msg.WithKeyboard {
 		spamReq.Meta.HasKeyboard = true
 	}
+	if msg.WithContact {
+		spamReq.Meta.HasContact = true
+	}
 	spamReq.Meta.Links = strings.Count(msg.Text, "http://") + strings.Count(msg.Text, "https://")
 	spamReq.Meta.MessageID = msg.ID
 

--- a/app/events/events.go
+++ b/app/events/events.go
@@ -360,6 +360,9 @@ func transform(msg *tbapi.Message) *bot.Message {
 	if msg.ReplyMarkup != nil { // detect attached keyboards/buttons
 		message.WithKeyboard = true
 	}
+	if msg.Contact != nil {
+		message.WithContact = true
+	}
 
 	// handle reply-to message if present
 	if msg.ReplyToMessage != nil {

--- a/app/main.go
+++ b/app/main.go
@@ -86,6 +86,7 @@ type options struct {
 		LinksOnly       bool   `long:"links-only" env:"LINKS_ONLY" description:"enable links only check"`
 		VideosOnly      bool   `long:"video-only" env:"VIDEO_ONLY" description:"enable video only check"`
 		AudiosOnly      bool   `long:"audio-only" env:"AUDIO_ONLY" description:"enable audio only check"`
+		ContactOnly     bool   `long:"contact-only" env:"CONTACT_ONLY" description:"enable contact only check"`
 		Forward         bool   `long:"forward" env:"FORWARD" description:"enable forward check"`
 		Keyboard        bool   `long:"keyboard" env:"KEYBOARD" description:"enable keyboard check"`
 		UsernameSymbols string `long:"username-symbols" env:"USERNAME_SYMBOLS" description:"prohibited symbols in username, disabled by default"`
@@ -508,7 +509,7 @@ func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *
 		StorageTimeout:           opts.StorageTimeout,
 		NoSpamReply:              opts.NoSpamReply,
 		CasEnabled:               opts.CAS.API != "",
-		MetaEnabled:              opts.Meta.ImageOnly || opts.Meta.LinksLimit >= 0 || opts.Meta.MentionsLimit >= 0 || opts.Meta.LinksOnly || opts.Meta.VideosOnly || opts.Meta.AudiosOnly || opts.Meta.Forward || opts.Meta.Keyboard || opts.Meta.UsernameSymbols != "",
+		MetaEnabled:              opts.Meta.ImageOnly || opts.Meta.LinksLimit >= 0 || opts.Meta.MentionsLimit >= 0 || opts.Meta.LinksOnly || opts.Meta.VideosOnly || opts.Meta.AudiosOnly || opts.Meta.ContactOnly || opts.Meta.Forward || opts.Meta.Keyboard || opts.Meta.UsernameSymbols != "",
 		MetaLinksLimit:           opts.Meta.LinksLimit,
 		MetaMentionsLimit:        opts.Meta.MentionsLimit,
 		MetaLinksOnly:            opts.Meta.LinksOnly,
@@ -517,6 +518,7 @@ func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *
 		MetaAudioOnly:            opts.Meta.AudiosOnly,
 		MetaForwarded:            opts.Meta.Forward,
 		MetaKeyboard:             opts.Meta.Keyboard,
+		MetaContactOnly:          opts.Meta.ContactOnly,
 		MetaUsernameSymbols:      opts.Meta.UsernameSymbols,
 		MultiLangLimit:           opts.MultiLangWords,
 		OpenAIEnabled:            opts.OpenAI.Token != "" || opts.OpenAI.APIBase != "",
@@ -672,6 +674,10 @@ func makeDetector(opts options) *tgspam.Detector {
 	if opts.Meta.Keyboard {
 		log.Printf("[INFO] keyboard check enabled")
 		metaChecks = append(metaChecks, tgspam.KeyboardCheck())
+	}
+	if opts.Meta.ContactOnly {
+		log.Printf("[INFO] contact only check enabled")
+		metaChecks = append(metaChecks, tgspam.ContactCheck())
 	}
 	if opts.Meta.UsernameSymbols != "" {
 		log.Printf("[INFO] username symbols check enabled, prohibited symbols: %q", opts.Meta.UsernameSymbols)

--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -161,6 +161,7 @@
                         <tr><th>Meta Video Only</th><td>{{.MetaVideoOnly}}</td></tr>
                         <tr><th>Meta Audio Only</th><td>{{.MetaAudioOnly}}</td></tr>
                         <tr><th>Meta Keyboard</th><td>{{.MetaKeyboard}}</td></tr>
+                        <tr><th>Meta Contact Only</th><td>{{.MetaContactOnly}}</td></tr>
                         <tr><th>Meta Username Symbols</th><td>{{if eq .MetaUsernameSymbols ""}}disabled{{else}}{{.MetaUsernameSymbols}}{{end}}</td></tr>
                     </tbody>
                 </table>

--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -87,6 +87,7 @@ type Settings struct {
 	MetaAudioOnly            bool          `json:"meta_audio_only"`
 	MetaForwarded            bool          `json:"meta_forwarded"`
 	MetaKeyboard             bool          `json:"meta_keyboard"`
+	MetaContactOnly          bool          `json:"meta_contact_only"`
 	MetaUsernameSymbols      string        `json:"meta_username_symbols"`
 	MultiLangLimit           int           `json:"multi_lang_limit"`
 	OpenAIEnabled            bool          `json:"openai_enabled"`

--- a/lib/spamcheck/spamcheck.go
+++ b/lib/spamcheck/spamcheck.go
@@ -23,12 +23,13 @@ type MetaData struct {
 	HasAudio    bool `json:"has_audio"`    // true if the message has an audio
 	HasForward  bool `json:"has_forward"`  // true if the message has a forward
 	HasKeyboard bool `json:"has_keyboard"` // true if the message has a keyboard (buttons)
+	HasContact  bool `json:"has_contact"`  // true if the message has a shared contact
 	MessageID   int  `json:"message_id"`   // telegram message ID
 }
 
 func (r *Request) String() string {
-	return fmt.Sprintf("msg:%q, user:%q, id:%s, images:%d, links:%d, mentions:%d, has_video:%v, has_audio:%v, has_forward:%v, has_keyboard:%v",
-		r.Msg, r.UserName, r.UserID, r.Meta.Images, r.Meta.Links, r.Meta.Mentions, r.Meta.HasVideo, r.Meta.HasAudio, r.Meta.HasForward, r.Meta.HasKeyboard)
+	return fmt.Sprintf("msg:%q, user:%q, id:%s, images:%d, links:%d, mentions:%d, has_video:%v, has_audio:%v, has_forward:%v, has_keyboard:%v, has_contact:%v",
+		r.Msg, r.UserName, r.UserID, r.Meta.Images, r.Meta.Links, r.Meta.Mentions, r.Meta.HasVideo, r.Meta.HasAudio, r.Meta.HasForward, r.Meta.HasKeyboard, r.Meta.HasContact)
 }
 
 // Response is a result of spam check.

--- a/lib/spamcheck/spamcheck_test.go
+++ b/lib/spamcheck/spamcheck_test.go
@@ -52,7 +52,7 @@ func TestRequestString(t *testing.T) {
 				Msg: "Hello, world!", UserID: "123", UserName: "Alice", Meta: MetaData{
 					Images: 2, Links: 1, Mentions: 0, HasVideo: false, HasAudio: false, HasForward: false, HasKeyboard: false,
 				}, CheckOnly: false},
-			expected: `msg:"Hello, world!", user:"Alice", id:123, images:2, links:1, mentions:0, has_video:false, has_audio:false, has_forward:false, has_keyboard:false`,
+			expected: `msg:"Hello, world!", user:"Alice", id:123, images:2, links:1, mentions:0, has_video:false, has_audio:false, has_forward:false, has_keyboard:false, has_contact:false`,
 		},
 		{
 			name: "Spam message",
@@ -60,12 +60,12 @@ func TestRequestString(t *testing.T) {
 				Msg: "Spam message", UserID: "456", UserName: "Bob", Meta: MetaData{
 					Images: 0, Links: 3, Mentions: 2, HasVideo: true, HasAudio: false, HasForward: false, HasKeyboard: false,
 				}, CheckOnly: true},
-			expected: `msg:"Spam message", user:"Bob", id:456, images:0, links:3, mentions:2, has_video:true, has_audio:false, has_forward:false, has_keyboard:false`,
+			expected: `msg:"Spam message", user:"Bob", id:456, images:0, links:3, mentions:2, has_video:true, has_audio:false, has_forward:false, has_keyboard:false, has_contact:false`,
 		},
 		{
 			name:     "Empty fields",
 			request:  Request{Msg: "", UserID: "", UserName: "", Meta: MetaData{}, CheckOnly: false},
-			expected: `msg:"", user:"", id:, images:0, links:0, mentions:0, has_video:false, has_audio:false, has_forward:false, has_keyboard:false`,
+			expected: `msg:"", user:"", id:, images:0, links:0, mentions:0, has_video:false, has_audio:false, has_forward:false, has_keyboard:false, has_contact:false`,
 		},
 	}
 

--- a/lib/tgspam/metachecks.go
+++ b/lib/tgspam/metachecks.go
@@ -102,6 +102,21 @@ func AudioCheck() MetaCheck {
 	}
 }
 
+// ContactCheck is a function that returns a MetaCheck function.
+// It checks if the message has a shared contact and the message is empty (i.e. it contains only contact).
+func ContactCheck() MetaCheck {
+	return func(req spamcheck.Request) spamcheck.Response {
+		if req.Meta.HasContact && req.Msg == "" {
+			return spamcheck.Response{
+				Name:    "contact",
+				Spam:    true,
+				Details: "contact without text",
+			}
+		}
+		return spamcheck.Response{Spam: false, Name: "contact", Details: "no contact without text"}
+	}
+}
+
 // ForwardedCheck is a function that returns a MetaCheck function.
 // It checks if the message is a forwarded message.
 func ForwardedCheck() MetaCheck {

--- a/lib/tgspam/metachecks_test.go
+++ b/lib/tgspam/metachecks_test.go
@@ -342,6 +342,37 @@ func TestAudioCheck(t *testing.T) {
 	}
 }
 
+func TestContactCheck(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      spamcheck.Request
+		expected spamcheck.Response
+	}{
+		{
+			name:     "no contact and text",
+			req:      spamcheck.Request{Msg: "This is a message with text.", Meta: spamcheck.MetaData{HasContact: false}},
+			expected: spamcheck.Response{Name: "contact", Spam: false, Details: "no contact without text"},
+		},
+		{
+			name:     "contact with text",
+			req:      spamcheck.Request{Msg: "This is a message with text and a contact.", Meta: spamcheck.MetaData{HasContact: true}},
+			expected: spamcheck.Response{Name: "contact", Spam: false, Details: "no contact without text"},
+		},
+		{
+			name:     "contact without text",
+			req:      spamcheck.Request{Msg: "", Meta: spamcheck.MetaData{HasContact: true}},
+			expected: spamcheck.Response{Name: "contact", Spam: true, Details: "contact without text"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := ContactCheck()
+			assert.Equal(t, tt.expected, check(tt.req))
+		})
+	}
+}
+
 func TestKeyboardCheck(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
**Summary**

Add `--meta.contact-only` option to detect messages containing only shared contacts (vCards) without text - a spam pattern where bots post contact cards with phone numbers.

**Changes:**
- Added `WithContact` field to `bot.Message` struct
- Added `HasContact` field to `spamcheck.MetaData` struct  
- Added `ContactCheck()` function in metachecks.go
- Added CLI flag `--meta.contact-only` / `META_CONTACT_ONLY`
- Updated web UI settings page
- Added tests and documentation

**Usage:**
```bash
--meta.contact-only  # CLI flag
META_CONTACT_ONLY=true  # env variable
```

Related to #354