### PR TITLE
fix channel ban - use SenderChat for ban and locator tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ tg-spam
 tg-spam-*
 _examples/lua_plugins/example
 docs/prompts/
+
+# ralphex progress logs
+.ralphex/progress/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,14 @@
 - The concatenation uses newline separator: `msg.Text + "\n" + msg.Quote`
 - Empty quote/reply-to text is ignored (no extra newline added)
 
+### Channel Message Handling
+- When a channel posts in a group, Telegram uses a shared fake user `Channel_Bot` (ID `136817688`) in `msg.From`
+- The actual channel identity is in `msg.SenderChat` with unique ID and username
+- `SenderChat.ID` is used for locator tracking (`AddMessage`, `AddSpam`), and for banning via `BanChatSenderChatConfig`
+- `bot.OnMessage` sets `Response.ChannelID = msg.SenderChat.ID` when SenderChat is present
+- Admin `/spam` command (`directReport`) detects `origMsg.SenderChat` and passes channel ID for ban and cleanup
+- Anonymous admin posts (where `SenderChat.ID == group chat ID`) skip spam check entirely
+
 ### ExtraDeleteIDs Feature
 - `spamcheck.Response` includes `ExtraDeleteIDs []int` field for additional message IDs to delete when spam is detected
 - Any spam checker can populate this field to request deletion of related messages

--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -19,7 +19,7 @@ type Response struct {
 	Send          bool                 // status
 	BanInterval   time.Duration        // bots banning user set the interval
 	User          User                 // user to ban
-	ChannelID     int64                // channel to ban, if set then User and BanInterval are ignored
+	ChannelID     int64                // channel to ban via BanChatSenderChatConfig, if set then User is ignored
 	ReplyTo       int                  // message to reply to, if 0 then no reply but common message
 	DeleteReplyTo bool                 // delete message what bot replays to
 	CheckResults  []spamcheck.Response // check results for the message

--- a/app/bot/spam_test.go
+++ b/app/bot/spam_test.go
@@ -454,6 +454,24 @@ func TestSpamFilter_OnMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "spam detected from channel message",
+			message: Message{
+				Text:       "spam message",
+				From:       User{ID: 136817688, Username: "Channel_Bot"},
+				SenderChat: SenderChat{ID: 12345, UserName: "spam_channel"},
+			},
+			wantResponse: Response{
+				Text:          `detected: "Channel_Bot" (136817688)`,
+				Send:          true,
+				BanInterval:   PermanentBanDuration,
+				DeleteReplyTo: true,
+				User:          User{ID: 136817688, Username: "Channel_Bot"},
+				ChannelID:     12345,
+				CheckResults:  []spamcheck.Response{{Name: "test", Spam: true, Details: "spam"}},
+			},
+			wantRequest: spamcheck.Request{Msg: "spam message", UserID: "12345", UserName: "spam_channel"},
+		},
+		{
 			name: "both Quote and ReplyTo.Text present - Quote takes precedence",
 			message: Message{
 				Text:  "check this",

--- a/app/events/events_test.go
+++ b/app/events/events_test.go
@@ -876,6 +876,8 @@ func Test_parseCallbackData(t *testing.T) {
 		{"valid prefix R? with valid data", "R?12345:678", 12345, 678, false},
 		{"valid prefix R! with valid data", "R!12345:678", 12345, 678, false},
 		{"valid prefix RX with valid data", "RX12345:678", 12345, 678, false},
+		{"negative channel ID", "-100123456:678", -100123456, 678, false},
+		{"negative channel ID with prefix", "?-100123456:678", -100123456, 678, false},
 	}
 
 	for _, tt := range tests {
@@ -888,6 +890,23 @@ func Test_parseCallbackData(t *testing.T) {
 				assert.Equal(t, tt.wantUserID, gotUserID)
 				assert.Equal(t, tt.wantMsgID, gotMsgID)
 			}
+		})
+	}
+}
+
+func Test_channelIDFromCallback(t *testing.T) {
+	tests := []struct {
+		name string
+		id   int64
+		want int64
+	}{
+		{"positive user ID", 12345, 0},
+		{"zero ID", 0, 0},
+		{"negative channel ID", -100123456, -100123456},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, channelIDFromCallback(tt.id))
 		})
 	}
 }


### PR DESCRIPTION
When a channel posts in a group, Telegram uses a shared fake user `Channel_Bot` (ID `136817688`) in `msg.From`. The actual channel identity is in `msg.SenderChat`. The ban infrastructure (`BanChatSenderChatConfig`) existed but was never reached because `ChannelID` was never set in the spam response.

**what changed:**
- `bot.OnMessage` now sets `Response.ChannelID = msg.SenderChat.ID` and uses channel identity for spam check request
- admin `/spam` command detects `origMsg.SenderChat` and passes channel ID for ban and cleanup
- locator stores channel ID/username instead of the shared Channel_Bot identity
- callback handlers (ban/unban buttons) route negative IDs to channel-specific API calls
- anonymous admin posts (SenderChat.ID == group chat ID) are protected from accidental bans
- nil-dereference fix in `getBanUsername` when `ReplyToMessage` is nil for direct channel posts

Related to #370