### PR TITLE
fix: Last(n) returns the most recent requests instead of the oldest

### DIFF
--- a/lib/spamcheck/history.go
+++ b/lib/spamcheck/history.go
@@ -40,7 +40,7 @@ func (h *LastRequests) Push(req Request) {
 	h.requests = h.requests.Next()
 }
 
-// Last returns up to n last requests in chronological order (oldest to newest)
+// Last returns up to n most recent requests in chronological order (oldest to newest)
 func (h *LastRequests) Last(n int) []Request {
 	if n < 1 {
 		return []Request{}
@@ -63,7 +63,7 @@ func (h *LastRequests) Last(n int) []Request {
 	})
 
 	if len(result) > n {
-		result = result[:n]
+		result = result[len(result)-n:]
 	}
 	return result
 }

--- a/lib/spamcheck/history_test.go
+++ b/lib/spamcheck/history_test.go
@@ -56,7 +56,7 @@ func TestLastRequestsSmallerRequest(t *testing.T) {
 
 	res := h.Last(1)
 	require.Len(t, res, 1)
-	assert.Equal(t, req1, res[0])
+	assert.Equal(t, req2, res[0], "Last(1) should return the most recent request")
 }
 
 func TestLastRequestsConcurrent(t *testing.T) {


### PR DESCRIPTION
`LastRequests.Last` walked the ring oldest to newest and truncated with `result[:n]`, keeping the oldest n entries. The LLM checkers use it to build recent-context history, so with the in-memory ring at its default 100 and a smaller per-provider history size they received the stalest ham messages instead of the latest. Keep the tail of the walk instead; the test that enshrined the old behaviour is updated.

codex xhigh review: no findings in the change itself. Part of the review-findings series (#405). Carries a copy of the #406 e2e-ui playwright pin commit so CI runs green; it drops out on rebase once #406 merges.