### PR TITLE
fix: scope locator primary keys by gid to prevent cross-group clobbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,6 +932,8 @@ It is not possible to run the bot for multiple groups, as the bot is designed to
 
 At the same time, multiple instances of the bot can share the same set of samples and dynamic data files. To do so, user should mount the same directory with samples and dynamic data files to all the instances of the bot.
 
+> **Upgrade note for shared PostgreSQL databases:** the message locator tables (`messages`, `spam`) are keyed by `(instance-id, ...)` and are migrated to composite primary keys on first startup of an upgraded instance. While a shared database has instances on mixed versions, older binaries can fail their locator upserts against the migrated schema (the old single-column `ON CONFLICT` target no longer exists). Upgrade all instances sharing one database together.
+
 ## Using tg-spam as a library
 
 The bot can be used as a library as well. To do so, import the `github.com/umputun/tg-spam/lib` package and create a new instance of the `Detector` struct. Then, call the `Check` method with the message and userID to check. The method will return `true` if the message is spam and `false` otherwise. In addition, the `Check` method will return the list of applied rules as well as the spam-related details.

--- a/app/storage/locator.go
+++ b/app/storage/locator.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 	_ "modernc.org/sqlite" // sqlite driver loaded here
 
 	"github.com/umputun/tg-spam/app/storage/engine"
@@ -31,34 +32,38 @@ const (
 var locatorQueries = engine.NewQueryMap().
 	Add(CmdCreateLocatorTables, engine.Query{
 		Sqlite: `CREATE TABLE IF NOT EXISTS messages (
-            hash TEXT PRIMARY KEY,
+            hash TEXT NOT NULL,
             gid TEXT NOT NULL DEFAULT '',
             time TIMESTAMP,
             chat_id INTEGER,
             user_id INTEGER,
             user_name TEXT,
-            msg_id INTEGER
+            msg_id INTEGER,
+            PRIMARY KEY (gid, hash)
         );
         CREATE TABLE IF NOT EXISTS spam (
-            user_id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL,
             gid TEXT NOT NULL DEFAULT '',
             time TIMESTAMP,
-            checks TEXT
+            checks TEXT,
+            PRIMARY KEY (gid, user_id)
         )`,
 		Postgres: `CREATE TABLE IF NOT EXISTS messages (
-            hash TEXT PRIMARY KEY,
+            hash TEXT NOT NULL,
             gid TEXT NOT NULL DEFAULT '',
             time TIMESTAMP,
             chat_id BIGINT,
             user_id BIGINT,
             user_name TEXT,
-            msg_id INTEGER
+            msg_id INTEGER,
+            PRIMARY KEY (gid, hash)
         );
         CREATE TABLE IF NOT EXISTS spam (
-            user_id BIGINT PRIMARY KEY,
+            user_id BIGINT NOT NULL,
             gid TEXT NOT NULL DEFAULT '',
             time TIMESTAMP,
-            checks TEXT
+            checks TEXT,
+            PRIMARY KEY (gid, user_id)
         )`,
 	}).
 	Add(CmdCreateLocatorIndexes, engine.Query{
@@ -87,24 +92,22 @@ var locatorQueries = engine.NewQueryMap().
 	Add(CmdAddLocatorMessage, engine.Query{
 		Sqlite: `INSERT OR REPLACE INTO messages (hash, gid, time, chat_id, user_id, user_name, msg_id) 
             VALUES (:hash, :gid, :time, :chat_id, :user_id, :user_name, :msg_id)`,
-		Postgres: `INSERT INTO messages (hash, gid, time, chat_id, user_id, user_name, msg_id) 
+		Postgres: `INSERT INTO messages (hash, gid, time, chat_id, user_id, user_name, msg_id)
             VALUES (:hash, :gid, :time, :chat_id, :user_id, :user_name, :msg_id)
-            ON CONFLICT (hash) DO UPDATE SET 
-            gid = :gid, 
-            time = :time, 
-            chat_id = :chat_id, 
-            user_id = :user_id, 
-            user_name = :user_name, 
+            ON CONFLICT (gid, hash) DO UPDATE SET
+            time = :time,
+            chat_id = :chat_id,
+            user_id = :user_id,
+            user_name = :user_name,
             msg_id = :msg_id`,
 	}).
 	Add(CmdAddLocatorSpam, engine.Query{
 		Sqlite: `INSERT OR REPLACE INTO spam (user_id, gid, time, checks) 
             VALUES (:user_id, :gid, :time, :checks)`,
-		Postgres: `INSERT INTO spam (user_id, gid, time, checks) 
+		Postgres: `INSERT INTO spam (user_id, gid, time, checks)
             VALUES (:user_id, :gid, :time, :checks)
-            ON CONFLICT (user_id) DO UPDATE SET 
-            gid = :gid, 
-            time = :time, 
+            ON CONFLICT (gid, user_id) DO UPDATE SET
+            time = :time,
             checks = :checks`,
 	})
 
@@ -154,48 +157,253 @@ func NewLocator(ctx context.Context, ttl time.Duration, minSize int, db *engine.
 }
 
 func (l *Locator) migrate(ctx context.Context, tx *sqlx.Tx, gid string) error {
-	// try to select with new structure, if works - already migrated
+	if err := l.migrateGIDColumns(ctx, tx, gid); err != nil {
+		return err
+	}
+	// legacy tables used single-column primary keys (messages.hash, spam.user_id) which break
+	// cross-group isolation when multiple instances share one database: an upsert from one gid
+	// clobbers another gid's row. upgrade them to composite (gid, ...) keys.
+	if err := l.migratePrimaryKeys(ctx, tx); err != nil {
+		return fmt.Errorf("failed to upgrade locator primary keys: %w", err)
+	}
+	// free the idx_spam_gid_time name before InitTable creates the locator indexes, in case an
+	// older detected_spam schema squatted it (postgres index names are schema-global).
+	if err := l.dropMisplacedSpamIndex(ctx, tx); err != nil {
+		return fmt.Errorf("failed to free misplaced spam index: %w", err)
+	}
+	return nil
+}
+
+// dropMisplacedSpamIndex drops idx_spam_gid_time when an older schema created it on a table other
+// than spam (the detected_spam duplicate). postgres index names are schema-global and NewLocator
+// runs before NewDetectedSpam, so leaving the squatted name would make the locator's own
+// CREATE INDEX IF NOT EXISTS idx_spam_gid_time ON spam a silent no-op for a whole startup. sqlite
+// names the locator's spam index differently (idx_spam_gid), so there is no collision there.
+func (l *Locator) dropMisplacedSpamIndex(ctx context.Context, tx *sqlx.Tx) error {
+	if l.Type() != engine.Postgres {
+		return nil
+	}
+	var misplaced int
+	query := `SELECT COUNT(*) FROM pg_indexes
+		WHERE indexname = 'idx_spam_gid_time' AND schemaname = current_schema() AND tablename <> 'spam'`
+	if err := tx.GetContext(ctx, &misplaced, query); err != nil {
+		return fmt.Errorf("failed to look up idx_spam_gid_time: %w", err)
+	}
+	if misplaced == 0 {
+		return nil // name is free or already owned by the spam table
+	}
+	// IF EXISTS so a concurrent upgrader that already freed the name turns this into a no-op
+	if _, err := tx.ExecContext(ctx, "DROP INDEX IF EXISTS idx_spam_gid_time"); err != nil {
+		return fmt.Errorf("failed to drop misplaced idx_spam_gid_time: %w", err)
+	}
+	log.Printf("[INFO] dropped misplaced idx_spam_gid_time to free the name for the locator spam index")
+	return nil
+}
+
+// migrateGIDColumns adds the gid column to messages and spam tables and backfills it with the provided gid.
+// each table is checked independently so a partially migrated schema (one table with gid, the other without)
+// completes before the primary key migration relies on the column.
+func (l *Locator) migrateGIDColumns(ctx context.Context, tx *sqlx.Tx, gid string) error {
+	tables := []struct {
+		name   string
+		addCmd engine.DBCmd
+	}{
+		{name: "messages", addCmd: CmdAddGIDColumnMessages},
+		{name: "spam", addCmd: CmdAddGIDColumnSpam},
+	}
+	for _, table := range tables {
+		hasGID, err := l.hasGIDColumn(ctx, tx, table.name)
+		if err != nil {
+			return fmt.Errorf("failed to check gid column on %s: %w", table.name, err)
+		}
+		if hasGID {
+			continue
+		}
+
+		addQuery, err := locatorQueries.Pick(l.Type(), table.addCmd)
+		if err != nil {
+			return fmt.Errorf("failed to get add GID query for %s: %w", table.name, err)
+		}
+		if _, err := tx.ExecContext(ctx, addQuery); err != nil && !strings.Contains(err.Error(), "duplicate column") {
+			return fmt.Errorf("failed to add gid column to %s: %w", table.name, err)
+		}
+
+		// update existing records with provided gid, table name is a hardcoded constant
+		query := l.Adopt(fmt.Sprintf("UPDATE %s SET gid = ? WHERE gid = ''", table.name)) //nolint:gosec // static table name
+		if _, err := tx.ExecContext(ctx, query, gid); err != nil {
+			return fmt.Errorf("failed to update gid for existing %s: %w", table.name, err)
+		}
+		log.Printf("[DEBUG] gid column added to %s and backfilled", table.name)
+	}
+	return nil
+}
+
+// hasGIDColumn reports whether the given table already has the gid column, using catalog
+// metadata instead of a probing query so a failed probe can't poison the transaction
+func (l *Locator) hasGIDColumn(ctx context.Context, tx *sqlx.Tx, table string) (bool, error) {
 	var count int
-	err := tx.GetContext(ctx, &count, "SELECT COUNT(*) FROM messages WHERE gid = ''")
-	if err == nil {
-		log.Printf("[DEBUG] locator tables already migrated")
+	switch l.Type() {
+	case engine.Sqlite:
+		if err := tx.GetContext(ctx, &count, "SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = 'gid'", table); err != nil {
+			return false, fmt.Errorf("failed to query table info: %w", err)
+		}
+	case engine.Postgres:
+		query := `SELECT COUNT(*) FROM information_schema.columns
+			WHERE table_name = $1 AND column_name = 'gid' AND table_schema = current_schema()`
+		if err := tx.GetContext(ctx, &count, query, table); err != nil {
+			return false, fmt.Errorf("failed to query information_schema: %w", err)
+		}
+	default:
+		return false, fmt.Errorf("unsupported database type %q", l.Type())
+	}
+	return count > 0, nil
+}
+
+// migratePrimaryKeys upgrades legacy single-column primary keys to composite (gid, ...) keys.
+// safe to run repeatedly: it detects the number of primary key columns and skips already-upgraded tables.
+// existing data can't violate the new keys: uniqueness on the old single column implies uniqueness on the pair.
+func (l *Locator) migratePrimaryKeys(ctx context.Context, tx *sqlx.Tx) error {
+	tables := []struct{ name, pkCols string }{
+		{name: "messages", pkCols: "gid, hash"},
+		{name: "spam", pkCols: "gid, user_id"},
+	}
+	for _, table := range tables {
+		var err error
+		switch l.Type() {
+		case engine.Sqlite:
+			err = l.migratePrimaryKeySqlite(ctx, tx, table.name, table.pkCols)
+		case engine.Postgres:
+			err = l.migratePrimaryKeyPostgres(ctx, tx, table.name, table.pkCols)
+		default:
+			err = fmt.Errorf("unsupported database type %q", l.Type())
+		}
+		if err != nil {
+			return fmt.Errorf("table %s: %w", table.name, err)
+		}
+	}
+	return nil
+}
+
+// migratePrimaryKeySqlite rebuilds the table with a composite primary key, sqlite can't alter primary keys in place.
+// indexes dropped with the old table are recreated by InitTable right after migration.
+func (l *Locator) migratePrimaryKeySqlite(ctx context.Context, tx *sqlx.Tx, table, pkCols string) error {
+	pk, err := l.primaryKeyColumns(ctx, tx, table)
+	if err != nil {
+		return err
+	}
+	if pk == pkCols {
+		return nil // already the expected composite key
+	}
+
+	// keep newSchemas and copyColumns in sync with the canonical CmdCreateLocatorTables schema:
+	// this rebuild path is permanent, and a column added only to the canonical schema would be
+	// silently dropped from a legacy database during the rebuild copy below.
+	newSchemas := map[string]string{
+		"messages": `CREATE TABLE messages_new (
+            hash TEXT NOT NULL,
+            gid TEXT NOT NULL DEFAULT '',
+            time TIMESTAMP,
+            chat_id INTEGER,
+            user_id INTEGER,
+            user_name TEXT,
+            msg_id INTEGER,
+            PRIMARY KEY (gid, hash)
+        )`,
+		"spam": `CREATE TABLE spam_new (
+            user_id INTEGER NOT NULL,
+            gid TEXT NOT NULL DEFAULT '',
+            time TIMESTAMP,
+            checks TEXT,
+            PRIMARY KEY (gid, user_id)
+        )`,
+	}
+	copyColumns := map[string]string{
+		"messages": "hash, gid, time, chat_id, user_id, user_name, msg_id",
+		"spam":     "user_id, gid, time, checks",
+	}
+
+	stmts := []string{
+		newSchemas[table],
+		fmt.Sprintf("INSERT INTO %[1]s_new (%[2]s) SELECT %[2]s FROM %[1]s", table, copyColumns[table]),
+		fmt.Sprintf("DROP TABLE %s", table),
+		fmt.Sprintf("ALTER TABLE %[1]s_new RENAME TO %[1]s", table),
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("failed to rebuild with composite primary key: %w", err)
+		}
+	}
+	log.Printf("[INFO] locator table %s rebuilt with composite primary key (%s)", table, pkCols)
+	return nil
+}
+
+// migratePrimaryKeyPostgres swaps the single-column primary key constraint for a composite one.
+// safe under concurrent upgraded starts sharing one database: it double-checks the primary key
+// under an exclusive table lock so only the first instance performs the swap.
+func (l *Locator) migratePrimaryKeyPostgres(ctx context.Context, tx *sqlx.Tx, table, pkCols string) error {
+	// fast path without taking an exclusive lock: already the expected composite key, nothing to do
+	pk, err := l.primaryKeyColumns(ctx, tx, table)
+	if err != nil {
+		return err
+	}
+	if pk == pkCols {
 		return nil
 	}
 
-	// add gid column to messages
-	addGIDMessagesQuery, err := locatorQueries.Pick(l.Type(), CmdAddGIDColumnMessages)
+	// lock the table so a second upgraded instance blocks here instead of racing the constraint
+	// swap, then re-check under the lock. the ALTER below needs this lock level anyway, so taking
+	// it explicitly on the migration path adds no extra contention.
+	if _, err = tx.ExecContext(ctx, "LOCK TABLE "+pq.QuoteIdentifier(table)+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+		return fmt.Errorf("failed to lock table for primary key migration: %w", err)
+	}
+	pk, err = l.primaryKeyColumns(ctx, tx, table)
 	if err != nil {
-		return fmt.Errorf("failed to get add messages GID query: %w", err)
+		return err
+	}
+	if pk == pkCols {
+		return nil // another instance completed the migration while we waited for the lock
 	}
 
-	_, err = tx.ExecContext(ctx, addGIDMessagesQuery)
-	if err != nil && !strings.Contains(err.Error(), "duplicate column") {
-		return fmt.Errorf("failed to add gid column to messages: %w", err)
+	var constraintName string
+	query := `SELECT tc.constraint_name FROM information_schema.table_constraints tc
+        WHERE tc.table_name = $1 AND tc.constraint_type = 'PRIMARY KEY' AND tc.table_schema = current_schema()`
+	if err := tx.GetContext(ctx, &constraintName, query, table); err != nil {
+		return fmt.Errorf("failed to get primary key constraint name: %w", err)
 	}
 
-	// add gid column to spam
-	addGIDSpamQuery, err := locatorQueries.Pick(l.Type(), CmdAddGIDColumnSpam)
-	if err != nil {
-		return fmt.Errorf("failed to get add spam GID query: %w", err)
+	//nolint:gosec // table and pkCols are hardcoded constants, constraint name comes from information_schema
+	alter := fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s, ADD PRIMARY KEY (%s)",
+		table, pq.QuoteIdentifier(constraintName), pkCols)
+	if _, err := tx.ExecContext(ctx, alter); err != nil {
+		return fmt.Errorf("failed to swap primary key constraint: %w", err)
 	}
-
-	_, err = tx.ExecContext(ctx, addGIDSpamQuery)
-	if err != nil && !strings.Contains(err.Error(), "duplicate column") {
-		return fmt.Errorf("failed to add gid column to spam: %w", err)
-	}
-
-	// update existing records with provided gid
-	query := l.Adopt("UPDATE messages SET gid = ? WHERE gid = ''")
-	if _, err = tx.ExecContext(ctx, query, gid); err != nil {
-		return fmt.Errorf("failed to update gid for existing messages: %w", err)
-	}
-
-	if _, err = tx.ExecContext(ctx, "UPDATE spam SET gid = ? WHERE gid = ''", gid); err != nil {
-		return fmt.Errorf("failed to update gid for existing spam: %w", err)
-	}
-
-	log.Printf("[DEBUG] locator tables migrated")
+	log.Printf("[INFO] locator table %s upgraded to composite primary key (%s)", table, pkCols)
 	return nil
+}
+
+// primaryKeyColumns returns the table's primary key columns in key order, joined as "a, b" to match
+// the pkCols form used by the migration. an empty string means no primary key.
+func (l *Locator) primaryKeyColumns(ctx context.Context, tx *sqlx.Tx, table string) (string, error) {
+	var cols []string
+	switch l.Type() {
+	case engine.Sqlite:
+		if err := tx.SelectContext(ctx, &cols,
+			"SELECT name FROM pragma_table_info(?) WHERE pk > 0 ORDER BY pk", table); err != nil {
+			return "", fmt.Errorf("failed to read sqlite primary key columns: %w", err)
+		}
+	case engine.Postgres:
+		query := `SELECT kcu.column_name FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+                ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+            WHERE tc.table_name = $1 AND tc.constraint_type = 'PRIMARY KEY' AND tc.table_schema = current_schema()
+            ORDER BY kcu.ordinal_position`
+		if err := tx.SelectContext(ctx, &cols, query, table); err != nil {
+			return "", fmt.Errorf("failed to read postgres primary key columns: %w", err)
+		}
+	default:
+		return "", fmt.Errorf("unsupported database type %q", l.Type())
+	}
+	return strings.Join(cols, ", "), nil
 }
 
 // Close closes the database

--- a/app/storage/locator_test.go
+++ b/app/storage/locator_test.go
@@ -3,7 +3,9 @@ package storage
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/umputun/tg-spam/app/storage/engine"
@@ -419,17 +421,61 @@ func (s *StorageTestSuite) TestLocator_Migration() {
 		db := dbt.DB
 
 		s.Run(fmt.Sprintf("with %s", db.Type()), func() {
-			if db.Type() == engine.Postgres {
-				s.T().Skip("skipping postgres for now")
+			// pkColCount returns the number of primary-key columns for a table, engine-aware
+			pkColCount := func(table string) int {
+				var n int
+				switch db.Type() {
+				case engine.Sqlite:
+					s.Require().NoError(db.Get(&n, "SELECT COUNT(*) FROM pragma_table_info('"+table+"') WHERE pk > 0"))
+				case engine.Postgres:
+					q := `SELECT COUNT(*) FROM information_schema.table_constraints tc
+						JOIN information_schema.key_column_usage kcu
+							ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+						WHERE tc.table_name = $1 AND tc.constraint_type = 'PRIMARY KEY' AND tc.table_schema = current_schema()`
+					s.Require().NoError(db.Get(&n, q, table))
+				}
+				return n
 			}
+
+			// gidColCount returns how many gid columns a table has, engine-aware
+			gidColCount := func(table string) int {
+				var n int
+				switch db.Type() {
+				case engine.Sqlite:
+					s.Require().NoError(db.Get(&n, "SELECT COUNT(*) FROM pragma_table_info('"+table+"') WHERE name = 'gid'"))
+				case engine.Postgres:
+					q := `SELECT COUNT(*) FROM information_schema.columns
+						WHERE table_name = $1 AND column_name = 'gid' AND table_schema = current_schema()`
+					s.Require().NoError(db.Get(&n, q, table))
+				}
+				return n
+			}
+
+			// pkColNames returns the primary-key columns in key order, engine-aware
+			pkColNames := func(table string) []string {
+				var names []string
+				switch db.Type() {
+				case engine.Sqlite:
+					s.Require().NoError(db.Select(&names, "SELECT name FROM pragma_table_info('"+table+"') WHERE pk > 0 ORDER BY pk"))
+				case engine.Postgres:
+					q := `SELECT kcu.column_name FROM information_schema.table_constraints tc
+						JOIN information_schema.key_column_usage kcu
+							ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+						WHERE tc.table_name = $1 AND tc.constraint_type = 'PRIMARY KEY' AND tc.table_schema = current_schema()
+						ORDER BY kcu.ordinal_position`
+					s.Require().NoError(db.Select(&names, q, table))
+				}
+				return names
+			}
+
 			db.Exec("DROP TABLE IF EXISTS messages")
 			db.Exec("DROP TABLE IF EXISTS spam")
 
 			s.Run("migrate from old schema", func() {
-				defer db.Exec("DROP TABLE messages")
-				defer db.Exec("DROP TABLE spam")
+				defer db.Exec("DROP TABLE IF EXISTS messages")
+				defer db.Exec("DROP TABLE IF EXISTS spam")
 
-				// setup old schema without gid
+				// setup old schema without gid, single-column primary keys (valid on both engines)
 				_, err := db.Exec(`
 					CREATE TABLE messages (
 						hash TEXT PRIMARY KEY,
@@ -448,99 +494,290 @@ func (s *StorageTestSuite) TestLocator_Migration() {
 				s.Require().NoError(err)
 
 				// insert test data in old format
-				_, err = db.Exec(`INSERT INTO messages (hash, time, chat_id, user_id, user_name, msg_id)
-            		VALUES ('hash1', ?, 1, 100, 'user1', 1)`, time.Now())
+				_, err = db.Exec(db.Adopt(`INSERT INTO messages (hash, time, chat_id, user_id, user_name, msg_id)
+					VALUES ('hash1', ?, 1, 100, 'user1', 1)`), time.Now())
 				s.Require().NoError(err)
 
 				checksJSON := `[{"Name":"test","Spam":true,"Details":"test"}]`
-				_, err = db.Exec(`INSERT INTO spam (user_id, time, checks)
-            		VALUES (100, ?, ?)`, time.Now(), checksJSON)
+				_, err = db.Exec(db.Adopt(`INSERT INTO spam (user_id, time, checks) VALUES (100, ?, ?)`), time.Now(), checksJSON)
 				s.Require().NoError(err)
 
 				// run migration through NewLocator
-				_, err = NewLocator(context.Background(), 10*time.Minute, 1, db)
+				_, err = NewLocator(ctx, 10*time.Minute, 1, db)
 				s.Require().NoError(err)
 
-				// verify structure
-				var msgCols, spamCols []struct {
-					CID       int     `db:"cid"`
-					Name      string  `db:"name"`
-					Type      string  `db:"type"`
-					NotNull   bool    `db:"notnull"`
-					DfltValue *string `db:"dflt_value"`
-					PK        bool    `db:"pk"`
-				}
-				err = db.Select(&msgCols, "PRAGMA table_info(messages)")
-				s.Require().NoError(err)
-				err = db.Select(&spamCols, "PRAGMA table_info(spam)")
-				s.Require().NoError(err)
-
-				msgColMap := make(map[string]string)
-				for _, col := range msgCols {
-					msgColMap[col.Name] = col.Type
-				}
-				s.Equal("TEXT", msgColMap["gid"])
-
-				spamColMap := make(map[string]string)
-				for _, col := range spamCols {
-					spamColMap[col.Name] = col.Type
-				}
-				s.Equal("TEXT", spamColMap["gid"])
-
-				// verify data migrated correctly
+				// gid column added to both tables and backfilled with the connection's gid
+				s.Equal(1, gidColCount("messages"))
+				s.Equal(1, gidColCount("spam"))
 				var msgGID, spamGID string
-				err = db.Get(&msgGID, "SELECT gid FROM messages WHERE hash = 'hash1'")
-				s.Require().NoError(err)
+				s.Require().NoError(db.Get(&msgGID, db.Adopt("SELECT gid FROM messages WHERE hash = ?"), "hash1"))
 				s.Equal("gr1", msgGID)
-
-				err = db.Get(&spamGID, "SELECT gid FROM spam WHERE user_id = 100")
-				s.Require().NoError(err)
+				s.Require().NoError(db.Get(&spamGID, db.Adopt("SELECT gid FROM spam WHERE user_id = ?"), 100))
 				s.Equal("gr1", spamGID)
+
+				// full row survived the rebuild/backfill, not just hash and gid
+				var m MsgMeta
+				s.Require().NoError(db.Get(&m,
+					db.Adopt("SELECT time, chat_id, user_id, user_name, msg_id FROM messages WHERE hash = ? AND gid = ?"),
+					"hash1", "gr1"))
+				s.Equal(int64(1), m.ChatID)
+				s.Equal(int64(100), m.UserID)
+				s.Equal("user1", m.UserName)
+				s.Equal(1, m.MsgID)
+
+				// primary keys upgraded to the exact composite columns in key order
+				s.Equal([]string{"gid", "hash"}, pkColNames("messages"), "messages pk should be (gid, hash)")
+				s.Equal([]string{"gid", "user_id"}, pkColNames("spam"), "spam pk should be (gid, user_id)")
+
+				// the migrated tables accept real upserts: a repeated insert must resolve through
+				// ON CONFLICT (gid, hash)/(gid, user_id) rather than error or duplicate
+				loc, err := NewLocator(ctx, 10*time.Minute, 1, db)
+				s.Require().NoError(err)
+				s.Require().NoError(loc.AddMessage(ctx, "post-migration text", 7, 500, "u500", 9))
+				s.Require().NoError(loc.AddMessage(ctx, "post-migration text", 7, 500, "u500", 11)) // upsert
+				got, found := loc.Message(ctx, "post-migration text")
+				s.Require().True(found)
+				s.Equal(11, got.MsgID, "upsert should update the existing row in place")
+				s.Require().NoError(loc.AddSpam(ctx, 500, []spamcheck.Response{{Name: "a", Spam: true}}))
+				s.Require().NoError(loc.AddSpam(ctx, 500, []spamcheck.Response{{Name: "b", Spam: false}})) // upsert
+				sd, found := loc.Spam(ctx, 500)
+				s.Require().True(found)
+				s.False(sd.Checks[0].Spam, "spam upsert should replace the existing row")
+			})
+
+			s.Run("migrate from partial schema", func() {
+				defer db.Exec("DROP TABLE IF EXISTS messages")
+				defer db.Exec("DROP TABLE IF EXISTS spam")
+
+				// messages already has gid (nullable, as the real migration adds it), spam does not -
+				// each table must migrate independently
+				_, err := db.Exec(`
+					CREATE TABLE messages (
+						hash TEXT PRIMARY KEY,
+						gid TEXT DEFAULT '',
+						time TIMESTAMP,
+						chat_id INTEGER,
+						user_id INTEGER,
+						user_name TEXT,
+						msg_id INTEGER
+					);
+					CREATE TABLE spam (
+						user_id INTEGER PRIMARY KEY,
+						time TIMESTAMP,
+						checks TEXT
+					)
+				`)
+				s.Require().NoError(err)
+
+				checksJSON := `[{"Name":"test","Spam":true,"Details":"test"}]`
+				_, err = db.Exec(db.Adopt(`INSERT INTO spam (user_id, time, checks) VALUES (100, ?, ?)`), time.Now(), checksJSON)
+				s.Require().NoError(err)
+
+				_, err = NewLocator(ctx, 10*time.Minute, 1, db)
+				s.Require().NoError(err)
+
+				// spam got the gid column backfilled and both tables got composite keys
+				var spamGID string
+				s.Require().NoError(db.Get(&spamGID, db.Adopt("SELECT gid FROM spam WHERE user_id = ?"), 100))
+				s.Equal("gr1", spamGID)
+
+				s.Equal(2, pkColCount("messages"))
+				s.Equal(2, pkColCount("spam"))
 			})
 
 			s.Run("migration idempotency", func() {
-				_, err := NewLocator(ctx, time.Hour, 1000, db)
-				s.Require().NoError(err)
-				defer db.Exec("DROP TABLE messages")
-				defer db.Exec("DROP TABLE spam")
+				defer db.Exec("DROP TABLE IF EXISTS messages")
+				defer db.Exec("DROP TABLE IF EXISTS spam")
 
-				// create schema with new tables including gid
+				// start from the current schema (already composite + gid), then run migration twice
 				createSchema, err := locatorQueries.Pick(db.Type(), CmdCreateLocatorTables)
 				s.Require().NoError(err)
 				_, err = db.Exec(createSchema)
 				s.Require().NoError(err)
 
-				// create first locator which should trigger migration
-				_, err = NewLocator(context.Background(), 10*time.Minute, 1, db)
+				_, err = NewLocator(ctx, 10*time.Minute, 1, db)
+				s.Require().NoError(err)
+				_, err = NewLocator(ctx, 10*time.Minute, 1, db)
 				s.Require().NoError(err)
 
-				// create second locator which should trigger migration again
-				_, err = NewLocator(context.Background(), 10*time.Minute, 1, db)
-				s.Require().NoError(err)
-
-				// verify structure remained the same
-				var msgCols []struct {
-					CID       int     `db:"cid"`
-					Name      string  `db:"name"`
-					Type      string  `db:"type"`
-					NotNull   bool    `db:"notnull"`
-					DfltValue *string `db:"dflt_value"`
-					PK        bool    `db:"pk"`
-				}
-				err = db.Select(&msgCols, "PRAGMA table_info(messages)")
-				s.Require().NoError(err)
-
-				gidColCount := 0
-				for _, col := range msgCols {
-					if col.Name == "gid" {
-						gidColCount++
-					}
-				}
-				s.Equal(1, gidColCount, "should have exactly one gid column")
+				// still exactly one gid column and a composite primary key
+				s.Equal(1, gidColCount("messages"), "should have exactly one gid column")
+				s.Equal(2, pkColCount("messages"))
 			})
 		})
 	}
+}
 
+func (s *StorageTestSuite) TestLocator_MigratePrimaryKeyPostgres() {
+	if testing.Short() {
+		s.T().Skip("skipping postgres test in short mode")
+	}
+	if s.pgContainer == nil {
+		s.T().Skip("postgres is not available")
+	}
+
+	ctx := context.Background()
+	db, err := engine.NewPostgres(ctx, s.pgContainer.ConnectionString(), "gr1")
+	s.Require().NoError(err)
+	defer db.Close()
+
+	db.Exec("DROP TABLE IF EXISTS messages")
+	db.Exec("DROP TABLE IF EXISTS spam")
+	defer db.Exec("DROP TABLE IF EXISTS messages")
+	defer db.Exec("DROP TABLE IF EXISTS spam")
+
+	// legacy schema: gid column present but single-column primary keys. gid is nullable to match
+	// how the real migration adds it (ADD COLUMN ... DEFAULT ''), so the constraint swap must rely
+	// on the implicit SET NOT NULL that ADD PRIMARY KEY performs on the composite columns
+	_, err = db.Exec(`
+		CREATE TABLE messages (
+			hash TEXT PRIMARY KEY,
+			gid TEXT DEFAULT '',
+			time TIMESTAMP,
+			chat_id BIGINT,
+			user_id BIGINT,
+			user_name TEXT,
+			msg_id INTEGER
+		);
+		CREATE TABLE spam (
+			user_id BIGINT PRIMARY KEY,
+			gid TEXT DEFAULT '',
+			time TIMESTAMP,
+			checks TEXT
+		)
+	`)
+	s.Require().NoError(err)
+
+	_, err = db.Exec(`INSERT INTO messages (hash, gid, time, chat_id, user_id, user_name, msg_id)
+		VALUES ('hash1', 'gr1', now(), 1, 100, 'user1', 1)`)
+	s.Require().NoError(err)
+
+	// run migration through NewLocator
+	_, err = NewLocator(ctx, 10*time.Minute, 1, db)
+	s.Require().NoError(err)
+
+	pkColsQuery := `SELECT COUNT(*) FROM information_schema.table_constraints tc
+		JOIN information_schema.key_column_usage kcu
+			ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+		WHERE tc.table_name = $1 AND tc.constraint_type = 'PRIMARY KEY' AND tc.table_schema = current_schema()`
+
+	var msgPKCols, spamPKCols int
+	s.Require().NoError(db.Get(&msgPKCols, pkColsQuery, "messages"))
+	s.Equal(2, msgPKCols, "messages should have composite (gid, hash) primary key")
+	s.Require().NoError(db.Get(&spamPKCols, pkColsQuery, "spam"))
+	s.Equal(2, spamPKCols, "spam should have composite (gid, user_id) primary key")
+
+	// verify data survived the constraint swap
+	var hash string
+	s.Require().NoError(db.Get(&hash, "SELECT hash FROM messages WHERE gid = 'gr1'"))
+	s.Equal("hash1", hash)
+
+	// migration is idempotent
+	_, err = NewLocator(ctx, 10*time.Minute, 1, db)
+	s.Require().NoError(err)
+}
+
+func (s *StorageTestSuite) TestLocator_FreesMisplacedSpamIndex() {
+	if testing.Short() {
+		s.T().Skip("skipping postgres test in short mode")
+	}
+	if s.pgContainer == nil {
+		s.T().Skip("postgres is not available")
+	}
+
+	ctx := context.Background()
+	db, err := engine.NewPostgres(ctx, s.pgContainer.ConnectionString(), "gr1")
+	s.Require().NoError(err)
+	defer db.Close()
+
+	db.Exec("DROP TABLE IF EXISTS messages")
+	db.Exec("DROP TABLE IF EXISTS spam")
+	db.Exec("DROP TABLE IF EXISTS legacy_squatter")
+	defer db.Exec("DROP TABLE IF EXISTS messages")
+	defer db.Exec("DROP TABLE IF EXISTS spam")
+	defer db.Exec("DROP TABLE IF EXISTS legacy_squatter")
+
+	// an older schema squatted the schema-global idx_spam_gid_time name on another table
+	_, err = db.Exec(`CREATE TABLE legacy_squatter (gid TEXT, ts TIMESTAMP);
+		CREATE INDEX idx_spam_gid_time ON legacy_squatter(gid, ts DESC)`)
+	s.Require().NoError(err)
+
+	// locator init must free the name and create its own index on the spam table in the same pass
+	_, err = NewLocator(ctx, 10*time.Minute, 1, db)
+	s.Require().NoError(err)
+
+	var table string
+	s.Require().NoError(db.Get(&table,
+		`SELECT tablename FROM pg_indexes WHERE indexname = 'idx_spam_gid_time' AND schemaname = current_schema()`))
+	s.Equal("spam", table, "idx_spam_gid_time should now belong to the locator's spam table")
+}
+
+func (s *StorageTestSuite) TestLocator_SharedDBGIDIsolation() {
+	ctx := context.Background()
+
+	testIsolation := func(db1, db2 *engine.SQL) {
+		locator1, err := NewLocator(ctx, time.Hour, 5, db1)
+		s.Require().NoError(err)
+		locator2, err := NewLocator(ctx, time.Hour, 5, db2)
+		s.Require().NoError(err)
+
+		// same text lands in both groups, the upsert must not clobber the other group's row
+		msg := "identical message posted in two groups"
+		s.Require().NoError(locator1.AddMessage(ctx, msg, 100, 1, "user1", 1))
+		s.Require().NoError(locator2.AddMessage(ctx, msg, 200, 2, "user2", 2))
+
+		meta1, found := locator1.Message(ctx, msg)
+		s.Require().True(found, "group1 message should survive group2 insert of the same text")
+		s.Equal(int64(100), meta1.ChatID)
+		s.Equal("user1", meta1.UserName)
+
+		meta2, found := locator2.Message(ctx, msg)
+		s.Require().True(found)
+		s.Equal(int64(200), meta2.ChatID)
+		s.Equal("user2", meta2.UserName)
+
+		// same user flagged in both groups, spam data must stay per-group
+		s.Require().NoError(locator1.AddSpam(ctx, 42, []spamcheck.Response{{Name: "check1", Spam: true}}))
+		s.Require().NoError(locator2.AddSpam(ctx, 42, []spamcheck.Response{{Name: "check2", Spam: false}}))
+
+		spam1, found := locator1.Spam(ctx, 42)
+		s.Require().True(found, "group1 spam data should survive group2 insert for the same user")
+		s.True(spam1.Checks[0].Spam)
+
+		spam2, found := locator2.Spam(ctx, 42)
+		s.Require().True(found)
+		s.False(spam2.Checks[0].Spam)
+	}
+
+	s.Run("sqlite shared file", func() {
+		file := filepath.Join(s.T().TempDir(), "shared.db")
+		db1, err := engine.NewSqlite(file, "gr1")
+		s.Require().NoError(err)
+		defer db1.Close()
+		db2, err := engine.NewSqlite(file, "gr2")
+		s.Require().NoError(err)
+		defer db2.Close()
+		testIsolation(db1, db2)
+	})
+
+	s.Run("postgres shared database", func() {
+		if testing.Short() {
+			s.T().Skip("skipping postgres test in short mode")
+		}
+		if s.pgContainer == nil {
+			s.T().Skip("postgres is not available")
+		}
+		connStr := s.pgContainer.ConnectionString()
+		db1, err := engine.NewPostgres(ctx, connStr, "loc-iso-gr1")
+		s.Require().NoError(err)
+		defer db1.Close()
+		db2, err := engine.NewPostgres(ctx, connStr, "loc-iso-gr2")
+		s.Require().NoError(err)
+		defer db2.Close()
+		defer db1.Exec("DELETE FROM messages WHERE gid IN ('loc-iso-gr1', 'loc-iso-gr2')")
+		defer db1.Exec("DELETE FROM spam WHERE gid IN ('loc-iso-gr1', 'loc-iso-gr2')")
+		testIsolation(db1, db2)
+	})
 }
 
 func (s *StorageTestSuite) TestLocator_GIDIsolation() {


### PR DESCRIPTION
`messages.hash` and `spam.user_id` were single-column primary keys while the upserts overwrite `gid` on conflict, so two instances with different `--instance-id` sharing one database destroy each other's rows: the same text (or a spam flag for the same user id) posted in group B clobbers group A's row, silently breaking `/spam` reply-matching and the spam-info/unban buttons.

Keys are now composite: `(gid, hash)` and `(gid, user_id)`. Existing databases upgrade at startup inside the existing migration transaction — sqlite rebuilds the tables (indexes recreated by `InitTable` right after), postgres swaps the PK constraint in place. Both paths are idempotent; old data can't violate the new keys since uniqueness on the single column implies uniqueness on the pair.

Tests: shared-DB isolation for both engines (the old isolation test used two separate databases, which is why it never caught this), postgres legacy-PK migration, and partial-schema migration.

Also addresses review feedback: gid columns are checked per table via catalog metadata (codex), the spam gid backfill goes through `Adopt` for postgres (Copilot on #405), and the constraint name is quoted with `pq.QuoteIdentifier` (codex).

Split from #405; siblings: #405 (approvedUsers race), #408 (x/net update — pending), #406 (e2e-ui playwright pin). Carries a copy of the #406 commit so e2e-ui can run green; it drops out on rebase once #406 merges.