### PR TITLE
fix: preserve InstanceID across loadConfigFromDB swap; rename collided subtests

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -464,14 +464,13 @@ func loadConfigFromDB(ctx context.Context, settings, defaults *config.Settings) 
 
 	// preserve InstanceID supplied by --instance-id / INSTANCE_ID. This field
 	// is the storage gid for every per-instance store (settings, samples,
-	// detected spam, locator, etc.). Letting an empty value from the DB blob
-	// overwrite it leaves activateServer constructing engines with gid=""
-	// — startup load works because loadConfigFromDB uses its own short-lived
-	// store keyed by the still-CLI value, but the runtime SettingsStore is
-	// then bound to the wrong gid and POST /config/reload fails with
-	// "no settings found in database". Affects external orchestrators
-	// (e.g. tg-spam-manager) that write per-instance config blobs without
-	// embedding instance_id.
+	// detected spam, locator, etc.) and the Argon2 salt for sensitive-field
+	// encryption. Letting an empty value from the DB blob overwrite it
+	// leaves activateServer constructing engines with gid="" and the runtime
+	// SettingsStore bound to the wrong gid, so POST /config/reload fails with
+	// "no settings found in database". Affects deployments that write the
+	// per-instance config blob from outside tg-spam (the wrapper builds the
+	// JSON itself and may not embed instance_id).
 	instanceID := settings.InstanceID
 
 	// replace settings with loaded values including credentials
@@ -482,9 +481,16 @@ func loadConfigFromDB(ctx context.Context, settings, defaults *config.Settings) 
 
 	// restore InstanceID from CLI when the DB blob doesn't carry one. If the
 	// blob has its own non-empty InstanceID (e.g. saved by tg-spam itself),
-	// trust the persisted value to avoid silently rebinding storage.
+	// trust the persisted value to avoid silently rebinding storage. Warn
+	// on divergence: a mismatch shifts both the runtime gid and the Argon2
+	// salt derived in app/config/crypt.go, so the next save would re-encrypt
+	// sensitive fields under a different key.
 	if settings.InstanceID == "" {
 		settings.InstanceID = instanceID
+	} else if instanceID != "" && settings.InstanceID != instanceID {
+		log.Printf("[WARN] persisted instance_id %q differs from CLI value %q; "+
+			"using persisted value, but next save will re-encrypt sensitive fields under a different Argon2 salt",
+			settings.InstanceID, instanceID)
 	}
 
 	// fill any field left zero by a partial/legacy blob from the CLI-default template

--- a/app/settings.go
+++ b/app/settings.go
@@ -462,11 +462,30 @@ func loadConfigFromDB(ctx context.Context, settings, defaults *config.Settings) 
 	// save original transient values only (non-functional values)
 	transient := settings.Transient
 
+	// preserve InstanceID supplied by --instance-id / INSTANCE_ID. This field
+	// is the storage gid for every per-instance store (settings, samples,
+	// detected spam, locator, etc.). Letting an empty value from the DB blob
+	// overwrite it leaves activateServer constructing engines with gid=""
+	// — startup load works because loadConfigFromDB uses its own short-lived
+	// store keyed by the still-CLI value, but the runtime SettingsStore is
+	// then bound to the wrong gid and POST /config/reload fails with
+	// "no settings found in database". Affects external orchestrators
+	// (e.g. tg-spam-manager) that write per-instance config blobs without
+	// embedding instance_id.
+	instanceID := settings.InstanceID
+
 	// replace settings with loaded values including credentials
 	*settings = *dbSettings
 
 	// restore transient values
 	settings.Transient = transient
+
+	// restore InstanceID from CLI when the DB blob doesn't carry one. If the
+	// blob has its own non-empty InstanceID (e.g. saved by tg-spam itself),
+	// trust the persisted value to avoid silently rebinding storage.
+	if settings.InstanceID == "" {
+		settings.InstanceID = instanceID
+	}
 
 	// fill any field left zero by a partial/legacy blob from the CLI-default template
 	settings.ApplyDefaults(defaults)

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -1117,6 +1117,60 @@ func TestLoadConfigFromDB_AppliesDefaults(t *testing.T) {
 	assert.True(t, loaded.Transient.ConfigDB)
 }
 
+func TestLoadConfigFromDB_PreservesCLIInstanceIDOnEmptyBlob(t *testing.T) {
+	setupLog(true)
+	tmpDir := t.TempDir()
+	dbFile := filepath.Join(tmpDir, "empty-instance.db")
+
+	// persist a blob with InstanceID="" — mirrors what an external wrapper
+	// writes when it builds the JSON without setting instance_id. saveConfigToDB
+	// here uses the empty InstanceID for the engine gid too, which is fine for
+	// the test fixture; the bug under test is what loadConfigFromDB does next.
+	blob := &config.Settings{
+		InstanceID: "",
+		Dry:        true,
+		Telegram:   config.TelegramSettings{Group: "g"},
+		Transient:  config.TransientSettings{DataBaseURL: dbFile},
+	}
+	ctx := context.Background()
+	require.NoError(t, saveConfigToDB(ctx, blob))
+
+	// rebind the DB file path so the subsequent loadConfigFromDB opens it under
+	// the CLI-supplied InstanceID. Without the preserve-on-empty branch, after
+	// *settings = *dbSettings the value would become "" and every later
+	// makeDB call in activateServer would bind to gid="", breaking
+	// POST /config/reload with "no settings found in database".
+	loaded := &config.Settings{
+		InstanceID: "cli-instance",
+		Transient: config.TransientSettings{
+			DataBaseURL: dbFile,
+			ConfigDB:    true,
+		},
+	}
+	// the blob row sits under gid="" (saveConfigToDB used the empty InstanceID),
+	// so manually re-key it to gid="cli-instance" to match the load path. This
+	// stages the exact disk layout the bug produces in production: a row whose
+	// gid matches the CLI value but whose JSON blob has instance_id="".
+	rekeyConfigBlobGID(t, dbFile, "cli-instance")
+
+	require.NoError(t, loadConfigFromDB(ctx, loaded, nil))
+	assert.Equal(t, "cli-instance", loaded.InstanceID, "CLI value must be retained when blob is empty")
+	assert.True(t, loaded.Dry, "other fields still come from the blob")
+}
+
+// rekeyConfigBlobGID rewrites the gid column of every row in the config table
+// of the given sqlite file. Used to stage a row whose gid matches the CLI
+// value but whose JSON blob has instance_id="" (the exact disk layout
+// produced by external wrappers that build the config JSON themselves).
+func rekeyConfigBlobGID(t *testing.T, dbFile, newGID string) {
+	t.Helper()
+	db, err := engine.New(context.Background(), dbFile, "")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	_, err = db.Exec("UPDATE config SET gid = $1", newGID)
+	require.NoError(t, err)
+}
+
 func TestLoadConfigFromDB_DoesNotOverrideExisting(t *testing.T) {
 	setupLog(true)
 	tmpDir := t.TempDir()

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -1808,7 +1808,7 @@ func TestDetector_CheckOpenAI(t *testing.T) {
 		assert.Len(t, mockOpenAIClient.CreateChatCompletionCalls(), 1)
 	})
 
-	t.Run("with openai and MinMsgLen - short message skips openai by default", func(t *testing.T) {
+	t.Run("with openai and MinMsgLen - short message skips openai by default (repeat)", func(t *testing.T) {
 		d := NewDetector(Config{MaxAllowedEmoji: -1, FirstMessageOnly: true, MinMsgLen: 50})
 		mockOpenAIClient := &mocks.OpenAIClientMock{
 			CreateChatCompletionFunc: func(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
@@ -1843,7 +1843,7 @@ func TestDetector_CheckOpenAI(t *testing.T) {
 		assert.Len(t, mockOpenAIClient.CreateChatCompletionCalls(), 1)
 	})
 
-	t.Run("with openai and MinMsgLen - short message checked when flag is true", func(t *testing.T) {
+	t.Run("with openai and MinMsgLen - short message checked when flag is true (repeat)", func(t *testing.T) {
 		d := NewDetector(Config{MaxAllowedEmoji: -1, FirstMessageOnly: true, MinMsgLen: 50})
 		mockOpenAIClient := &mocks.OpenAIClientMock{
 			CreateChatCompletionFunc: func(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
@@ -1881,7 +1881,7 @@ func TestDetector_CheckOpenAI(t *testing.T) {
 		assert.Len(t, mockOpenAIClient.CreateChatCompletionCalls(), 2)
 	})
 
-	t.Run("with openai and MinMsgLen - short message already spam skips openai", func(t *testing.T) {
+	t.Run("with openai and MinMsgLen - short message already spam skips openai (with LoadResult assert)", func(t *testing.T) {
 		d := NewDetector(Config{MaxAllowedEmoji: -1, FirstMessageOnly: true, MinMsgLen: 50})
 		mockOpenAIClient := &mocks.OpenAIClientMock{
 			CreateChatCompletionFunc: func(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {


### PR DESCRIPTION
Two unrelated cleanups picked up while reviewing #294 end-to-end against an external wrapper that runs tg-spam in `--confdb` mode.

## 1. `POST /config/reload` returns 500 from a clean state

`loadConfigFromDB` (`app/settings.go:466`) does `*settings = *dbSettings` and clobbers the CLI/env-supplied `InstanceID` with whatever the persisted blob carries. Any deployment that writes the per-instance config blob from outside tg-spam (e.g. a wrapper that builds the JSON itself) can easily leave `instance_id` empty, so after the swap `settings.InstanceID == ""`.

The startup load *itself* still works, because `loadConfigFromDB` makes its own short-lived store keyed by the CLI value before the swap. The damage shows up one layer up: `activateServer` then constructs the runtime data DB and the `webapi.Server.SettingsStore` via `makeDB(ctx, settings)`, where `settings.InstanceID` is now `""` — so every per-instance store binds to `gid=""`. The startup logs make this visible:

```
[INFO] new database engine, conn: ..., gid: 019d2443-...    ← loadConfigFromDB temp store
[INFO] configuration loaded from database successfully
[WARN] dry mode, no actual bans
[INFO] new database engine, conn: ..., gid:                 ← activateServer, gid clobbered
```

### Reproduction

Externally written row is `(gid=<instance-id>, ...)` with `instance_id: ""` inside the JSON. Bot starts up successfully (the temp store's gid still matches), but `POST /config/reload` later goes through `s.SettingsStore.Load` (`app/webapi/config.go:75`), which sits on the empty-gid engine:

```
[ERROR] failed to load configuration: no settings found in database: sql: no rows in result set
HTTP 500
```

The first subsequent UI Save with `saveToDb=true` then *writes* a fresh row under `gid=""`, so later reloads succeed against a different row. Two writers (the external one and the bot itself) end up on different rows — split-brain.

### Fix

Snapshot `settings.InstanceID` before the swap and restore it when the loaded blob's value is empty. A blob that *does* carry its own non-empty `InstanceID` (saved by tg-spam itself) is still trusted, so existing single-binary deployments are unaffected. When CLI and blob disagree on a non-empty value, log a `[WARN]` — divergence shifts the runtime gid AND the Argon2 salt derived in `app/config/crypt.go`, so the next save would re-encrypt sensitive fields under a different key.

```go
instanceID := settings.InstanceID
*settings = *dbSettings
settings.Transient = transient
if settings.InstanceID == "" {
    settings.InstanceID = instanceID
} else if instanceID != "" && settings.InstanceID != instanceID {
    log.Printf("[WARN] persisted instance_id %q differs from CLI value %q; ...", settings.InstanceID, instanceID)
}
```

`TestLoadConfigFromDB_PreservesCLIInstanceIDOnEmptyBlob` covers the new branch: stages a row whose gid matches the CLI value but whose JSON blob has `instance_id: ""`, then asserts the CLI value is retained after load.

## 2. Three subtests in `TestDetector_CheckOpenAI` had colliding names

`lib/tgspam/detector_test.go` had two sets of three subtests sharing identical names (`with openai and MinMsgLen - short message ...`) — Go was running them under `#01` suffixes. Two are byte-identical to their earlier siblings (almost certainly a master-merge artefact); the third differs slightly (uses `spam` instead of `viagra` and adds an assertion on `LoadStopWords`'s `LoadResult`). Renamed the second set with `(repeat)` and `(with LoadResult assert)` so `-run` filtering disambiguates and `-v` output stops looking like a bug. Test bodies untouched in case the duplication was deliberate; trivial to drop the two pure repeats in a follow-up if you'd prefer.

## Validation

```
go build ./...                    # clean
go test -race ./app/... ./lib/... # all green
golangci-lint run ./app/... ./lib/... # 0 issues
```