### PR TITLE
fix: pin htmx version and add SRI to admin UI CDN assets

### DIFF
--- a/app/webapi/assets/components/heads.html
+++ b/app/webapi/assets/components/heads.html
@@ -1,5 +1,9 @@
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
-<script src="https://unpkg.com/htmx.org"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
+      integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet"
+      integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
+<script src="https://unpkg.com/htmx.org@2.0.10/dist/htmx.min.js"
+        integrity="sha384-H5SrcfygHmAuTDZphMHqBJLc3FhssKjG7w/CeCpFReSfwBWDTKpkzPP8c+cLsK+V" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-U1DAWAznBHeqEIlVSCgzq+c9gqGAJn5c/t99JyeKa9xxaYpSvHU5awsuZVVFIhvj" crossorigin="anonymous"></script>
 <link href="styles.css" rel="stylesheet">


### PR DESCRIPTION
The admin UI loaded whatever the latest htmx happened to be from unpkg with no integrity check, and the pinned bootstrap assets also lacked SRI. A CDN compromise would run arbitrary JS in the authenticated admin's browser with full bot control including DB download via the backup endpoint. Pin htmx to 2.0.10 and add sha384 integrity attributes to all four external resources; hashes computed from the actual CDN responses, and the e2e-ui suite loads the page in a real browser so a hash mismatch fails CI.

codex xhigh review: no findings (confirmed the htmx 2.0.10 tag and template compatibility). Part of the review-findings series (#405). Carries a copy of the #406 e2e-ui playwright pin commit so CI runs green; it drops out on rebase once #406 merges.