### PR TITLE
ci: fix invalid paths_ignored key in build-app workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,12 @@
 name: build-app
 on:
   push:
-    branches:
-    tags:
-    paths_ignored:
+    paths-ignore:
       - ".github/workflows/updater.yml"
       - "updater/**"
       - "**.md"
   pull_request:
-    paths_ignored:
+    paths-ignore:
       - ".github/workflows/updater.yml"
       - "updater/**"
       - "**.md"


### PR DESCRIPTION
GitHub Actions silently ignores the unknown `paths_ignored` key (the valid form is `paths-ignore`), so the intended skip for docs-only and updater-only changes never applied and build-app ran on every push. Tag pushes keep triggering the workflow since GitHub does not evaluate path filters for tags, so the docker release chain is unaffected. Also drops the empty `branches:`/`tags:` filters that matched everything anyway.

codex xhigh review: no findings. Part of the review-findings series (#405).