### PR TITLE
fix(bot): count mentions from image caption entities

### DIFF
--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -104,9 +104,16 @@ func (s *SpamFilter) OnMessage(msg Message, checkOnly bool) (response Response) 
 	spamReq.Meta.Links = strings.Count(msg.Text, "http://") + strings.Count(msg.Text, "https://")
 	spamReq.Meta.MessageID = msg.ID
 
-	// count mentions from entities
+	// count mentions from entities (both regular and caption entities)
 	if msg.Entities != nil {
 		for _, entity := range *msg.Entities {
+			if entity.Type == "mention" || entity.Type == "text_mention" {
+				spamReq.Meta.Mentions++
+			}
+		}
+	}
+	if msg.Image != nil && msg.Image.Entities != nil {
+		for _, entity := range *msg.Image.Entities {
 			if entity.Type == "mention" || entity.Type == "text_mention" {
 				spamReq.Meta.Mentions++
 			}


### PR DESCRIPTION
Previously, mentions were only counted from regular message entities. Messages with images that have captions (like forwarded messages with @username in the caption) were not detecting mentions since Telegram uses CaptionEntities for those, stored in Image.Entities.

**Changes:**
- `app/bot/spam.go` - also count mentions from `msg.Image.Entities`
- Added test cases for text mentions, image caption mentions, and combined scenarios