### PR TITLE
Fix approved-user reaction spam exemption

### DIFF
--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -643,7 +643,7 @@ func (d *Detector) IsApprovedUser(userID string) bool {
 	if !ok {
 		return false
 	}
-	return ui.Count > d.FirstMessagesCount
+	return ui.Count >= d.FirstMessagesCount
 }
 
 // AddApprovedUser adds user IDs to the list of approved users.

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -3362,12 +3362,10 @@ func TestDetector_ShortMessageApproval(t *testing.T) {
 		spam, _ := d.Check(spamcheck.Request{Msg: "another normal message here", UserID: "456"})
 		assert.False(t, spam)
 
-		// user should NOT be approved yet (need count > FirstMessagesCount)
-		assert.False(t, d.IsApprovedUser("456"))
+		// user is approved once the configured number of normal messages is reached
+		assert.True(t, d.IsApprovedUser("456"))
 
 		// after 3 messages, user is pre-approved (count >= FirstMessagesCount)
-		// but IsApprovedUser returns false because it checks count > FirstMessagesCount
-		// this is the existing behavior, not related to our fix
 
 		// 4th message will be pre-approved
 		spam, cr := d.Check(spamcheck.Request{Msg: "fourth normal message", UserID: "456"})
@@ -3380,8 +3378,7 @@ func TestDetector_ShortMessageApproval(t *testing.T) {
 		d.lock.RUnlock()
 		assert.Equal(t, 3, actualCount)
 
-		// IsApprovedUser still returns false (3 > 3 is false)
-		assert.False(t, d.IsApprovedUser("456"))
+		assert.True(t, d.IsApprovedUser("456"))
 	})
 
 	t.Run("mix of short and normal messages", func(t *testing.T) {
@@ -3418,9 +3415,8 @@ func TestDetector_ShortMessageApproval(t *testing.T) {
 		assert.False(t, spam)
 
 		// with the mix of short and normal messages, only the normal ones count
-		// after 3 normal messages, count is 3, user is pre-approved but IsApprovedUser
-		// returns false because it checks count > FirstMessagesCount
-		assert.False(t, d.IsApprovedUser("789"))
+		// after 3 normal messages, count is 3 and user is approved
+		assert.True(t, d.IsApprovedUser("789"))
 	})
 
 	t.Run("short messages with storage", func(t *testing.T) {
@@ -3450,16 +3446,15 @@ func TestDetector_ShortMessageApproval(t *testing.T) {
 		d.Check(spamcheck.Request{Msg: "normal message two", UserID: "111"})
 		assert.Len(t, mockUserStore.WriteCalls(), 2)
 
-		// user is not approved yet (need > 2)
-		assert.False(t, d.IsApprovedUser("111"))
+		// user is approved once count reaches FirstMessagesCount
+		assert.True(t, d.IsApprovedUser("111"))
 
 		// after 2 messages, count is 2 which equals FirstMessagesCount
 		// so the 3rd message will be pre-approved and won't update storage
 		d.Check(spamcheck.Request{Msg: "normal message three", UserID: "111"})
 		// storage write is NOT called for pre-approved message
 		assert.Len(t, mockUserStore.WriteCalls(), 2)
-		// IsApprovedUser returns false because count (2) is not > FirstMessagesCount (2)
-		assert.False(t, d.IsApprovedUser("111"))
+		assert.True(t, d.IsApprovedUser("111"))
 	})
 
 	t.Run("short messages cleared as ham by LLM still don't count towards approval", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix `IsApprovedUser` so it uses the same approval threshold as the message spam-check path.

A user is treated as pre-approved by message checks once their approval count reaches `FirstMessagesCount`, but `IsApprovedUser` still required the count to be greater than `FirstMessagesCount`. This meant a user auto-approved during a long-running process could be skipped by message checks while still being treated as unapproved by reaction spam detection and approved-only report checks.

The mismatch was introduced in `76636403` (`fix +1 issue with first message check`), which changed the message check from `>` to `>=` but left `IsApprovedUser` on `>`.

## Reproduce

With `FirstMessagesCount=1`:

1. Start the bot and let a user send one normal message.
2. The user gets written to `approved_users`, and the in-memory approval count becomes `1`.
3. Send another message from the same user.
4. The message path treats the user as pre-approved because `1 >= 1`.
5. Add enough reactions from that same user to hit the reaction spam threshold.
6. The reaction path still treats the user as unapproved because `IsApprovedUser` checks `1 > 1`.

After a process restart, the stored user is loaded with `Count = FirstMessagesCount + 1`, so the bug is harder to hit. The affected case is a long-running process where the user was auto-approved in memory and the process has not restarted since.