### PR TITLE
fix(bot): count links from url and text_link entities

### DIFF
--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -104,18 +104,24 @@ func (s *SpamFilter) OnMessage(msg Message, checkOnly bool) (response Response) 
 	spamReq.Meta.Links = strings.Count(msg.Text, "http://") + strings.Count(msg.Text, "https://")
 	spamReq.Meta.MessageID = msg.ID
 
-	// count mentions from entities (both regular and caption entities)
+	// count mentions and links from entities (both regular and caption entities)
 	if msg.Entities != nil {
 		for _, entity := range *msg.Entities {
-			if entity.Type == "mention" || entity.Type == "text_mention" {
+			switch entity.Type {
+			case "mention", "text_mention":
 				spamReq.Meta.Mentions++
+			case "url", "text_link":
+				spamReq.Meta.Links++
 			}
 		}
 	}
 	if msg.Image != nil && msg.Image.Entities != nil {
 		for _, entity := range *msg.Image.Entities {
-			if entity.Type == "mention" || entity.Type == "text_mention" {
+			switch entity.Type {
+			case "mention", "text_mention":
 				spamReq.Meta.Mentions++
+			case "url", "text_link":
+				spamReq.Meta.Links++
 			}
 		}
 	}


### PR DESCRIPTION
Links were only counted by searching for `http://` in text. Now also counts `url` and `text_link` entities from both message and image caption entities.

This catches clickable links where displayed text differs from the URL (e.g., "НАЖМИТЕ НА ЭТОТ ТЕКСТ" linking to example.com).

**Changes:**
- `app/bot/spam.go` - count links from `url` and `text_link` entities in both `msg.Entities` and `msg.Image.Entities`
- Added test cases for url entities, text_link entities, and combined scenarios