### PR TITLE
ci: pin playwright-go CLI version in e2e-ui workflow

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -23,6 +23,8 @@ jobs:
   e2e-ui:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      PLAYWRIGHT_GO_VERSION: v0.5200.1 # keep in sync with playwright-community/playwright-go in go.mod
 
     steps:
       - name: checkout
@@ -40,15 +42,15 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_GO_VERSION }}-${{ hashFiles('go.sum') }}
 
       - name: install playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5200.1 install --with-deps chromium
+        run: go run github.com/playwright-community/playwright-go/cmd/playwright@${{ env.PLAYWRIGHT_GO_VERSION }} install --with-deps chromium
 
       - name: install playwright deps only
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5200.1 install-deps chromium
+        run: go run github.com/playwright-community/playwright-go/cmd/playwright@${{ env.PLAYWRIGHT_GO_VERSION }} install-deps chromium
 
       - name: run e2e ui tests
         run: go test -v -count=1 -timeout=5m -tags=e2e ./e2e-ui/...

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -44,11 +44,11 @@ jobs:
 
       - name: install playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: go run github.com/playwright-community/playwright-go/cmd/playwright@latest install --with-deps chromium
+        run: go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5200.1 install --with-deps chromium
 
       - name: install playwright deps only
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: go run github.com/playwright-community/playwright-go/cmd/playwright@latest install-deps chromium
+        run: go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5200.1 install-deps chromium
 
       - name: run e2e ui tests
         run: go test -v -count=1 -timeout=5m -tags=e2e ./e2e-ui/...

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ unfuck-ai-comments:
 
 # install playwright browsers (run once or after playwright-go version update)
 e2e-ui-setup:
-	go run github.com/playwright-community/playwright-go/cmd/playwright@latest install --with-deps chromium
+	go run github.com/playwright-community/playwright-go/cmd/playwright@v0.5200.1 install --with-deps chromium
 
 # run e2e ui tests headless (default, for CI and quick checks)
 e2e-ui:


### PR DESCRIPTION
The e2e-ui workflow installs the playwright CLI with `@latest`, and upstream's new v0.6100.0 tag declares its module path as `github.com/mxschmitt/playwright-go`, so `go run ...@latest` fails to resolve and every e2e-ui run on app/lib changes breaks at the install step (see the red check on #405).

Pin to v0.5200.1 — the version in go.mod — which also keeps the installed browser driver in sync with the library the tests link against. The browser cache key now includes the pinned version (single env var shared with both install steps), so a cache entry saved by the old `@latest` installer can't mask the pin.

Blocks green e2e-ui on #405 and its sibling PRs; they carry a copy of this commit until this merges.