### PR TITLE
fix: guard nil From in listener update loop

### DIFF
--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -187,7 +187,8 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 
 			// handle admin chat messages. can be just messages (MsgHandler will ignore those)
 			// or forwards of undetected spam by admins to admin's chat (in this case MsgHandler will process them and ban/train)
-			if update.Message != nil && l.isAdminChat(update.Message.Chat.ID, update.Message.From.UserName, update.Message.From.ID) {
+			if update.Message != nil && update.Message.From != nil &&
+				l.isAdminChat(update.Message.Chat.ID, update.Message.From.UserName, update.Message.From.ID) {
 				if l.DisableAdminSpamForward {
 					continue
 				}
@@ -280,6 +281,15 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 				// immediately delete leave message if requested
 				if l.DeleteLeaveMessages {
 					l.deleteSystemMessage(update.Message.MessageID, update.Message.Chat.ID, "leave")
+				}
+				continue
+			}
+
+			// messages without a sender can't be matched against superusers or report commands,
+			// send them straight to the regular processing which handles nil From safely
+			if update.Message.From == nil {
+				if err := l.procEvents(update); err != nil {
+					log.Printf("[WARN] failed to process update: %v", err)
 				}
 				continue
 			}

--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -101,6 +101,60 @@ func TestTelegramListener_Do(t *testing.T) {
 
 }
 
+func TestTelegramListener_DoNilFrom(t *testing.T) {
+	mockLogger := &mocks.SpamLoggerMock{SaveFunc: func(msg *bot.Message, response *bot.Response) {}}
+	mockAPI := &mocks.TbAPIMock{
+		GetChatFunc: func(config tbapi.ChatInfoConfig) (tbapi.ChatFullInfo, error) {
+			return tbapi.ChatFullInfo{Chat: tbapi.Chat{ID: 123}}, nil
+		},
+		SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+			return tbapi.Message{Text: c.(tbapi.MessageConfig).Text, From: &tbapi.User{UserName: "user"}}, nil
+		},
+		GetChatAdministratorsFunc: func(config tbapi.ChatAdministratorsConfig) ([]tbapi.ChatMember, error) {
+			return []tbapi.ChatMember{}, nil
+		},
+	}
+	botMock := &mocks.BotMock{OnMessageFunc: func(msg bot.Message, checkOnly bool) bot.Response {
+		return bot.Response{}
+	}}
+
+	locator, teardown := prepTestLocator(t)
+	defer teardown()
+
+	l := TelegramListener{
+		SpamLogger: mockLogger,
+		TbAPI:      mockAPI,
+		Bot:        botMock,
+		Group:      "gr",
+		AdminGroup: "987654321",
+		Locator:    locator,
+		SuperUsers: SuperUsers{"super"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// group message without a sender must pass through the Do loop without panicking,
+	// both on the admin-chat check and on the superuser/report checks
+	updMsg := tbapi.Update{
+		Message: &tbapi.Message{
+			Chat: tbapi.Chat{ID: 123, Type: "supergroup"},
+			Text: "text 123",
+			Date: int(time.Date(2020, 2, 11, 19, 35, 55, 9, time.UTC).Unix()),
+		},
+	}
+
+	updChan := make(chan tbapi.Update, 1)
+	updChan <- updMsg
+	close(updChan)
+	mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+	err := l.Do(ctx)
+	require.EqualError(t, err, "telegram update chan closed")
+	require.Len(t, botMock.OnMessageCalls(), 1, "nil-From message should still reach regular processing")
+	assert.Equal(t, "text 123", botMock.OnMessageCalls()[0].Msg.Text)
+}
+
 func TestTelegramListener_DoWithBotBan(t *testing.T) {
 	mockLogger := &mocks.SpamLoggerMock{SaveFunc: func(msg *bot.Message, response *bot.Response) {}}
 	mockAPI := &mocks.TbAPIMock{


### PR DESCRIPTION
The Do loop dereferenced `update.Message.From` on the admin-chat check and the superuser/report checks with no nil check, ahead of the nil-From handling in procEvents. A message without a sender panics the process — there is no recover in the loop. The codebase already treats nil From as possible (transform guards it, and a dedicated procEvents-level test exists), but nothing protected the loop itself.

Skip the admin-chat match for nil-From messages and route them straight to procEvents, whose transform already produces a zero-value From. Covered by a Do-loop-level test with a nil-From group message.

codex xhigh review noted that `SpamFilter.OnMessage` returns early on `From.ID == 0` before its SenderChat substitution, so a hypothetical From=nil+SenderChat post would not be spam-checked — that behaviour is pre-existing and unchanged here, and real channel posts always carry the shared Channel_Bot user in From, so the shape does not occur in practice. Part of the review-findings series (#405). Carries a copy of the #406 e2e-ui playwright pin commit so CI runs green; it drops out on rebase once #406 merges.