### PR TITLE
Wrap webapi router with http.CrossOriginProtection for CSRF defence

### DIFF
--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -200,6 +200,7 @@ func (s *Server) Run(ctx context.Context) error {
 	router.Use(rest.AppInfo("tg-spam", "umputun", s.Version), rest.Ping)
 	router.Use(tollbooth.HTTPMiddleware(tollbooth.NewLimiter(50, nil)))
 	router.Use(rest.SizeLimit(1024 * 1024)) // 1M max request size
+	router.Use(http.NewCrossOriginProtection().Handler)
 
 	if s.AuthPasswd != "" || s.AuthHash != "" {
 		log.Printf("[INFO] basic auth enabled for webapi server")

--- a/app/webapi/webapi_test.go
+++ b/app/webapi/webapi_test.go
@@ -59,6 +59,76 @@ func TestServer_Run(t *testing.T) {
 	<-done
 }
 
+func TestServer_RunCrossOriginProtection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := NewServer(Config{ListenAddr: ":9879", Version: "dev",
+		Detector: &mocks.DetectorMock{
+			CheckFunc: func(spamcheck.Request) (bool, []spamcheck.Response) { return false, nil },
+		},
+		SpamFilter: &mocks.SpamFilterMock{}, AuthPasswd: "test"})
+	done := make(chan struct{})
+	go func() {
+		err := srv.Run(ctx)
+		assert.NoError(t, err)
+		close(done)
+	}()
+	t.Cleanup(func() { cancel(); <-done })
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://localhost:9879/ping")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 50*time.Millisecond, "server did not start")
+
+	tests := []struct {
+		name          string
+		method        string
+		path          string
+		secFetchSite  string
+		origin        string
+		wantForbidden bool
+	}{
+		{name: "GET ping allowed without headers", method: "GET", path: "/ping"},
+		{name: "POST same-origin allowed", method: "POST", path: "/check", secFetchSite: "same-origin"},
+		{name: "POST none allowed (direct nav)", method: "POST", path: "/check", secFetchSite: "none"},
+		{name: "POST cross-site rejected", method: "POST", path: "/check",
+			secFetchSite: "cross-site", wantForbidden: true},
+		{name: "POST same-site rejected (subdomain)", method: "POST", path: "/check",
+			secFetchSite: "same-site", wantForbidden: true},
+		{name: "POST origin mismatch rejected", method: "POST", path: "/check",
+			origin: "http://evil.com", wantForbidden: true},
+		{name: "POST no headers (non-browser) allowed", method: "POST", path: "/check"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := bytes.NewBufferString(`{"msg":"x"}`)
+			req, err := http.NewRequest(tt.method, "http://localhost:9879"+tt.path, body)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.SetBasicAuth("tg-spam", "test")
+			if tt.secFetchSite != "" {
+				req.Header.Set("Sec-Fetch-Site", tt.secFetchSite)
+			}
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			if tt.wantForbidden {
+				assert.Equal(t, http.StatusForbidden, resp.StatusCode, "should be rejected as cross-origin")
+				return
+			}
+			assert.NotEqual(t, http.StatusForbidden, resp.StatusCode, "should not be rejected as cross-origin")
+		})
+	}
+}
+
 func TestServer_RunAuth(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Adds Go 1.25's `http.NewCrossOriginProtection().Handler` to the webapi global middleware chain in `app/webapi/webapi.go`. One line of code, ~70 lines of test.

### Why

The webapi has an htmx UI that issues many state-changing requests behind HTTP basic auth: `POST /spam`, `POST /ham`, `POST /users/add`, `POST /users/delete`, `POST /dictionary/add`, `POST /dictionary/delete`, `POST /detected_spam/add`, `PUT /samples`, etc. Basic auth credentials are cached by the browser and automatically replayed on _any_ request to the realm -- including cross-origin POSTs from a malicious page. There was previously no defence against this.

`http.CrossOriginProtection` checks the browser-set `Sec-Fetch-Site` header (a [forbidden header](https://fetch.spec.whatwg.org/#forbidden-header-name) JS cannot forge, shipped in all major browsers since 2023) with an `Origin` vs `Host` fallback for older clients. OWASP elevated this algorithm from defence-in-depth to a primary CSRF defence in [its cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) in December 2025.

### What changed

- `app/webapi/webapi.go` -- one line in the `router.Use(...)` block in `Run()`
- `app/webapi/webapi_test.go` -- new `TestServer_RunCrossOriginProtection` covering same-origin / cross-site / origin-host-mismatch / non-browser cases

### Behaviour notes

- HTMX-driven POSTs from the webUI run as same-origin requests, so `Sec-Fetch-Site: same-origin` is sent and the middleware passes them through. Verified end-to-end via the new test.
- API consumers (curl, scripts, server-to-server) do not send `Sec-Fetch-Site` -- the middleware treats this as a non-browser request and lets them through. Existing API integrations are unaffected.
- A cross-origin browser POST to any state-changing endpoint (e.g. an attacker page issuing `fetch()` against `/spam`) is now rejected with 403 before the basic auth credentials reach the handler.

### References

- [Go 1.25 release notes -- net/http.CrossOriginProtection](https://go.dev/doc/go1.25#nethttppkgnethttp)
- [pkg.go.dev -- http.CrossOriginProtection](https://pkg.go.dev/net/http#CrossOriginProtection)
- Filippo Valsorda, [Cross-Site Request Forgery](https://words.filippo.io/csrf/) -- the research the stdlib middleware is based on
- [OWASP CSRF Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) -- Fetch Metadata as primary defence
- [Datasette PR #2689](https://github.com/simonw/datasette/pull/2689) -- production migration off CSRF tokens to this algorithm in April 2026