### PR TITLE
fix: drop world-writable permissions on docker preset dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY entrypoint.sh /srv/entrypoint.sh
 RUN \
  adduser -s /bin/sh -D -u 1000 app && chown -R app:app /home/app && \
  chown -R app:app /srv/preset /srv/data && \
- chmod -R 777 /srv/preset && \
+ chmod -R 755 /srv/preset && \
  chmod -R 775 /srv/data && \
  chmod +x /srv/entrypoint.sh && \
  ls -la /srv/preset


### PR DESCRIPTION
The preset files are copied into the writable data dir by entrypoint.sh on first start and only read afterwards; 777 let any other uid in the container tamper with the seed spam/ham samples. The dir is owned by the app user, 755 keeps the build-time conversion and runtime copy working.

codex xhigh review: no findings, verified against entrypoint.sh and the build-time convert step. Part of the review-findings series (#405).