### PR TITLE
perf: reuse a single idle timer in the update loop

### DIFF
--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -175,7 +175,12 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 
 	updates := l.TbAPI.GetUpdatesChan(u)
 	log.Printf("[DEBUG] start listening for updates")
+	// single reusable idle timer, re-armed each iteration: time.After in a loop leaks one
+	// live timer per update until it fires
+	idleTimer := time.NewTimer(l.IdleDuration)
+	defer idleTimer.Stop()
 	for {
+		idleTimer.Reset(l.IdleDuration)
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("listener context canceled: %w", ctx.Err())
@@ -331,7 +336,7 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 				continue
 			}
 
-		case <-time.After(l.IdleDuration): // hit bots on idle timeout
+		case <-idleTimer.C: // hit bots on idle timeout
 			resp := l.Bot.OnMessage(bot.Message{Text: "idle"}, false)
 			if err := l.sendBotResponse(resp, l.chatID, NotificationSilent); err != nil {
 				log.Printf("[WARN] failed to respond on idle, %v", err)


### PR DESCRIPTION
`time.After` allocated a fresh timer every loop iteration; each abandoned timer stays live until it fires (up to IdleDuration), accumulating one per update under sustained traffic. Use one timer re-armed per iteration; `Timer.Reset` without drain is safe since Go 1.23 and the module requires 1.25.

codex xhigh review: no findings. Part of the review-findings series (#405). Carries a copy of the #406 e2e-ui playwright pin commit so CI runs green; it drops out on rebase once #406 merges.