### PR TITLE
fix(server): skip random password when SERVER_AUTH_HASH is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,9 +657,9 @@ Pls note: Missed spam messages forwarded to the admin chat will be banned and re
 
 The bot can be run with a webapi server. This is useful for integration with other tools. The server is disabled by default, to enable it pass `--server.enabled [$SERVER_ENABLED]`. The server will listen on the port specified by `--server.listen [$SERVER_LISTEN]` parameter (default is `:8080`).
 
-By default, the server is protected by basic auth with user `tg-spam` and randomly generated password. This password and the hash are printed to the console on startup. If user wants to set a custom auth password, it can be done with `--server.auth [$SERVER_AUTH]` parameter. Setting it to empty string will disable basic auth protection. 
+By default, the server is protected by basic auth with user `tg-spam` and randomly generated password. This password is printed to the console on startup. If user wants to set a custom auth password, it can be done with `--server.auth [$SERVER_AUTH]` parameter. Setting it to empty string will disable basic auth protection. 
 
-For better security, it is possible to set the password hash instead, with `--server.auth-hash [$SERVER_AUTH_HASH]` parameter. The hash should be generated with any command what can make bcrypt hash. For example, the following command will generate a hash for the password `your_password`: `htpasswd -n -B -b tg-spam your_password | cut -d':' -f2`
+For better security, it is possible to set the password hash instead, with `--server.auth-hash [$SERVER_AUTH_HASH]` parameter. Setting `--server.auth-hash` alone is sufficient — when a hash is provided, no random password is generated regardless of `--server.auth`, and only hash-based auth is enforced. The hash should be generated with any command what can make bcrypt hash. For example, the following command will generate a hash for the password `your_password`: `htpasswd -n -B -b tg-spam your_password | cut -d':' -f2`
 
 alternatively, it is possible to use one of the following commands to generate the hash:
 ```

--- a/app/main.go
+++ b/app/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/go-pkgz/fileutils"
 	"github.com/go-pkgz/lgr"
-	"github.com/go-pkgz/rest"
 	"github.com/jessevdk/go-flags"
 	"github.com/sashabaranov/go-openai"
 	"google.golang.org/genai"
@@ -508,16 +507,17 @@ func checkVolumeMount(opts options) (ok bool) {
 func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *storage.Locator,
 	db *engine.SQL, dmUsersProvider webapi.DMUsersProvider, botUsername string) (err error) {
 	authPassswd := opts.Server.AuthPasswd
-	if opts.Server.AuthPasswd == "auto" {
+	switch {
+	case opts.Server.AuthHash != "":
+		// user supplied a bcrypt hash; leave password empty so the inner
+		// authMiddleware short-circuits and only hash auth is enforced.
+		authPassswd = ""
+	case opts.Server.AuthPasswd == "auto":
 		authPassswd, err = webapi.GenerateRandomPassword(20)
 		if err != nil {
 			return fmt.Errorf("can't generate random password, %w", err)
 		}
-		authHash, err := rest.GenerateBcryptHash(authPassswd)
-		if err != nil {
-			return fmt.Errorf("can't generate bcrypt hash for password, %w", err)
-		}
-		log.Printf("[WARN] generated basic auth password for user tg-spam: %q, bcrypt hash: %s", authPassswd, authHash)
+		log.Printf("[WARN] generated basic auth password for user tg-spam: %q", authPassswd)
 	}
 
 	// make store and load approved users

--- a/app/main.go
+++ b/app/main.go
@@ -509,8 +509,10 @@ func activateServer(ctx context.Context, opts options, sf *bot.SpamFilter, loc *
 	authPassswd := opts.Server.AuthPasswd
 	switch {
 	case opts.Server.AuthHash != "":
-		// user supplied a bcrypt hash; leave password empty so the inner
-		// authMiddleware short-circuits and only hash auth is enforced.
+		// user supplied a bcrypt hash; leave password empty. the outer router
+		// already enforces the hash via BasicAuthWithBcryptHashAndPrompt, and
+		// authMiddleware is bypassed whenever AuthPasswd is empty, avoiding
+		// a second (unknown) password check on inner routes.
 		authPassswd = ""
 	case opts.Server.AuthPasswd == "auto":
 		authPassswd, err = webapi.GenerateRandomPassword(20)

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -264,21 +264,99 @@ func Test_activateServerOnly(t *testing.T) {
 }
 
 func Test_activateServerAuthHashOnly(t *testing.T) {
-	// regression for issue #381: when SERVER_AUTH is left at default "auto" but
-	// SERVER_AUTH_HASH is explicitly set, the server must not generate a random
-	// password; hash-based auth alone must work end-to-end (including inner
-	// authMiddleware on /, /check, etc.).
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+	// regression for issue #381: SERVER_AUTH left at default "auto" with
+	// SERVER_AUTH_HASH explicitly set must authenticate via hash alone, both
+	// on the webUI and on authApi routes.
 	const knownPassword = "secret-known-pass"
 	authHash, err := rest.GenerateBcryptHash(knownPassword)
 	require.NoError(t, err)
 
+	baseURL := runActivateServerForTest(t, ":9989", "auto", authHash)
+
+	t.Run("webUI correct password accepted", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/", http.NoBody)
+		require.NoError(t, err)
+		req.SetBasicAuth("tg-spam", knownPassword)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("webUI wrong password rejected", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/", http.NoBody)
+		require.NoError(t, err)
+		req.SetBasicAuth("tg-spam", "wrong-password")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("authApi correct password accepted", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/settings", http.NoBody)
+		require.NoError(t, err)
+		req.SetBasicAuth("tg-spam", knownPassword)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("authApi wrong password rejected", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/settings", http.NoBody)
+		require.NoError(t, err)
+		req.SetBasicAuth("tg-spam", "wrong-password")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func Test_activateServerAuthHashOverridesExplicitPasswd(t *testing.T) {
+	// when both SERVER_AUTH (explicit) and SERVER_AUTH_HASH are set, hash wins:
+	// the explicit password must not be accepted, only the hash-matching one.
+	const knownPassword = "hash-matching-pass"
+	const explicitPassword = "ignored-explicit-pass"
+	authHash, err := rest.GenerateBcryptHash(knownPassword)
+	require.NoError(t, err)
+
+	baseURL := runActivateServerForTest(t, ":9990", explicitPassword, authHash)
+
+	t.Run("hash-matching password accepted", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/", http.NoBody)
+		require.NoError(t, err)
+		req.SetBasicAuth("tg-spam", knownPassword)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("explicit password ignored", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/", http.NoBody)
+		require.NoError(t, err)
+		req.SetBasicAuth("tg-spam", explicitPassword)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+// runActivateServerForTest boots the full execute() flow with a minimal set of
+// options sufficient for web-server-only mode, waits for /ping to respond, and
+// returns the base URL. Cleanup (context cancel + goroutine join) is registered
+// via t.Cleanup.
+func runActivateServerForTest(t *testing.T, listenAddr, authPasswd, authHash string) string {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
 	var opts options
 	opts.Server.Enabled = true
-	opts.Server.ListenAddr = ":9989"
-	opts.Server.AuthPasswd = "auto" // default, simulates SERVER_AUTH unset
+	opts.Server.ListenAddr = listenAddr
+	opts.Server.AuthPasswd = authPasswd
 	opts.Server.AuthHash = authHash
 	opts.InstanceID = "gr1"
 	opts.DataBaseURL = fmt.Sprintf("sqlite://%s", path.Join(t.TempDir(), "tg-spam.db"))
@@ -288,13 +366,13 @@ func Test_activateServerAuthHashOnly(t *testing.T) {
 	require.NoError(t, err)
 	_, err = fh.WriteString("spam1\nspam2\nspam3\n")
 	require.NoError(t, err)
-	fh.Close()
+	require.NoError(t, fh.Close())
 
 	fh, err = os.Create(path.Join(opts.Files.SamplesDataPath, "ham-samples.txt"))
 	require.NoError(t, err)
 	_, err = fh.WriteString("ham1\nham2\nham3\n")
 	require.NoError(t, err)
-	fh.Close()
+	require.NoError(t, fh.Close())
 
 	done := make(chan struct{})
 	go func() {
@@ -302,9 +380,14 @@ func Test_activateServerAuthHashOnly(t *testing.T) {
 		assert.NoError(t, execErr)
 		close(done)
 	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
 
+	baseURL := "http://localhost" + listenAddr
 	require.Eventually(t, func() bool {
-		pingResp, pingErr := http.Get("http://localhost:9989/ping")
+		pingResp, pingErr := http.Get(baseURL + "/ping")
 		if pingErr != nil {
 			return false
 		}
@@ -312,19 +395,7 @@ func Test_activateServerAuthHashOnly(t *testing.T) {
 		return pingResp.StatusCode == http.StatusOK
 	}, time.Second*5, time.Millisecond*100, "server did not start")
 
-	// hit an authMiddleware-protected route with the password matching AuthHash;
-	// must succeed when the bug is fixed (401 today because inner middleware
-	// expects the random-generated password).
-	req, err := http.NewRequest(http.MethodGet, "http://localhost:9989/", http.NoBody)
-	require.NoError(t, err)
-	req.SetBasicAuth("tg-spam", knownPassword)
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode, "SERVER_AUTH_HASH-only config must not require the generated password")
-
-	cancel()
-	<-done
+	return baseURL
 }
 
 func Test_checkVolumeMount(t *testing.T) {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-pkgz/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -258,6 +259,70 @@ func Test_activateServerOnly(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "pong", string(body))
+	cancel()
+	<-done
+}
+
+func Test_activateServerAuthHashOnly(t *testing.T) {
+	// regression for issue #381: when SERVER_AUTH is left at default "auto" but
+	// SERVER_AUTH_HASH is explicitly set, the server must not generate a random
+	// password; hash-based auth alone must work end-to-end (including inner
+	// authMiddleware on /, /check, etc.).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const knownPassword = "secret-known-pass"
+	authHash, err := rest.GenerateBcryptHash(knownPassword)
+	require.NoError(t, err)
+
+	var opts options
+	opts.Server.Enabled = true
+	opts.Server.ListenAddr = ":9989"
+	opts.Server.AuthPasswd = "auto" // default, simulates SERVER_AUTH unset
+	opts.Server.AuthHash = authHash
+	opts.InstanceID = "gr1"
+	opts.DataBaseURL = fmt.Sprintf("sqlite://%s", path.Join(t.TempDir(), "tg-spam.db"))
+	opts.Files.SamplesDataPath, opts.Files.DynamicDataPath = t.TempDir(), t.TempDir()
+
+	fh, err := os.Create(path.Join(opts.Files.SamplesDataPath, "spam-samples.txt"))
+	require.NoError(t, err)
+	_, err = fh.WriteString("spam1\nspam2\nspam3\n")
+	require.NoError(t, err)
+	fh.Close()
+
+	fh, err = os.Create(path.Join(opts.Files.SamplesDataPath, "ham-samples.txt"))
+	require.NoError(t, err)
+	_, err = fh.WriteString("ham1\nham2\nham3\n")
+	require.NoError(t, err)
+	fh.Close()
+
+	done := make(chan struct{})
+	go func() {
+		execErr := execute(ctx, opts)
+		assert.NoError(t, execErr)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		pingResp, pingErr := http.Get("http://localhost:9989/ping")
+		if pingErr != nil {
+			return false
+		}
+		defer pingResp.Body.Close()
+		return pingResp.StatusCode == http.StatusOK
+	}, time.Second*5, time.Millisecond*100, "server did not start")
+
+	// hit an authMiddleware-protected route with the password matching AuthHash;
+	// must succeed when the bug is fixed (401 today because inner middleware
+	// expects the random-generated password).
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:9989/", http.NoBody)
+	require.NoError(t, err)
+	req.SetBasicAuth("tg-spam", knownPassword)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode, "SERVER_AUTH_HASH-only config must not require the generated password")
+
 	cancel()
 	<-done
 }


### PR DESCRIPTION
When `SERVER_AUTH` is left at the default `"auto"` but `SERVER_AUTH_HASH` is explicitly set, `activateServer` still generates a random plain password. The inner `authMiddleware` then requires that unknown password, breaking login to `/`, `/check`, and other gated routes when only AUTH_HASH is configured.

With `AuthHash` present, leave `authPassswd` empty so `authMiddleware` short-circuits and only bcrypt hash auth is enforced. Also drops a dead local `authHash` that was only logged, never used.

Added regression test `Test_activateServerAuthHashOnly` that exercises the full `execute` flow with AUTH_HASH set and AUTH unset — fails on master (401), passes with this change.

Fixes #381
