### PR TITLE
ci: use explicit ["**"] branches/tags in build-app push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: build-app
 on:
   push:
+    branches: ["**"]
+    tags: ["**"]
     paths-ignore:
       - ".github/workflows/updater.yml"
       - "updater/**"


### PR DESCRIPTION
Follow-up to #412, which fixed the `paths_ignored` → `paths-ignore` typo (correct) but also removed the `branches:`/`tags:` keys from `ci.yml`'s `push` trigger. Those keys are intentional.

**Why the keys matter:** GitHub scopes `push` events by ref type. Defining `branches` but not `tags` (or vice-versa) *excludes* the undefined ref type. With both set to `["**"]`, `build-app` runs on:
- **all branch pushes** — still filtered by `paths-ignore` (docs/updater-only pushes skip), and
- **all tag pushes** — GitHub *ignores* `paths`/`paths-ignore` for tags, so release tags `vX.Y.Z` still trigger `build-app`, which is what lets `docker.yml`'s `workflow_run` publish the release image.

The `branches:` key is also what runs CI on every feature-branch push, independent of the `pull_request` trigger.

**Why `["**"]` and not the old empty/null form:** equivalent (both match all refs incl. slashed names like `feature/x` — which a single `*` would *not*), but the empty form is flagged by actionlint as `string should not be empty`; `["**"]` is lint-clean. Quoted so the leading `**` is not a YAML alias.

Scoped to `ci.yml` only. `updater.yml` uses the same empty-key shape and ideally gets the same one-line change, but editing it here triggers `build-updater`'s push-build on the branch, whose DockerHub login uses `github.actor` and fails for any non-owner collaborator push — so that one is best applied directly on master. Left out to keep this PR green.

Ref: [workflow syntax docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).