### PR TITLE
chore: remove dead gid-column query registration from samples

### DIFF
--- a/app/storage/samples.go
+++ b/app/storage/samples.go
@@ -96,10 +96,6 @@ var samplesQueries = engine.NewQueryMap().
 			CREATE INDEX IF NOT EXISTS idx_samples_gid ON samples(gid);
 			CREATE INDEX IF NOT EXISTS idx_samples_origin ON samples(gid,origin);
 			CREATE INDEX IF NOT EXISTS idx_samples_message_hash ON samples(message_hash);`,
-	}).
-	Add(CmdAddGIDColumn, engine.Query{
-		Sqlite:   "ALTER TABLE samples ADD COLUMN gid TEXT DEFAULT ''",
-		Postgres: "ALTER TABLE samples ADD COLUMN IF NOT EXISTS gid TEXT DEFAULT ''",
 	})
 
 // NewSamples creates a new Samples storage


### PR DESCRIPTION
`Samples.migrate` is a no-op, so the registered `CmdAddGIDColumn` query can never be picked. Dead since the samples table gained gid in its create statement.

codex xhigh review: no findings, confirmed unused. Part of the review-findings series (#405). Carries a copy of the #406 e2e-ui playwright pin commit so CI runs green; it drops out on rebase once #406 merges.