### PR TITLE
fix: data race on approvedUsers map in Detector.Check

### DIFF
--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -393,11 +393,13 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 		ctx, cancel := d.ctxWithStoreTimeout()
 		defer cancel()
 		d.auLock.Lock()
-		// cap the count at approved level: concurrent first messages from the same user can all
-		// pass the pre-approved check before any increment lands, and an inflated count would
-		// weaken the short-msg-flood excess calculation
+		// cap the count at the organic approval level: concurrent first messages from the same
+		// user can all pass the pre-approved check before any increment lands, and an inflated
+		// count would weaken the short-msg-flood excess calculation. sequential flow never gets
+		// past FirstMessagesCount because the pre-approved branch short-circuits; the +1 sentinel
+		// is reserved for explicit AddApprovedUser and storage-loaded users
 		newCount := d.approvedUsers[req.UserID].Count + 1
-		if maxCount := d.FirstMessagesCount + 1; newCount > maxCount {
+		if maxCount := max(d.FirstMessagesCount, 1); newCount > maxCount {
 			newCount = maxCount
 		}
 		au := approved.UserInfo{

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -393,8 +393,15 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 		ctx, cancel := d.ctxWithStoreTimeout()
 		defer cancel()
 		d.auLock.Lock()
+		// cap the count at approved level: concurrent first messages from the same user can all
+		// pass the pre-approved check before any increment lands, and an inflated count would
+		// weaken the short-msg-flood excess calculation
+		newCount := d.approvedUsers[req.UserID].Count + 1
+		if maxCount := d.FirstMessagesCount + 1; newCount > maxCount {
+			newCount = maxCount
+		}
 		au := approved.UserInfo{
-			Count:     d.approvedUsers[req.UserID].Count + 1,
+			Count:     newCount,
 			UserID:    req.UserID,
 			UserName:  req.UserName,
 			Timestamp: time.Now(),

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -61,6 +61,10 @@ type Detector struct {
 	spamHistory *spamcheck.LastRequests
 
 	lock sync.RWMutex
+	// auLock guards approvedUsers map access. it is a leaf lock: safe to take while holding
+	// d.lock in either mode, never acquire d.lock while holding it. needed because Check
+	// updates the map while holding d.lock as a read lock only.
+	auLock sync.RWMutex
 }
 
 // LLMConsensusMode controls how eligible LLM checks flip the base decision.
@@ -243,7 +247,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	}
 
 	// approved user don't need content analysis checks, but only skip if no spam detected by behavioral checks
-	if req.UserID != "" && d.FirstMessageOnly && !isSpamDetected(cr) && d.approvedUsers[req.UserID].Count >= d.FirstMessagesCount {
+	if req.UserID != "" && d.FirstMessageOnly && !isSpamDetected(cr) && d.approvedCount(req.UserID) >= d.FirstMessagesCount {
 		// include previous check results (e.g., duplicate check) in the response
 		return false, append(cr, spamcheck.Response{Name: "pre-approved", Spam: false, Details: "user already approved"})
 	}
@@ -388,6 +392,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	if (d.FirstMessageOnly || d.FirstMessagesCount > 0) && !req.CheckOnly && !isShortMessage {
 		ctx, cancel := d.ctxWithStoreTimeout()
 		defer cancel()
+		d.auLock.Lock()
 		au := approved.UserInfo{
 			Count:     d.approvedUsers[req.UserID].Count + 1,
 			UserID:    req.UserID,
@@ -395,6 +400,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 			Timestamp: time.Now(),
 		}
 		d.approvedUsers[req.UserID] = au // update approved users status in memory
+		d.auLock.Unlock()
 		if d.userStorage != nil {
 			// update approved users status in storage
 			_ = d.userStorage.Write(ctx, au) // ignore error, failed to write to storage is not critical here
@@ -500,7 +506,9 @@ func (d *Detector) Reset() {
 	d.tokenizedSpam = []map[string]int{}
 	d.excludedTokens = map[string]struct{}{}
 	d.classifier.reset()
+	d.auLock.Lock()
 	d.approvedUsers = make(map[string]approved.UserInfo)
+	d.auLock.Unlock()
 	d.stopWords = []string{}
 
 	// close the Lua engine and reset Lua checks if it exists
@@ -584,7 +592,9 @@ func (d *Detector) WithLuaEngine(engine LuaPluginEngine) error {
 func (d *Detector) WithUserStorage(storage UserStorage) (count int, err error) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
+	d.auLock.Lock()
 	d.approvedUsers = make(map[string]approved.UserInfo) // reset approved users
+	d.auLock.Unlock()
 	d.userStorage = storage
 
 	ctx, cancel := d.ctxWithStoreTimeout()
@@ -594,10 +604,12 @@ func (d *Detector) WithUserStorage(storage UserStorage) (count int, err error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to read approved users from storage: %w", err)
 	}
+	d.auLock.Lock()
 	for _, user := range users {
 		user.Count = d.FirstMessagesCount + 1 // +1 to skip first message check if count is 0
 		d.approvedUsers[user.UserID] = user
 	}
+	d.auLock.Unlock()
 	return len(users), nil
 }
 
@@ -623,14 +635,23 @@ func (d *Detector) WithHamUpdater(s SampleUpdater) { d.hamSamplesUpd = s }
 func (d *Detector) ApprovedUsers() (res []approved.UserInfo) {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
+	d.auLock.RLock()
 	res = make([]approved.UserInfo, 0, len(d.approvedUsers))
 	for _, info := range d.approvedUsers {
 		res = append(res, info)
 	}
+	d.auLock.RUnlock()
 	sort.Slice(res, func(i, j int) bool {
 		return res[i].Timestamp.After(res[j].Timestamp)
 	})
 	return res
+}
+
+// approvedCount returns the approved-messages count for a given user ID under auLock.
+func (d *Detector) approvedCount(userID string) int {
+	d.auLock.RLock()
+	defer d.auLock.RUnlock()
+	return d.approvedUsers[userID].Count
 }
 
 // IsApprovedUser checks if a given user ID is approved.
@@ -639,7 +660,9 @@ func (d *Detector) IsApprovedUser(userID string) bool {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
 
+	d.auLock.RLock()
 	ui, ok := d.approvedUsers[userID]
+	d.auLock.RUnlock()
 	if !ok {
 		return false
 	}
@@ -654,12 +677,14 @@ func (d *Detector) AddApprovedUser(user approved.UserInfo) error {
 	if ts.IsZero() {
 		ts = time.Now()
 	}
+	d.auLock.Lock()
 	d.approvedUsers[user.UserID] = approved.UserInfo{
 		UserID:    user.UserID,
 		UserName:  user.UserName,
 		Count:     d.FirstMessagesCount + 1, // +1 to skip first message check if count is 0
 		Timestamp: ts,
 	}
+	d.auLock.Unlock()
 
 	if d.userStorage != nil {
 		ctx, cancel := d.ctxWithStoreTimeout()
@@ -674,7 +699,9 @@ func (d *Detector) AddApprovedUser(user approved.UserInfo) error {
 // RemoveApprovedUser removes approved user for given IDs
 func (d *Detector) RemoveApprovedUser(id string) error {
 	d.lock.Lock()
+	d.auLock.Lock()
 	delete(d.approvedUsers, id)
+	d.auLock.Unlock()
 	d.lock.Unlock()
 
 	if d.userStorage != nil {
@@ -1072,7 +1099,7 @@ func (d *Detector) isShortMsgFlood(req spamcheck.Request) spamcheck.Response {
 	if len([]rune(req.Msg)) >= d.MinMsgLen {
 		return notSpam("message not short")
 	}
-	approvedCount := d.approvedUsers[req.UserID].Count
+	approvedCount := d.approvedCount(req.UserID)
 	// defensive: in app/main.go FirstMessageOnly is forced true whenever FirstMessagesCount > 0,
 	// so approved users short-circuit at the pre-approved branch in Check and never reach this.
 	// the guard matters for library consumers that construct Detector with FirstMessageOnly=false

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -574,6 +574,44 @@ func TestDetector_CheckDuplicatesConcurrency(t *testing.T) {
 	assert.Equal(t, expectedCount+1, count, "count should be accurate with no race conditions")
 }
 
+func TestDetector_CheckApprovedUsersConcurrency(t *testing.T) {
+	d := NewDetector(Config{FirstMessageOnly: true, FirstMessagesCount: 1})
+
+	concurrency := 10
+	iterations := 20
+
+	var wg sync.WaitGroup
+	wg.Add(concurrency * 2)
+
+	// writers: distinct users get added to approvedUsers via the Check approval path
+	for i := range concurrency {
+		go func() {
+			defer wg.Done()
+			for j := range iterations {
+				d.Check(spamcheck.Request{
+					UserID: fmt.Sprintf("user-%d-%d", i, j),
+					Msg:    "long enough legitimate message to pass the approval path",
+				})
+			}
+		}()
+	}
+
+	// readers: exercise concurrent approvedUsers reads while writers update the map
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			for j := range iterations {
+				d.IsApprovedUser(fmt.Sprintf("user-0-%d", j))
+				d.ApprovedUsers()
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.True(t, d.IsApprovedUser("user-0-0"), "user should be approved after first ham message")
+	assert.Len(t, d.ApprovedUsers(), concurrency*iterations)
+}
+
 func TestDetector_CheckDuplicatesMemoryProtection(t *testing.T) {
 	d := NewDetector(Config{
 		DuplicateDetection: struct {

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -612,6 +612,36 @@ func TestDetector_CheckApprovedUsersConcurrency(t *testing.T) {
 	assert.Len(t, d.ApprovedUsers(), concurrency*iterations)
 }
 
+func TestDetector_CheckApprovedUsersConcurrencySameUser(t *testing.T) {
+	d := NewDetector(Config{FirstMessageOnly: true, FirstMessagesCount: 2})
+
+	concurrency := 10
+	iterations := 20
+
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	// concurrent messages from one user: all can pass the pre-approved check before
+	// any increment lands, the count must still not exceed the approved level
+	for i := range concurrency {
+		go func() {
+			defer wg.Done()
+			for j := range iterations {
+				d.Check(spamcheck.Request{
+					UserID: "same-user",
+					Msg:    fmt.Sprintf("long enough legitimate message %d-%d to pass the approval path", i, j),
+				})
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.True(t, d.IsApprovedUser("same-user"))
+	users := d.ApprovedUsers()
+	require.Len(t, users, 1)
+	assert.LessOrEqual(t, users[0].Count, d.FirstMessagesCount+1, "count must be capped at approved level")
+}
+
 func TestDetector_CheckDuplicatesMemoryProtection(t *testing.T) {
 	d := NewDetector(Config{
 		DuplicateDetection: struct {

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -639,7 +639,21 @@ func TestDetector_CheckApprovedUsersConcurrencySameUser(t *testing.T) {
 	assert.True(t, d.IsApprovedUser("same-user"))
 	users := d.ApprovedUsers()
 	require.Len(t, users, 1)
-	assert.LessOrEqual(t, users[0].Count, d.FirstMessagesCount+1, "count must be capped at approved level")
+	assert.LessOrEqual(t, users[0].Count, d.FirstMessagesCount, "count must be capped at organic approval level")
+}
+
+func TestDetector_CheckApprovedCountCap(t *testing.T) {
+	// with FirstMessageOnly disabled the pre-approved branch never short-circuits,
+	// so every ham message hits the increment and the cap is exercised deterministically
+	d := NewDetector(Config{FirstMessagesCount: 2})
+
+	for i := range 10 {
+		d.Check(spamcheck.Request{UserID: "u1", Msg: fmt.Sprintf("long enough legitimate message %d", i)})
+	}
+
+	users := d.ApprovedUsers()
+	require.Len(t, users, 1)
+	assert.Equal(t, 2, users[0].Count, "count must be capped at FirstMessagesCount")
 }
 
 func TestDetector_CheckDuplicatesMemoryProtection(t *testing.T) {


### PR DESCRIPTION
`Detector.Check` writes the `approvedUsers` map while holding `d.lock` as a read lock only, so two concurrent `Check` calls on the approval path — `FirstMessageOnly` is on by default — panic with a concurrent map write. The web `/check` API with `check_only:false` is a live concurrent trigger. The existing concurrency test never enabled `FirstMessageOnly`, which is why `-race` stayed green.

Fixed with a leaf-level `auLock` guarding all map access. The new `TestDetector_CheckApprovedUsersConcurrency` fails under `-race` on the previous code and passes now. Per codex review, the count increment is capped at the approved level so concurrent first messages from the same user can't inflate it past `FirstMessagesCount` (which would weaken short-msg-flood detection), covered by a same-user concurrency test.

Rescoped from the original three-fix bundle per review feedback; siblings: #407 (locator gid-scoped keys), #408 (x/net update), #406 (e2e-ui playwright pin). Carries a copy of the #406 commit so e2e-ui can run green; it drops out on rebase once #406 merges.