### PR TITLE
fix: remove duplicate detected_spam index with colliding name

### DIFF
--- a/app/storage/detected_spam.go
+++ b/app/storage/detected_spam.go
@@ -70,7 +70,6 @@ var detectedSpamQueries = engine.NewQueryMap().
 	AddSame(CmdCreateDetectedSpamIndexes, `
       	CREATE INDEX IF NOT EXISTS idx_detected_spam_gid_ts ON detected_spam(gid, timestamp DESC);
         CREATE INDEX IF NOT EXISTS idx_detected_spam_user_id_gid ON detected_spam(user_id, gid);
-		CREATE INDEX IF NOT EXISTS idx_spam_gid_time ON detected_spam(gid, timestamp DESC);
         CREATE INDEX IF NOT EXISTS idx_detected_spam_gid ON detected_spam(gid)`,
 	).
 	Add(CmdAddGIDColumn, engine.Query{
@@ -182,6 +181,20 @@ func (ds *DetectedSpam) FindByUserID(ctx context.Context, userID int64) (*Detect
 }
 
 func (ds *DetectedSpam) migrate(ctx context.Context, tx *sqlx.Tx, gid string) error {
+	if err := ds.migrateGIDColumn(ctx, tx, gid); err != nil {
+		return err
+	}
+	// drop the stray idx_spam_gid_time on detected_spam left behind by older versions: it
+	// duplicated idx_detected_spam_gid_ts, and its name collides with the locator's
+	// spam(gid, time) index on postgres where index names are schema-wide
+	if err := ds.dropStrayIndex(ctx, tx); err != nil {
+		return fmt.Errorf("failed to drop stray detected_spam index: %w", err)
+	}
+	return nil
+}
+
+// migrateGIDColumn adds the gid column and backfills it with the provided gid
+func (ds *DetectedSpam) migrateGIDColumn(ctx context.Context, tx *sqlx.Tx, gid string) error {
 	// try to select with new structure, if works - already migrated
 	var count int
 	err := tx.GetContext(ctx, &count, "SELECT COUNT(*) FROM detected_spam WHERE gid = ''")
@@ -207,5 +220,32 @@ func (ds *DetectedSpam) migrate(ctx context.Context, tx *sqlx.Tx, gid string) er
 	}
 
 	log.Printf("[DEBUG] detected_spam table migrated")
+	return nil
+}
+
+// dropStrayIndex removes the idx_spam_gid_time index from detected_spam on existing databases.
+// on sqlite the locator never uses this name so it can only belong to detected_spam; on postgres
+// the locator legitimately owns it on the spam table, so it is dropped only when it belongs here.
+func (ds *DetectedSpam) dropStrayIndex(ctx context.Context, tx *sqlx.Tx) error {
+	switch ds.Type() {
+	case engine.Sqlite:
+		if _, err := tx.ExecContext(ctx, "DROP INDEX IF EXISTS idx_spam_gid_time"); err != nil {
+			return fmt.Errorf("sqlite drop failed: %w", err)
+		}
+	case engine.Postgres:
+		var count int
+		query := `SELECT COUNT(*) FROM pg_indexes
+			WHERE indexname = 'idx_spam_gid_time' AND tablename = 'detected_spam' AND schemaname = current_schema()`
+		if err := tx.GetContext(ctx, &count, query); err != nil {
+			return fmt.Errorf("postgres index lookup failed: %w", err)
+		}
+		if count > 0 {
+			if _, err := tx.ExecContext(ctx, "DROP INDEX idx_spam_gid_time"); err != nil {
+				return fmt.Errorf("postgres drop failed: %w", err)
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported database type %q", ds.Type())
+	}
 	return nil
 }

--- a/app/storage/detected_spam_test.go
+++ b/app/storage/detected_spam_test.go
@@ -402,3 +402,35 @@ func (s *StorageTestSuite) TestDetectedSpam_FindByUserID() {
 		})
 	}
 }
+
+func (s *StorageTestSuite) TestDetectedSpam_DropStrayIndex() {
+	ctx := context.Background()
+	for _, dbt := range s.getTestDB() {
+		db := dbt.DB
+		s.Run(fmt.Sprintf("with %s", db.Type()), func() {
+			db.Exec("DROP TABLE IF EXISTS detected_spam")
+			defer db.Exec("DROP TABLE IF EXISTS detected_spam")
+
+			// create the table via first init, then plant the stray index older versions created
+			_, err := NewDetectedSpam(ctx, db)
+			s.Require().NoError(err)
+			db.Exec("DROP INDEX IF EXISTS idx_spam_gid_time") // free the name in case another table owns it
+			_, err = db.Exec("CREATE INDEX idx_spam_gid_time ON detected_spam(gid, timestamp DESC)")
+			s.Require().NoError(err)
+
+			// re-init runs the migration which must drop the stray index
+			_, err = NewDetectedSpam(ctx, db)
+			s.Require().NoError(err)
+
+			var count int
+			switch db.Type() {
+			case engine.Sqlite:
+				err = db.Get(&count, "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_spam_gid_time'")
+			case engine.Postgres:
+				err = db.Get(&count, "SELECT COUNT(*) FROM pg_indexes WHERE indexname='idx_spam_gid_time' AND tablename='detected_spam'")
+			}
+			s.Require().NoError(err)
+			s.Equal(0, count, "stray index should be dropped by migration")
+		})
+	}
+}


### PR DESCRIPTION
`idx_spam_gid_time` on detected_spam duplicated `idx_detected_spam_gid_ts` (identical columns) and collided by name with the locator's legitimate `idx_spam_gid_time` on the spam table. Index names are database-global in both sqlite and postgres and `CREATE INDEX IF NOT EXISTS` matches by name only, so whichever table initialised second silently skipped its index.

Removes the stray creation and adds a guarded migration for existing databases: on sqlite the name can only belong to detected_spam (the locator never uses it there) so it is dropped outright; on postgres it is dropped only when pg_indexes shows it on detected_spam, leaving the locator's index untouched. codex xhigh review flagged the existing-database case on the first pass; addressed with the migration plus a test. Part of the review-findings series (#405). Carries a copy of the #406 e2e-ui playwright pin commit so CI runs green; it drops out on rebase once #406 merges.