### PR TITLE
restore configurable basic-auth user

### DIFF
--- a/app/config/settings.go
+++ b/app/config/settings.go
@@ -209,6 +209,7 @@ type MessageSettings struct {
 type ServerSettings struct {
 	Enabled    bool   `json:"enabled" yaml:"enabled" db:"server_enabled"`
 	ListenAddr string `json:"listen_addr" yaml:"listen_addr" db:"server_listen_addr"`
+	AuthUser   string `json:"auth_user,omitempty" yaml:"auth_user,omitempty" db:"server_auth_user"`
 	AuthHash   string `json:"auth_hash" yaml:"auth_hash" db:"server_auth_hash"`
 }
 

--- a/app/main.go
+++ b/app/main.go
@@ -649,7 +649,8 @@ func activateServer(ctx context.Context, settings *config.Settings, sf *bot.Spam
 		Dictionary:      dictionaryStore,
 		StorageEngine:   db, // add database engine for backup functionality
 		DMUsersProvider: dmUsersProvider,
-		AuthHash:        authHash, // use the hash (either from options or generated)
+		AuthUser:        settings.Server.AuthUser, // optional basic auth user (defaults to "tg-spam" when empty)
+		AuthHash:        authHash,                 // use the hash (either from options or generated)
 		Version:         revision,
 		Dbg:             settings.Transient.Dbg,
 		BotUsername:     botUsername,

--- a/app/webapi/webapi.go
+++ b/app/webapi/webapi.go
@@ -73,7 +73,8 @@ type Config struct {
 	StorageEngine   StorageEngine    // database engine access for backups
 	DMUsersProvider DMUsersProvider  // provider for recent DM users
 	SettingsStore   SettingsStore    // configuration storage interface
-	AuthHash        string           // basic auth bcrypt hash for user "tg-spam"
+	AuthUser        string           // basic auth user; empty falls back to AppSettings.Server.AuthUser, then "tg-spam"
+	AuthHash        string           // basic auth bcrypt hash
 	Dbg             bool             // debug mode
 	BotUsername     string           // resolved telegram bot username
 	AppSettings     *config.Settings // application settings (domain model)
@@ -156,7 +157,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// a safety fallback if AppSettings hash is empty so a DB that lost the
 	// hash can't silently unlock the API.
 	if s.AuthHash != "" {
-		log.Printf("[INFO] basic auth enabled for webapi server (user: tg-spam)")
+		log.Printf("[INFO] basic auth enabled for webapi server (user: %s)", s.activeAuthUser())
 		router.Use(s.basicAuthMiddleware)
 	} else {
 		log.Printf("[WARN] basic auth disabled, access to webapi is not protected")
@@ -198,12 +199,14 @@ func (s *Server) basicAuthMiddleware(h http.Handler) http.Handler {
 	})
 }
 
-// checkBasicAuth returns true when user is "tg-spam" and passwd matches the
-// currently active bcrypt hash. The active hash is AppSettings.Server.AuthHash
-// when non-empty, else the startup AuthHash; startup serves as a safety
-// fallback so reloads that drop the DB hash can't unlock the server.
+// checkBasicAuth returns true when user matches the active auth user and
+// passwd matches the currently active bcrypt hash. The active user is
+// AppSettings.Server.AuthUser when non-empty, else the startup AuthUser, else
+// the historical default "tg-spam". The active hash follows the same precedence
+// over AuthHash; startup serves as a safety fallback so reloads that drop the
+// DB hash can't unlock the server.
 func (s *Server) checkBasicAuth(user, passwd string) bool {
-	if user != "tg-spam" {
+	if user != s.activeAuthUser() {
 		return false
 	}
 	hash := s.AuthHash
@@ -216,6 +219,22 @@ func (s *Server) checkBasicAuth(user, passwd string) bool {
 		return false
 	}
 	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(passwd)) == nil
+}
+
+// activeAuthUser returns the configured basic auth username with the same
+// precedence as the hash: settings -> startup -> "tg-spam" default.
+func (s *Server) activeAuthUser() string {
+	s.appSettingsMu.RLock()
+	if s.AppSettings != nil && s.AppSettings.Server.AuthUser != "" {
+		u := s.AppSettings.Server.AuthUser
+		s.appSettingsMu.RUnlock()
+		return u
+	}
+	s.appSettingsMu.RUnlock()
+	if s.AuthUser != "" {
+		return s.AuthUser
+	}
+	return "tg-spam"
 }
 
 func (s *Server) routes(router *routegroup.Bundle) *routegroup.Bundle {

--- a/app/webapi/webapi_test.go
+++ b/app/webapi/webapi_test.go
@@ -215,6 +215,31 @@ func TestServer_checkBasicAuth(t *testing.T) {
 		assert.False(t, srv.checkBasicAuth("tg-spam", ""))
 		assert.False(t, srv.checkBasicAuth("tg-spam", "anything"))
 	})
+
+	t.Run("AppSettings AuthUser overrides default", func(t *testing.T) {
+		srv := &Server{Config: Config{
+			AuthHash:    startupHash,
+			AppSettings: &config.Settings{Server: config.ServerSettings{AuthUser: "custom"}},
+		}}
+		assert.True(t, srv.checkBasicAuth("custom", "startup"))
+		assert.False(t, srv.checkBasicAuth("tg-spam", "startup"), "default must not work when AuthUser is set")
+	})
+
+	t.Run("startup AuthUser used when AppSettings empty", func(t *testing.T) {
+		srv := &Server{Config: Config{AuthUser: "startupuser", AuthHash: startupHash, AppSettings: &config.Settings{}}}
+		assert.True(t, srv.checkBasicAuth("startupuser", "startup"))
+		assert.False(t, srv.checkBasicAuth("tg-spam", "startup"))
+	})
+
+	t.Run("AppSettings AuthUser wins over startup", func(t *testing.T) {
+		srv := &Server{Config: Config{
+			AuthUser:    "startupuser",
+			AuthHash:    startupHash,
+			AppSettings: &config.Settings{Server: config.ServerSettings{AuthUser: "settingsuser"}},
+		}}
+		assert.True(t, srv.checkBasicAuth("settingsuser", "startup"))
+		assert.False(t, srv.checkBasicAuth("startupuser", "startup"))
+	})
 }
 
 func TestServer_routes(t *testing.T) {


### PR DESCRIPTION
## Why

Commit `b822cb1` (in the recent _fix: address code review findings_ squash) hardcoded the basic-auth username to the literal `"tg-spam"` inside `checkBasicAuth` and removed both `webapi.Server.AuthUser` and `ServerSettings.AuthUser`. Before that squash, the username was configurable via `s.AuthUser` and the runtime `rest.BasicAuthWithBcryptHashAndPrompt(s.AuthUser, s.AuthHash)` middleware honoured it.

That broke downstream deployments which run tg-spam in `--confdb` mode behind a reverse proxy with per-instance credentials. Concrete example: [tg-spam-manager](https://github.com/tg-spam/tg-spam-manager) creates one bot container per channel, each with a randomly generated `auth_user` written to the bot's settings DB. Existing installs store usernames like `tgsm-fa773b54`; the new tg-spam image silently rejects them with 401 (the dashboard iframe shows a basic-auth prompt), forcing manual SQL migration.

## What this PR does

- Re-adds `AuthUser` on `webapi.Server.Config` and on `config.ServerSettings` (with json/yaml/db tags, `omitempty` so existing JSON blobs deserialise unchanged).
- Threads it through `activateServer` in `app/main.go`.
- Replaces the hardcoded compare with `s.activeAuthUser()`, which picks settings → startup → `"tg-spam"` default with the same precedence already used for `AuthHash`.
- Updates the startup log line to print the actual username.

## Backwards compatibility

The `"tg-spam"` default kicks in whenever `AuthUser` is unset both in startup and in `AppSettings.Server` — so any existing deployment that never configured a username keeps working byte-for-byte the same as the post-squash behaviour. Persisted JSON without `auth_user` round-trips fine because the field is `omitempty`.

## Tests

`TestServer_checkBasicAuth` gains three new sub-tests covering the new precedence cases (settings overrides default, startup used when settings empty, settings wins over startup). All existing webapi/config/main tests still pass:

```
ok  	github.com/umputun/tg-spam/app/webapi	11.323s
ok  	github.com/umputun/tg-spam/app/config	9.992s
ok  	github.com/umputun/tg-spam/app	10.714s
```

If you'd prefer a smaller surface (e.g. drop the `ServerSettings` field and only keep startup `AuthUser`, or drop the user check entirely so any bcrypt-passing username works), happy to rework — flagging this version because it most cleanly restores prior behaviour.