### PR TITLE
fix: clean up /report handling and reported-user display

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ To enable user spam reporting, set `--report.enabled` to `true` and configure an
 4. Admins can review the reported message and take action using inline buttons:
    - **Approve Ban**: Immediately ban the reported user and delete the reported message
    - **Reject**: Reject this report without taking action
-   - **Ban Reporter**: Open a dialog to select and ban a specific reporter who may be abusing the reporting system (requires confirmation)
+   - **Ban Reporters**: Open a dialog to select and ban a specific reporter who may be abusing the reporting system (requires confirmation)
 
 #### Advanced Reporting Features
 

--- a/app/events/reports.go
+++ b/app/events/reports.go
@@ -334,7 +334,13 @@ func (r *userReports) reportedUserMD(name string, id int64) string {
 	if name == "" {
 		name = fmt.Sprintf("user%d", id)
 	}
-	return fmt.Sprintf("[%s (%d)](tg://user?id=%d)", escapeMarkDownV1Text(name), id, id)
+	// escape for a markdown-v1 link label: backslash first, then the markdown specials, then "]" which
+	// escapeMarkDownV1Text does not handle and which would otherwise close the label early (link injection
+	// via an arbitrary first+last display name)
+	label := strings.ReplaceAll(name, "\\", "\\\\")
+	label = escapeMarkDownV1Text(label)
+	label = strings.ReplaceAll(label, "]", "\\]")
+	return fmt.Sprintf("[%s (%d)](tg://user?id=%d)", label, id, id)
 }
 
 // sendAutoBanNotification sends notification to admin chat about automatic ban

--- a/app/events/reports.go
+++ b/app/events/reports.go
@@ -80,6 +80,11 @@ func (r *userReports) DirectUserReport(ctx context.Context, update tbapi.Update)
 
 	// validate reported user is not super user (check both username and ID)
 	if r.superUsers.IsSuper(origMsg.From.UserName, origMsg.From.ID) {
+		// still delete the /report command to keep chat clean
+		_, _ = r.tbAPI.Request(tbapi.DeleteMessageConfig{BaseChatMessage: tbapi.BaseChatMessage{
+			MessageID:  update.Message.MessageID,
+			ChatConfig: tbapi.ChatConfig{ChatID: r.primChatID},
+		}})
 		return fmt.Errorf("reported message is from super-user %s (%d), ignored", origMsg.From.UserName, origMsg.From.ID)
 	}
 

--- a/app/events/reports.go
+++ b/app/events/reports.go
@@ -141,6 +141,14 @@ func (r *userReports) DirectUserReport(ctx context.Context, update tbapi.Update)
 		return fmt.Errorf("reports storage not initialized")
 	}
 
+	// resolve reported user name to match the ban report format: @username, then first+last name
+	reportedName := ""
+	if origMsg.From.UserName != "" {
+		reportedName = "@" + origMsg.From.UserName
+	} else {
+		reportedName = strings.TrimSpace(origMsg.From.FirstName + " " + origMsg.From.LastName)
+	}
+
 	// create report
 	report := storage.Report{
 		MsgID:            origMsg.MessageID,
@@ -148,7 +156,7 @@ func (r *userReports) DirectUserReport(ctx context.Context, update tbapi.Update)
 		ReporterUserID:   update.Message.From.ID,
 		ReporterUserName: update.Message.From.UserName,
 		ReportedUserID:   origMsg.From.ID,
-		ReportedUserName: origMsg.From.UserName,
+		ReportedUserName: reportedName,
 		MsgText:          msgTxt,
 	}
 
@@ -320,6 +328,15 @@ func (r *userReports) executeAutoBan(ctx context.Context, reports []storage.Repo
 	return nil
 }
 
+// reportedUserMD formats the reported user as a markdown link "name (id)", matching the ban report format.
+// falls back to "user<id>" when the name is empty so the link label is never blank.
+func (r *userReports) reportedUserMD(name string, id int64) string {
+	if name == "" {
+		name = fmt.Sprintf("user%d", id)
+	}
+	return fmt.Sprintf("[%s (%d)](tg://user?id=%d)", escapeMarkDownV1Text(name), id, id)
+}
+
 // sendAutoBanNotification sends notification to admin chat about automatic ban
 func (r *userReports) sendAutoBanNotification(reports []storage.Report) error {
 	if len(reports) == 0 {
@@ -350,11 +367,10 @@ func (r *userReports) sendAutoBanNotification(reports []storage.Report) error {
 		actionType = "restricted"
 	}
 
-	notificationText := fmt.Sprintf("**Auto-%s user after %d reports**\n\n[%s](tg://user?id=%d)\n\n%s\n\n**Reporters:**\n%s",
+	notificationText := fmt.Sprintf("**Auto-%s user after %d reports**\n\n%s\n\n%s\n\n**Reporters:**\n%s",
 		actionType,
 		len(reports),
-		escapeMarkDownV1Text(reportedUserName),
-		reportedUserID,
+		r.reportedUserMD(reportedUserName, reportedUserID),
 		msgText,
 		strings.Join(reporterList, "\n"))
 
@@ -408,11 +424,10 @@ func (r *userReports) updateNotificationForAutoBan(reports []storage.Report) err
 	}
 
 	// create updated notification text with auto-ban confirmation
-	updatedText := fmt.Sprintf("**User spam reported (%d reports)**\n\n[%s](tg://user?id=%d)\n\n%s\n\n"+
+	updatedText := fmt.Sprintf("**User spam reported (%d reports)**\n\n%s\n\n%s\n\n"+
 		"**Reporters:**\n%s\n\n_auto-%s after reaching %d reports_",
 		len(reports),
-		escapeMarkDownV1Text(reportedUserName),
-		reportedUserID,
+		r.reportedUserMD(reportedUserName, reportedUserID),
 		msgText,
 		strings.Join(reporterList, "\n"),
 		actionType,
@@ -466,10 +481,9 @@ func (r *userReports) sendReportNotification(ctx context.Context, reports []stor
 	}
 
 	// format notification message
-	notificationText := fmt.Sprintf("**User spam reported (%d reports)**\n\n[%s](tg://user?id=%d)\n\n%s\n\n**Reporters:**\n%s",
+	notificationText := fmt.Sprintf("**User spam reported (%d reports)**\n\n%s\n\n%s\n\n**Reporters:**\n%s",
 		len(reports),
-		escapeMarkDownV1Text(reportedUserName),
-		reportedUserID,
+		r.reportedUserMD(reportedUserName, reportedUserID),
 		msgText,
 		strings.Join(reporterList, "\n"))
 
@@ -483,7 +497,7 @@ func (r *userReports) sendReportNotification(ctx context.Context, reports []stor
 		tbapi.NewInlineKeyboardRow(
 			tbapi.NewInlineKeyboardButtonData("✅ Approve Ban", fmt.Sprintf("R+%d:%d", reportedUserID, msgID)),
 			tbapi.NewInlineKeyboardButtonData("❌ Reject", fmt.Sprintf("R-%d:%d", reportedUserID, msgID)),
-			tbapi.NewInlineKeyboardButtonData("⛔️ Ban Reporter", fmt.Sprintf("R?%d:%d", reportedUserID, msgID)),
+			tbapi.NewInlineKeyboardButtonData("⛔️ Ban Reporters", fmt.Sprintf("R?%d:%d", reportedUserID, msgID)),
 		),
 	)
 
@@ -547,7 +561,7 @@ func (r *userReports) updateReportNotification(_ context.Context, reports []stor
 
 	// create notification message
 	notification := fmt.Sprintf("**User spam reported (%d reports)**\n\n", len(reports)) +
-		fmt.Sprintf("[%s](tg://user?id=%d)\n\n", escapeMarkDownV1Text(reportedUserName), reportedUserID) +
+		fmt.Sprintf("%s\n\n", r.reportedUserMD(reportedUserName, reportedUserID)) +
 		fmt.Sprintf("%s\n\n", msgText) +
 		fmt.Sprintf("**Reporters:**\n%s", strings.Join(reporterList, "\n"))
 
@@ -560,7 +574,7 @@ func (r *userReports) updateReportNotification(_ context.Context, reports []stor
 		tbapi.NewInlineKeyboardRow(
 			tbapi.NewInlineKeyboardButtonData("✅ Approve Ban", fmt.Sprintf("R+%d:%d", reportedUserID, msgID)),
 			tbapi.NewInlineKeyboardButtonData("❌ Reject", fmt.Sprintf("R-%d:%d", reportedUserID, msgID)),
-			tbapi.NewInlineKeyboardButtonData("⛔️ Ban Reporter", fmt.Sprintf("R?%d:%d", reportedUserID, msgID)),
+			tbapi.NewInlineKeyboardButtonData("⛔️ Ban Reporters", fmt.Sprintf("R?%d:%d", reportedUserID, msgID)),
 		),
 	)
 
@@ -842,10 +856,9 @@ func (r *userReports) callbackReportBanReporterConfirm(ctx context.Context, quer
 				escapeMarkDownV1Text(rName), report.ReporterUserID))
 		}
 
-		updText := fmt.Sprintf("**User spam reported (%d reports)**\n\n[%s](tg://user?id=%d)\n\n%s\n\n**Reporters:**\n%s",
+		updText := fmt.Sprintf("**User spam reported (%d reports)**\n\n%s\n\n%s\n\n**Reporters:**\n%s",
 			len(remainingReports),
-			escapeMarkDownV1Text(reportedUserName),
-			reportedUserID,
+			r.reportedUserMD(reportedUserName, reportedUserID),
 			msgText,
 			strings.Join(reporterList, "\n"))
 		updText += fmt.Sprintf("\n\n_reporter %s banned by %s_", escapeMarkDownV1Text(reporterName), query.From.UserName)
@@ -859,7 +872,7 @@ func (r *userReports) callbackReportBanReporterConfirm(ctx context.Context, quer
 			tbapi.NewInlineKeyboardRow(
 				tbapi.NewInlineKeyboardButtonData("✅ Approve Ban", fmt.Sprintf("R+%d:%d", reportedUserID, msgID)),
 				tbapi.NewInlineKeyboardButtonData("❌ Reject", fmt.Sprintf("R-%d:%d", reportedUserID, msgID)),
-				tbapi.NewInlineKeyboardButtonData("⛔️ Ban Reporter", fmt.Sprintf("R?%d:%d", reportedUserID, msgID)),
+				tbapi.NewInlineKeyboardButtonData("⛔️ Ban Reporters", fmt.Sprintf("R?%d:%d", reportedUserID, msgID)),
 			),
 		)
 
@@ -889,7 +902,7 @@ func (r *userReports) callbackReportCancel(_ context.Context, query *tbapi.Callb
 		tbapi.NewInlineKeyboardRow(
 			tbapi.NewInlineKeyboardButtonData("✅ Approve Ban", fmt.Sprintf("R+%d:%d", reportedUserID, msgID)),
 			tbapi.NewInlineKeyboardButtonData("❌ Reject", fmt.Sprintf("R-%d:%d", reportedUserID, msgID)),
-			tbapi.NewInlineKeyboardButtonData("⛔️ Ban Reporter", fmt.Sprintf("R?%d:%d", reportedUserID, msgID)),
+			tbapi.NewInlineKeyboardButtonData("⛔️ Ban Reporters", fmt.Sprintf("R?%d:%d", reportedUserID, msgID)),
 		),
 	)
 

--- a/app/events/reports_test.go
+++ b/app/events/reports_test.go
@@ -219,8 +219,12 @@ func TestUserReports_DirectUserReport(t *testing.T) {
 		assert.Empty(t, mockReports.AddCalls(), "should not add report")
 	})
 
-	t.Run("reported user is superuser - should return error", func(t *testing.T) {
-		mockAPI := &mocks.TbAPIMock{}
+	t.Run("reported user is superuser - should delete command and return error", func(t *testing.T) {
+		mockAPI := &mocks.TbAPIMock{
+			RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+				return &tbapi.APIResponse{Ok: true}, nil
+			},
+		}
 		mockReports := &mocks.ReportsMock{}
 
 		rep := &userReports{
@@ -248,7 +252,11 @@ func TestUserReports_DirectUserReport(t *testing.T) {
 		err := rep.DirectUserReport(context.Background(), update)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "from super-user")
-		assert.Empty(t, mockAPI.RequestCalls(), "should not delete message")
+		require.Len(t, mockAPI.RequestCalls(), 1, "should still delete /report command")
+		delReq, ok := mockAPI.RequestCalls()[0].C.(tbapi.DeleteMessageConfig)
+		require.True(t, ok, "request should be a delete message config")
+		assert.Equal(t, 789, delReq.MessageID, "should delete the /report command message")
+		assert.Equal(t, int64(123), delReq.ChatID, "should delete from primary chat")
 		assert.Empty(t, mockReports.AddCalls(), "should not add report")
 	})
 

--- a/app/events/reports_test.go
+++ b/app/events/reports_test.go
@@ -1190,6 +1190,7 @@ func TestUserReports_AutoBan(t *testing.T) {
 					}
 					assert.Contains(t, editMsg.Text, "auto-banned", "should mention auto-ban in updated text")
 					assert.Contains(t, editMsg.Text, "5 reports", "should show report count")
+					assert.Contains(t, editMsg.Text, "[spammer (666)](tg://user?id=666)", "reported user should render as name (id) link")
 				}
 				return tbapi.Message{MessageID: 123}, nil
 			},
@@ -1383,6 +1384,8 @@ func TestUserReports_reportedUserMD(t *testing.T) {
 		{"with display name", "Елена Дроздова", 8788140656, "[Елена Дроздова (8788140656)](tg://user?id=8788140656)"},
 		{"empty name falls back to user<id>", "", 8250189078, "[user8250189078 (8250189078)](tg://user?id=8250189078)"},
 		{"markdown chars escaped", "spam_user*bot", 666, "[spam\\_user\\*bot (666)](tg://user?id=666)"},
+		{"link delimiter injection escaped", "bad](http://evil)", 666, "[bad\\](http://evil) (666)](tg://user?id=666)"},
+		{"backslash escaped", "a\\b", 666, "[a\\\\b (666)](tg://user?id=666)"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1428,7 +1431,7 @@ func TestUserReports_SendReportNotification(t *testing.T) {
 		assert.Equal(t, int64(456), sentMsg.ChatID, "should send to admin chat")
 		assert.Equal(t, tbapi.ModeMarkdown, sentMsg.ParseMode, "should use markdown")
 		assert.Contains(t, sentMsg.Text, "User spam reported (1 reports)", "should contain report count")
-		assert.Contains(t, sentMsg.Text, "spammer", "should contain reported user name")
+		assert.Contains(t, sentMsg.Text, "[spammer (666)](tg://user?id=666)", "reported user should render as name (id) link")
 		assert.Contains(t, sentMsg.Text, "spam message", "should contain message text")
 		assert.Contains(t, sentMsg.Text, "reporter1", "should contain reporter name")
 
@@ -1443,6 +1446,26 @@ func TestUserReports_SendReportNotification(t *testing.T) {
 		assert.Equal(t, "R-666:100", *keyboard.InlineKeyboard[0][1].CallbackData)
 		assert.Equal(t, "⛔️ Ban Reporters", keyboard.InlineKeyboard[0][2].Text)
 		assert.Equal(t, "R?666:100", *keyboard.InlineKeyboard[0][2].CallbackData)
+	})
+
+	t.Run("empty reported name falls back to user<id> link", func(t *testing.T) {
+		var sentMsg tbapi.MessageConfig
+		mockAPI := &mocks.TbAPIMock{
+			SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+				sentMsg = c.(tbapi.MessageConfig)
+				return tbapi.Message{MessageID: 999}, nil
+			},
+		}
+		mockReports := &mocks.ReportsMock{
+			UpdateAdminMsgIDFunc: func(ctx context.Context, msgID int, chatID int64, adminMsgID int) error { return nil },
+		}
+		rep := &userReports{tbAPI: mockAPI, adminChatID: 456, ReportConfig: ReportConfig{Storage: mockReports}}
+
+		reports := []storage.Report{
+			{MsgID: 100, ChatID: 200, ReportedUserID: 666, ReportedUserName: "", ReporterUserID: 111, ReporterUserName: "reporter1", MsgText: "spam"},
+		}
+		require.NoError(t, rep.sendReportNotification(context.Background(), reports))
+		assert.Contains(t, sentMsg.Text, "[user666 (666)](tg://user?id=666)", "blank name should fall back to user<id> link")
 	})
 
 	t.Run("successful notification with multiple reports", func(t *testing.T) {
@@ -1740,7 +1763,7 @@ func TestUserReports_UpdateReportNotification(t *testing.T) {
 		assert.Equal(t, 888, editedMsg.MessageID, "should edit correct message")
 		assert.Equal(t, tbapi.ModeMarkdown, editedMsg.ParseMode, "should use markdown")
 		assert.Contains(t, editedMsg.Text, "User spam reported (3 reports)", "should contain updated report count")
-		assert.Contains(t, editedMsg.Text, "spammer", "should contain reported user name")
+		assert.Contains(t, editedMsg.Text, "[spammer (666)](tg://user?id=666)", "reported user should render as name (id) link")
 		assert.Contains(t, editedMsg.Text, "spam message", "should contain message text")
 		assert.Contains(t, editedMsg.Text, "reporter1", "should contain first reporter")
 		assert.Contains(t, editedMsg.Text, "reporter2", "should contain second reporter")

--- a/app/events/reports_test.go
+++ b/app/events/reports_test.go
@@ -1063,11 +1063,15 @@ func TestUserReports_CheckReportThreshold(t *testing.T) {
 
 func TestUserReports_AutoBan(t *testing.T) {
 	t.Run("auto-ban triggers at correct threshold", func(t *testing.T) {
+		var sentMsg tbapi.MessageConfig
 		mockAPI := &mocks.TbAPIMock{
 			RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
 				return &tbapi.APIResponse{Ok: true}, nil
 			},
 			SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+				if m, ok := c.(tbapi.MessageConfig); ok {
+					sentMsg = m
+				}
 				return tbapi.Message{MessageID: 123}, nil
 			},
 		}
@@ -1116,6 +1120,7 @@ func TestUserReports_AutoBan(t *testing.T) {
 		assert.Len(t, mockReports.DeleteByMessageCalls(), 1, "should delete reports")
 		assert.GreaterOrEqual(t, len(mockAPI.RequestCalls()), 1, "should delete message")
 		assert.Len(t, mockAPI.SendCalls(), 1, "should send auto-ban notification")
+		assert.Contains(t, sentMsg.Text, "[spammer (666)](tg://user?id=666)", "reported user should render as name (id) link")
 	})
 
 	t.Run("auto-ban respects soft-ban mode", func(t *testing.T) {

--- a/app/events/reports_test.go
+++ b/app/events/reports_test.go
@@ -136,7 +136,7 @@ func TestUserReports_DirectUserReport(t *testing.T) {
 				assert.Equal(t, int64(111), report.ReporterUserID)
 				assert.Equal(t, "reporter", report.ReporterUserName)
 				assert.Equal(t, int64(666), report.ReportedUserID)
-				assert.Equal(t, "spammer", report.ReportedUserName)
+				assert.Equal(t, "@spammer", report.ReportedUserName, "username should be prefixed with @")
 				assert.Equal(t, "spam message", report.MsgText)
 				return nil
 			},
@@ -184,6 +184,52 @@ func TestUserReports_DirectUserReport(t *testing.T) {
 		assert.Len(t, mockAPI.RequestCalls(), 1, "should delete /report message")
 		assert.Len(t, mockReports.AddCalls(), 1, "should add report to storage")
 		assert.Len(t, mockReports.GetReporterCountSinceCalls(), 1, "should check rate limit")
+	})
+
+	t.Run("reported user without username - resolves first+last name", func(t *testing.T) {
+		mockAPI := &mocks.TbAPIMock{
+			RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+				return &tbapi.APIResponse{Ok: true}, nil
+			},
+		}
+		mockReports := &mocks.ReportsMock{
+			AddFunc: func(ctx context.Context, report storage.Report) error {
+				assert.Equal(t, int64(666), report.ReportedUserID)
+				assert.Equal(t, "Елена Дроздова", report.ReportedUserName, "should fall back to first+last name")
+				return nil
+			},
+			GetByMessageFunc: func(ctx context.Context, msgID int, chatID int64) ([]storage.Report, error) {
+				return []storage.Report{}, nil
+			},
+		}
+		mockBot := &mocks.BotMock{IsApprovedUserFunc: func(id int64) bool { return true }}
+
+		rep := &userReports{
+			tbAPI:        mockAPI,
+			bot:          mockBot,
+			primChatID:   123,
+			adminChatID:  456,
+			superUsers:   SuperUsers{},
+			ReportConfig: ReportConfig{Storage: mockReports, Threshold: 2},
+		}
+
+		update := tbapi.Update{
+			Message: &tbapi.Message{
+				MessageID: 789,
+				Chat:      tbapi.Chat{ID: 123},
+				Text:      "/report",
+				From:      &tbapi.User{UserName: "reporter", ID: 111},
+				ReplyToMessage: &tbapi.Message{
+					MessageID: 999,
+					From:      &tbapi.User{ID: 666, FirstName: "Елена", LastName: "Дроздова"},
+					Text:      "spam message",
+				},
+			},
+		}
+
+		err := rep.DirectUserReport(context.Background(), update)
+		require.NoError(t, err)
+		require.Len(t, mockReports.AddCalls(), 1, "should add report to storage")
 	})
 
 	t.Run("reporter is superuser - should return error", func(t *testing.T) {
@@ -1325,6 +1371,26 @@ func TestUserReports_AutoBan(t *testing.T) {
 	})
 }
 
+func TestUserReports_reportedUserMD(t *testing.T) {
+	rep := &userReports{}
+	tests := []struct {
+		name     string
+		userName string
+		id       int64
+		want     string
+	}{
+		{"with username", "@spammer", 666, "[@spammer (666)](tg://user?id=666)"},
+		{"with display name", "Елена Дроздова", 8788140656, "[Елена Дроздова (8788140656)](tg://user?id=8788140656)"},
+		{"empty name falls back to user<id>", "", 8250189078, "[user8250189078 (8250189078)](tg://user?id=8250189078)"},
+		{"markdown chars escaped", "spam_user*bot", 666, "[spam\\_user\\*bot (666)](tg://user?id=666)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, rep.reportedUserMD(tc.userName, tc.id))
+		})
+	}
+}
+
 func TestUserReports_SendReportNotification(t *testing.T) {
 	t.Run("successful notification with single report", func(t *testing.T) {
 		var sentMsg tbapi.MessageConfig
@@ -1375,7 +1441,7 @@ func TestUserReports_SendReportNotification(t *testing.T) {
 		assert.Equal(t, "R+666:100", *keyboard.InlineKeyboard[0][0].CallbackData)
 		assert.Equal(t, "❌ Reject", keyboard.InlineKeyboard[0][1].Text)
 		assert.Equal(t, "R-666:100", *keyboard.InlineKeyboard[0][1].CallbackData)
-		assert.Equal(t, "⛔️ Ban Reporter", keyboard.InlineKeyboard[0][2].Text)
+		assert.Equal(t, "⛔️ Ban Reporters", keyboard.InlineKeyboard[0][2].Text)
 		assert.Equal(t, "R?666:100", *keyboard.InlineKeyboard[0][2].CallbackData)
 	})
 
@@ -1688,7 +1754,7 @@ func TestUserReports_UpdateReportNotification(t *testing.T) {
 		assert.Equal(t, "R+666:100", *editedMsg.ReplyMarkup.InlineKeyboard[0][0].CallbackData)
 		assert.Equal(t, "❌ Reject", editedMsg.ReplyMarkup.InlineKeyboard[0][1].Text)
 		assert.Equal(t, "R-666:100", *editedMsg.ReplyMarkup.InlineKeyboard[0][1].CallbackData)
-		assert.Equal(t, "⛔️ Ban Reporter", editedMsg.ReplyMarkup.InlineKeyboard[0][2].Text)
+		assert.Equal(t, "⛔️ Ban Reporters", editedMsg.ReplyMarkup.InlineKeyboard[0][2].Text)
 		assert.Equal(t, "R?666:100", *editedMsg.ReplyMarkup.InlineKeyboard[0][2].CallbackData)
 	})
 
@@ -2301,7 +2367,7 @@ func TestUserReports_CallbackReportCancel(t *testing.T) {
 					assert.Equal(t, "R+666:100", *editMarkup.ReplyMarkup.InlineKeyboard[0][0].CallbackData)
 					assert.Equal(t, "❌ Reject", editMarkup.ReplyMarkup.InlineKeyboard[0][1].Text)
 					assert.Equal(t, "R-666:100", *editMarkup.ReplyMarkup.InlineKeyboard[0][1].CallbackData)
-					assert.Equal(t, "⛔️ Ban Reporter", editMarkup.ReplyMarkup.InlineKeyboard[0][2].Text)
+					assert.Equal(t, "⛔️ Ban Reporters", editMarkup.ReplyMarkup.InlineKeyboard[0][2].Text)
 					assert.Equal(t, "R?666:100", *editMarkup.ReplyMarkup.InlineKeyboard[0][2].CallbackData)
 				}
 				return tbapi.Message{}, nil


### PR DESCRIPTION
three fixes in the user spam-report (`/report`) flow.

**skip super-user reports cleanly** - replying `/report` to a moderator/admin message still skips the report, but the `/report` command is now deleted to keep the chat clean (matching the not-approved and rate-limited branches). Previously it was left in the chat.

**reported user shown as `name (id)` with a link** - the admin notification rendered the reported user as an empty markdown link label when the user had no `@username`, leaking the raw `tg://user?id=...` URL. The name is now resolved at report time (`@username`, else first+last) and every notification renders `[name (id)](tg://user?id=id)`, matching the ban report. The label is escaped for markdown-v1 (including `]` and backslash) so an arbitrary display name can't break or hijack the link.

**`Ban Reporter` to `Ban Reporters`** - the button opens a per-reporter picker, so the plural reads right. Banning is still individual.

tests cover the name resolution, the `name (id)` format across all notification paths, the empty-name fallback, and the markdown escaping. README updated for the button label.
