### PR TITLE
feat: add mention-only meta check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,9 @@
 - Run single test: `go test -v -race ./path/to/package -run TestName`
 - Lint: `golangci-lint run`
 - Coverage report: `go test -race -coverprofile=coverage.out ./... && go tool cover -func=coverage.out`
-- Normalize code comments: `command -v unfuck-ai-comments >/dev/null || go install github.com/umputun/unfuck-ai-comments@latest; unfuck-ai-comments run --fmt --skip=mocks ./...`
 
 ## Important Workflow Notes
-- Always run tests, linter and normalize comments before committing
+- Always run tests and linter before committing
 - For linter use `golangci-lint run`
 - Run tests and linter after making significant changes to verify functionality
 - Go version: 1.24+

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ This option is disabled by default. If set to a positive number, the bot will ch
 
 This option is disabled by default. If `--meta.links-only` set or `env:META_LINKS_ONLY` is `true`, the bot will check the message for the presence of any text. If the message contains links but no text, it will be marked as spam.
 
+**Mention only check**
+
+This option is disabled by default. If `--meta.mention-only` set or `env:META_MENTION_ONLY` is `true`, the bot will check messages that contain at least one mention (@username). If the message is nothing but mentions with only trivial trailing content (digits, whitespace or punctuation, e.g. `@user 3`), it will be marked as spam. Messages with real words alongside the mention (e.g. `@user thanks`) are not affected.
+
 **Image only check**
 
 This option is disabled by default. If `--meta.image-only` set or `env:META_IMAGE_ONLY` is `true`, the bot will check the message for the presence of any image. If the message contains images with text shorter than `--min-msg-len` (default: 50 characters), it will be marked as spam. This catches common spam patterns like promotional images with just "@username" as caption.
@@ -615,6 +619,7 @@ meta:
       --meta.mentions-limit=            max mentions in message, disabled by default (default: -1) [$META_MENTIONS_LIMIT]
       --meta.image-only                 enable image only check [$META_IMAGE_ONLY]
       --meta.links-only                 enable links only check [$META_LINKS_ONLY]
+      --meta.mention-only               enable mention only check [$META_MENTION_ONLY]
       --meta.video-only                 enable video only check [$META_VIDEO_ONLY]
       --meta.audio-only                 enable audio only check [$META_AUDIO_ONLY]
       --meta.contact-only               enable contact only check [$META_CONTACT_ONLY]

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This option is disabled by default. If `--meta.links-only` set or `env:META_LINK
 
 **Mention only check**
 
-This option is disabled by default. If `--meta.mention-only` set or `env:META_MENTION_ONLY` is `true`, the bot will check messages that contain at least one mention (@username). If the message is nothing but mentions with only trivial trailing content (digits, whitespace or punctuation, e.g. `@user 3`), it will be marked as spam. Messages with real words alongside the mention (e.g. `@user thanks`) are not affected.
+This option is disabled by default. If `--meta.mention-only` set or `env:META_MENTION_ONLY` is `true`, the bot will check messages that contain at least one mention (@username). If the message is nothing but mentions plus trivial content (digits, whitespace or punctuation in any position, e.g. `@user 3`), it will be marked as spam. Messages with real words alongside the mention (e.g. `@user thanks`) are not affected.
 
 **Image only check**
 

--- a/app/config/settings.go
+++ b/app/config/settings.go
@@ -110,6 +110,7 @@ type MetaSettings struct {
 	MentionsLimit   int    `json:"mentions_limit" yaml:"mentions_limit" db:"meta_mentions_limit"`
 	ImageOnly       bool   `json:"image_only" yaml:"image_only" db:"meta_image_only"`
 	LinksOnly       bool   `json:"links_only" yaml:"links_only" db:"meta_links_only"`
+	MentionOnly     bool   `json:"mention_only" yaml:"mention_only" db:"meta_mention_only"`
 	VideosOnly      bool   `json:"videos_only" yaml:"videos_only" db:"meta_videos_only"`
 	AudiosOnly      bool   `json:"audios_only" yaml:"audios_only" db:"meta_audios_only"`
 	Forward         bool   `json:"forward" yaml:"forward" db:"meta_forward"`
@@ -272,6 +273,7 @@ func (s *Settings) IsMetaEnabled() bool {
 		s.Meta.LinksLimit >= 0 ||
 		s.Meta.MentionsLimit >= 0 ||
 		s.Meta.LinksOnly ||
+		s.Meta.MentionOnly ||
 		s.Meta.VideosOnly ||
 		s.Meta.AudiosOnly ||
 		s.Meta.Forward ||

--- a/app/config/settings_test.go
+++ b/app/config/settings_test.go
@@ -114,6 +114,7 @@ func TestSettings_IsMetaEnabled(t *testing.T) {
 		linksLimit     int
 		mentionsLimit  int
 		linksOnly      bool
+		mentionOnly    bool
 		videosOnly     bool
 		audiosOnly     bool
 		forward        bool
@@ -128,6 +129,7 @@ func TestSettings_IsMetaEnabled(t *testing.T) {
 		{name: "linksLimit enabled", linksLimit: 3, mentionsLimit: -1, expected: true},
 		{name: "mentionsLimit enabled", linksLimit: -1, mentionsLimit: 5, expected: true},
 		{name: "linksOnly enabled", linksLimit: -1, mentionsLimit: -1, linksOnly: true, expected: true},
+		{name: "mentionOnly enabled", linksLimit: -1, mentionsLimit: -1, mentionOnly: true, expected: true},
 		{name: "videosOnly enabled", linksLimit: -1, mentionsLimit: -1, videosOnly: true, expected: true},
 		{name: "audiosOnly enabled", linksLimit: -1, mentionsLimit: -1, audiosOnly: true, expected: true},
 		{name: "forward enabled", linksLimit: -1, mentionsLimit: -1, forward: true, expected: true},
@@ -145,6 +147,7 @@ func TestSettings_IsMetaEnabled(t *testing.T) {
 			s.Meta.LinksLimit = tt.linksLimit
 			s.Meta.MentionsLimit = tt.mentionsLimit
 			s.Meta.LinksOnly = tt.linksOnly
+			s.Meta.MentionOnly = tt.mentionOnly
 			s.Meta.VideosOnly = tt.videosOnly
 			s.Meta.AudiosOnly = tt.audiosOnly
 			s.Meta.Forward = tt.forward

--- a/app/main.go
+++ b/app/main.go
@@ -88,6 +88,7 @@ type options struct {
 		MentionsLimit   int    `long:"mentions-limit" env:"MENTIONS_LIMIT" default:"-1" description:"max mentions in message, disabled by default"`
 		ImageOnly       bool   `long:"image-only" env:"IMAGE_ONLY" description:"enable image only check"`
 		LinksOnly       bool   `long:"links-only" env:"LINKS_ONLY" description:"enable links only check"`
+		MentionOnly     bool   `long:"mention-only" env:"MENTION_ONLY" description:"enable mention only check"`
 		VideosOnly      bool   `long:"video-only" env:"VIDEO_ONLY" description:"enable video only check"`
 		AudiosOnly      bool   `long:"audio-only" env:"AUDIO_ONLY" description:"enable audio only check"`
 		ContactOnly     bool   `long:"contact-only" env:"CONTACT_ONLY" description:"enable contact only check"`
@@ -886,6 +887,10 @@ func makeDetector(settings *config.Settings) *tgspam.Detector {
 	if settings.Meta.LinksOnly {
 		log.Printf("[INFO] links only check enabled")
 		metaChecks = append(metaChecks, tgspam.LinkOnlyCheck())
+	}
+	if settings.Meta.MentionOnly {
+		log.Printf("[INFO] mention only check enabled")
+		metaChecks = append(metaChecks, tgspam.MentionOnlyCheck())
 	}
 	if settings.Meta.Forward {
 		log.Printf("[INFO] forward check enabled")

--- a/app/settings.go
+++ b/app/settings.go
@@ -54,6 +54,7 @@ func optToSettings(opts options) *config.Settings {
 			MentionsLimit:   opts.Meta.MentionsLimit,
 			ImageOnly:       opts.Meta.ImageOnly,
 			LinksOnly:       opts.Meta.LinksOnly,
+			MentionOnly:     opts.Meta.MentionOnly,
 			VideosOnly:      opts.Meta.VideosOnly,
 			AudiosOnly:      opts.Meta.AudiosOnly,
 			Forward:         opts.Meta.Forward,

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -309,6 +309,7 @@ func TestOptToSettings(t *testing.T) {
 		o.Meta.MentionsLimit = 3
 		o.Meta.ImageOnly = true
 		o.Meta.LinksOnly = true
+		o.Meta.MentionOnly = true
 		o.Meta.VideosOnly = true
 		o.Meta.AudiosOnly = true
 		o.Meta.Forward = true
@@ -450,6 +451,7 @@ func TestOptToSettings(t *testing.T) {
 				assert.Equal(t, 3, settings.Meta.MentionsLimit)
 				assert.True(t, settings.Meta.ImageOnly)
 				assert.True(t, settings.Meta.LinksOnly)
+				assert.True(t, settings.Meta.MentionOnly)
 				assert.True(t, settings.Meta.VideosOnly)
 				assert.True(t, settings.Meta.AudiosOnly)
 				assert.True(t, settings.Meta.Forward)

--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -318,6 +318,10 @@
                         <label class="form-check-label" for="metaLinksOnly">Meta Links Only</label>
                     </div>
                     <div class="form-check form-switch mt-2">
+                        <input class="form-check-input" type="checkbox" id="metaMentionOnly" name="metaMentionOnly" {{if .Meta.MentionOnly}}checked{{end}}>
+                        <label class="form-check-label" for="metaMentionOnly">Meta Mention Only</label>
+                    </div>
+                    <div class="form-check form-switch mt-2">
                         <input class="form-check-input" type="checkbox" id="metaImageOnly" name="metaImageOnly" {{if .Meta.ImageOnly}}checked{{end}}>
                         <label class="form-check-label" for="metaImageOnly">Meta Image Only</label>
                     </div>
@@ -346,6 +350,7 @@
                         <tr><th>Meta Links Limit</th><td>{{if eq .Meta.LinksLimit -1}}disabled{{else}}{{.Meta.LinksLimit}}{{end}}</td></tr>
                         <tr><th>Meta Mentions Limit</th><td>{{if eq .Meta.MentionsLimit -1}}disabled{{else}}{{.Meta.MentionsLimit}}{{end}}</td></tr>
                         <tr><th>Meta Links Only</th><td>{{.Meta.LinksOnly}}</td></tr>
+                        <tr><th>Meta Mention Only</th><td>{{.Meta.MentionOnly}}</td></tr>
                         <tr><th>Meta Image Only</th><td>{{.Meta.ImageOnly}}</td></tr>
                         <tr><th>Meta Video Only</th><td>{{.Meta.VideosOnly}}</td></tr>
                         <tr><th>Meta Audio Only</th><td>{{.Meta.AudiosOnly}}</td></tr>

--- a/app/webapi/config.go
+++ b/app/webapi/config.go
@@ -277,18 +277,18 @@ func updateSettingsFromForm(settings *config.Settings, r *http.Request) {
 
 	// meta checks: server-side authoritative master toggle. Behavior:
 	//   - form contains zero meta-related fields → skip the entire block so
-	//     unrelated saves preserve all 11 IsMetaEnabled-contributing fields
+	//     unrelated saves preserve all 12 IsMetaEnabled-contributing fields
 	//   - metaEnabled=on → write rendered fields from form; rendered booleans
 	//     follow presence-of-on (absent == unchecked == false), unrendered
 	//     booleans (metaContactOnly, metaGiveaway) and the optional
 	//     metaUsernameSymbols are gated on r.Form presence so submits without
 	//     them preserve existing values
-	//   - metaEnabled absent → master toggle off, clear ALL 11 fields used by
+	//   - metaEnabled absent → master toggle off, clear ALL 12 fields used by
 	//     isMetaEnabled() so a checked per-feature box (e.g., metaImageOnly)
 	//     cannot keep meta enabled
 	metaFormFields := []string{
 		"metaEnabled", "metaLinksLimit", "metaMentionsLimit", "metaUsernameSymbols",
-		"metaLinksOnly", "metaImageOnly", "metaVideoOnly", "metaAudioOnly",
+		"metaLinksOnly", "metaMentionOnly", "metaImageOnly", "metaVideoOnly", "metaAudioOnly",
 		"metaForwarded", "metaKeyboard", "metaContactOnly", "metaGiveaway",
 	}
 	hasMetaForm := false
@@ -317,6 +317,7 @@ func updateSettingsFromForm(settings *config.Settings, r *http.Request) {
 				settings.Meta.UsernameSymbols = r.FormValue("metaUsernameSymbols")
 			}
 			settings.Meta.LinksOnly = r.FormValue("metaLinksOnly") == "on"
+			settings.Meta.MentionOnly = r.FormValue("metaMentionOnly") == "on"
 			settings.Meta.ImageOnly = r.FormValue("metaImageOnly") == "on"
 			settings.Meta.VideosOnly = r.FormValue("metaVideoOnly") == "on"
 			settings.Meta.AudiosOnly = r.FormValue("metaAudioOnly") == "on"
@@ -338,6 +339,7 @@ func updateSettingsFromForm(settings *config.Settings, r *http.Request) {
 			settings.Meta.MentionsLimit = -1
 			settings.Meta.UsernameSymbols = ""
 			settings.Meta.LinksOnly = false
+			settings.Meta.MentionOnly = false
 			settings.Meta.ImageOnly = false
 			settings.Meta.VideosOnly = false
 			settings.Meta.AudiosOnly = false

--- a/app/webapi/config_test.go
+++ b/app/webapi/config_test.go
@@ -733,6 +733,7 @@ func TestUpdateConfigHandler(t *testing.T) {
 		form.Add("metaLinksLimit", "3")
 		form.Add("metaMentionsLimit", "5")
 		form.Add("metaLinksOnly", "on")
+		form.Add("metaMentionOnly", "on")
 		form.Add("metaImageOnly", "on")
 		form.Add("metaUsernameSymbols", "@#")
 		form.Add("casEnabled", "on")
@@ -763,6 +764,7 @@ func TestUpdateConfigHandler(t *testing.T) {
 		assert.Equal(t, 3, settings.Meta.LinksLimit)
 		assert.Equal(t, 5, settings.Meta.MentionsLimit)
 		assert.True(t, settings.Meta.LinksOnly)
+		assert.True(t, settings.Meta.MentionOnly)
 		assert.True(t, settings.Meta.ImageOnly)
 		assert.Equal(t, "@#", settings.Meta.UsernameSymbols)
 		assert.Equal(t, "https://api.cas.chat", settings.CAS.API)
@@ -1718,7 +1720,7 @@ func TestUpdateSettingsFromForm_MetaUsernameSymbolsEmptyDisables(t *testing.T) {
 func TestUpdateSettingsFromForm_MetaDisabled_ClearsAllMetaFields(t *testing.T) {
 	// when the meta master toggle is off (metaEnabled absent) and the form
 	// contains at least one meta-related field, the server-side authoritative
-	// toggle must clear ALL 11 fields used by IsMetaEnabled so a checked
+	// toggle must clear ALL 12 fields used by IsMetaEnabled so a checked
 	// per-feature box (e.g., metaImageOnly) cannot keep meta enabled
 	settings := &config.Settings{
 		Meta: config.MetaSettings{
@@ -1727,6 +1729,7 @@ func TestUpdateSettingsFromForm_MetaDisabled_ClearsAllMetaFields(t *testing.T) {
 			UsernameSymbols: "@",
 			ImageOnly:       true,
 			LinksOnly:       true,
+			MentionOnly:     true,
 			VideosOnly:      true,
 			AudiosOnly:      true,
 			Forward:         true,
@@ -1742,6 +1745,7 @@ func TestUpdateSettingsFromForm_MetaDisabled_ClearsAllMetaFields(t *testing.T) {
 	form.Add("metaUsernameSymbols", "@")
 	form.Add("metaImageOnly", "on")
 	form.Add("metaLinksOnly", "on")
+	form.Add("metaMentionOnly", "on")
 	form.Add("metaVideoOnly", "on")
 	form.Add("metaAudioOnly", "on")
 	form.Add("metaForwarded", "on")
@@ -1761,6 +1765,7 @@ func TestUpdateSettingsFromForm_MetaDisabled_ClearsAllMetaFields(t *testing.T) {
 	assert.Empty(t, settings.Meta.UsernameSymbols, "UsernameSymbols must be cleared")
 	assert.False(t, settings.Meta.ImageOnly, "ImageOnly must be cleared")
 	assert.False(t, settings.Meta.LinksOnly, "LinksOnly must be cleared")
+	assert.False(t, settings.Meta.MentionOnly, "MentionOnly must be cleared")
 	assert.False(t, settings.Meta.VideosOnly, "VideosOnly must be cleared")
 	assert.False(t, settings.Meta.AudiosOnly, "AudiosOnly must be cleared")
 	assert.False(t, settings.Meta.Forward, "Forward must be cleared")
@@ -1805,7 +1810,7 @@ func TestUpdateSettingsFromForm_MetaEnabled_HonorsAllFields(t *testing.T) {
 
 func TestUpdateSettingsFromForm_NoMetaFields_PreservesExisting(t *testing.T) {
 	// when the form contains zero meta-related fields, the meta block is
-	// skipped entirely so partial saves preserve all 11 fields
+	// skipped entirely so partial saves preserve all 12 fields
 	settings := &config.Settings{
 		Meta: config.MetaSettings{
 			LinksLimit:  10,

--- a/db-conf.md
+++ b/db-conf.md
@@ -265,7 +265,7 @@ encrypted JSON blob. Sensitive string fields are encrypted individually with an
 - `History` — duration, min size, size
 - `Logger` — enabled, filename, max size, max backups
 - `CAS` — API, timeout, user agent
-- `Meta` — links limit, mentions limit, image/links/videos/audios-only, forward, keyboard, username symbols, **`contact_only`**, **`giveaway`**
+- `Meta` — links limit, mentions limit, image/links/mention/videos/audios-only, forward, keyboard, username symbols, **`contact_only`**, **`giveaway`**
 - `OpenAI` — full config, token (encrypted)
 - `Gemini` — token (encrypted), veto, prompt, custom prompts, model, max tokens response (`int32`), max symbols request, retry count, history size, check short messages
 - `LLM` — consensus, request timeout

--- a/e2e-ui/e2e_test.go
+++ b/e2e-ui/e2e_test.go
@@ -469,6 +469,106 @@ func TestSettings_MaxShortMsgCountPersists(t *testing.T) {
 	assert.Equal(t, firstMessagesText, got)
 }
 
+func TestSettings_MentionOnlyPersists(t *testing.T) {
+	const (
+		port     = 18093
+		dbPath   = "/tmp/tg-spam-e2e-mentiononly.db"
+		dataPath = "/tmp/tg-spam-e2e-mentiononly-data"
+		password = "e2e-mentiononly-password"
+		user     = "tg-spam"
+	)
+	settingsURL := fmt.Sprintf("http://localhost:%d", port)
+
+	// clean any leftover state from a prior run
+	_ = os.Remove(dbPath)
+	_ = os.RemoveAll(dataPath)
+	require.NoError(t, os.MkdirAll(dataPath, 0o755))
+	require.NoError(t, os.WriteFile(dataPath+"/spam-samples.txt", []byte("buy crypto now\n"), 0o644))
+	require.NoError(t, os.WriteFile(dataPath+"/ham-samples.txt", []byte("hello world\n"), 0o644))
+
+	// confdb mode requires settings to already exist in the DB; bootstrap them
+	// by running save-config first against the same DB with server enabled.
+	saveCmd := exec.Command("/tmp/tg-spam-e2e",
+		"save-config",
+		"--db="+dbPath,
+		"--files.samples="+dataPath,
+		"--files.dynamic="+dataPath,
+		"--server.enabled",
+		fmt.Sprintf("--server.listen=:%d", port),
+		"--server.auth="+password,
+	)
+	saveCmd.Stdout = os.Stdout
+	saveCmd.Stderr = os.Stderr
+	require.NoError(t, saveCmd.Run(), "failed to bootstrap settings via save-config")
+
+	cmd := exec.Command("/tmp/tg-spam-e2e",
+		"--server.enabled",
+		fmt.Sprintf("--server.listen=:%d", port),
+		"--server.auth="+password,
+		"--db="+dbPath,
+		"--files.samples="+dataPath,
+		"--files.dynamic="+dataPath,
+		"--confdb",
+		"--dbg",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		_ = os.Remove(dbPath)
+		_ = os.RemoveAll(dataPath)
+	})
+
+	require.NoError(t, waitForServer(settingsURL+"/ping", 30*time.Second))
+
+	ctx, err := browser.NewContext(playwright.BrowserNewContextOptions{
+		HttpCredentials: &playwright.HttpCredentials{
+			Username: user,
+			Password: password,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ctx.Close() })
+
+	page, err := ctx.NewPage()
+	require.NoError(t, err)
+
+	_, err = page.Goto(settingsURL + "/list_settings")
+	require.NoError(t, err)
+
+	// switch to the Meta Checks tab where the mention-only toggle lives
+	require.NoError(t, page.Locator("#meta-checks-tab").Click())
+	waitVisible(t, page.Locator("#metaMentionOnly"))
+
+	// verify default rendered (unchecked)
+	checked, err := page.Locator("#metaMentionOnly").IsChecked()
+	require.NoError(t, err)
+	assert.False(t, checked, "mention-only must be unchecked by default")
+
+	// enable the meta master toggle and mention-only, then save
+	require.NoError(t, page.Locator("#metaEnabled").Check())
+	require.NoError(t, page.Locator("#metaMentionOnly").Check())
+	require.NoError(t, page.Locator("button[type='submit']:has-text('Save Changes')").Click())
+
+	// wait for the save success alert
+	assert.Eventually(t, func() bool {
+		text, e := page.Locator("#update-result").TextContent()
+		return e == nil && contains(text, "Configuration updated successfully")
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// reload the page and verify the toggle persisted
+	_, err = page.Goto(settingsURL + "/list_settings")
+	require.NoError(t, err)
+	require.NoError(t, page.Locator("#meta-checks-tab").Click())
+	waitVisible(t, page.Locator("#metaMentionOnly"))
+
+	got, err := page.Locator("#metaMentionOnly").IsChecked()
+	require.NoError(t, err)
+	assert.True(t, got, "mention-only must stay checked after reload")
+}
+
 // --- navigation tests ---
 
 func TestNavbar_NavigationWorks(t *testing.T) {

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -2093,6 +2093,27 @@ func TestDetector_CheckWithMeta(t *testing.T) {
 	})
 }
 
+func TestDetector_CheckWithMentionOnly(t *testing.T) {
+	d := NewDetector(Config{MaxAllowedEmoji: -1})
+	d.WithMetaChecks(MentionOnlyCheck())
+
+	t.Run("mention with number is spam", func(t *testing.T) {
+		spam, cr := d.Check(spamcheck.Request{Msg: "@blah 3", Meta: spamcheck.MetaData{Mentions: 1}})
+		assert.True(t, spam)
+		require.Len(t, cr, 1)
+		assert.Equal(t, "mention-only", cr[0].Name)
+		assert.True(t, cr[0].Spam)
+	})
+
+	t.Run("mention with real word is ham", func(t *testing.T) {
+		spam, cr := d.Check(spamcheck.Request{Msg: "@john thanks", Meta: spamcheck.MetaData{Mentions: 1}})
+		assert.False(t, spam)
+		require.Len(t, cr, 1)
+		assert.Equal(t, "mention-only", cr[0].Name)
+		assert.False(t, cr[0].Spam)
+	})
+}
+
 func TestDetector_CheckMultiLang(t *testing.T) {
 	d := NewDetector(Config{MultiLangWords: 2, MaxAllowedEmoji: -1})
 	tests := []struct {

--- a/lib/tgspam/metachecks.go
+++ b/lib/tgspam/metachecks.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/umputun/tg-spam/lib/spamcheck"
 )
@@ -54,6 +55,33 @@ func LinkOnlyCheck() MetaCheck {
 			}
 		}
 		return spamcheck.Response{Spam: false, Name: "link-only", Details: "message contains text"}
+	}
+}
+
+var mentionRe = regexp.MustCompile(`@[a-zA-Z0-9_]+`)
+
+// MentionOnlyCheck is a function that returns a MetaCheck function that checks if the req.Msg
+// contains nothing but mentions, optionally followed by trivial content (digits, whitespace or
+// punctuation). It catches messages like "@user 3" where a spammer posts a bare mention and a
+// number and no real text. The check is gated on at least one mention being present, so messages
+// without mentions (e.g. a lone number) are never flagged.
+func MentionOnlyCheck() MetaCheck {
+	return func(req spamcheck.Request) spamcheck.Response {
+		if req.Meta.Mentions == 0 {
+			return spamcheck.Response{Name: "mention-only", Spam: false, Details: "no mentions"}
+		}
+		if strings.TrimSpace(req.Msg) == "" {
+			return spamcheck.Response{Name: "mention-only", Spam: false, Details: "empty message"}
+		}
+		residue := mentionRe.ReplaceAllString(req.Msg, "")
+		for _, r := range residue {
+			if unicode.IsDigit(r) || unicode.IsSpace(r) || unicode.IsPunct(r) {
+				continue
+			}
+			// a letter, emoji or other meaningful symbol remains, so it is more than mentions
+			return spamcheck.Response{Spam: false, Name: "mention-only", Details: "message contains text"}
+		}
+		return spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"}
 	}
 }
 

--- a/lib/tgspam/metachecks.go
+++ b/lib/tgspam/metachecks.go
@@ -61,10 +61,15 @@ func LinkOnlyCheck() MetaCheck {
 var mentionRe = regexp.MustCompile(`@[a-zA-Z0-9_]+`)
 
 // MentionOnlyCheck is a function that returns a MetaCheck function that checks if the req.Msg
-// contains nothing but mentions, optionally followed by trivial content (digits, whitespace or
-// punctuation). It catches messages like "@user 3" where a spammer posts a bare mention and a
-// number and no real text. The check is gated on at least one mention being present, so messages
-// without mentions (e.g. a lone number) are never flagged.
+// contains nothing but mentions plus trivial content (digits, whitespace or punctuation) in any
+// position. It catches messages like "@user 3" where a spammer posts a bare mention and a number
+// and no real text. The check is gated on at least one mention being present, so messages without
+// mentions (e.g. a lone number) are never flagged.
+//
+// Limitations: only literal "@name" mentions are stripped, so a text_mention (a display-name
+// mention with no "@") keeps its name in the residue and is not flagged. The check also evaluates
+// req.Msg as given, which upstream includes quoted/reply-to text, so a mention-only message posted
+// alongside quoted text will not be flagged.
 func MentionOnlyCheck() MetaCheck {
 	return func(req spamcheck.Request) spamcheck.Response {
 		if req.Meta.Mentions == 0 {
@@ -79,7 +84,7 @@ func MentionOnlyCheck() MetaCheck {
 				continue
 			}
 			// a letter, emoji or other meaningful symbol remains, so it is more than mentions
-			return spamcheck.Response{Spam: false, Name: "mention-only", Details: "message contains text"}
+			return spamcheck.Response{Name: "mention-only", Spam: false, Details: "message contains text"}
 		}
 		return spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"}
 	}

--- a/lib/tgspam/metachecks_test.go
+++ b/lib/tgspam/metachecks_test.go
@@ -122,6 +122,77 @@ func TestLinkOnlyCheck(t *testing.T) {
 	}
 }
 
+func TestMentionOnlyCheck(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      spamcheck.Request
+		expected spamcheck.Response
+	}{
+		{
+			name:     "no mentions",
+			req:      spamcheck.Request{Msg: "just a plain message", Meta: spamcheck.MetaData{Mentions: 0}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "no mentions"},
+		},
+		{
+			name:     "bare number without mention",
+			req:      spamcheck.Request{Msg: "3", Meta: spamcheck.MetaData{Mentions: 0}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "no mentions"},
+		},
+		{
+			name:     "mention only",
+			req:      spamcheck.Request{Msg: "@blah", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"},
+		},
+		{
+			name:     "mention with trailing number",
+			req:      spamcheck.Request{Msg: "@blah 3", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"},
+		},
+		{
+			name:     "mention with several numbers",
+			req:      spamcheck.Request{Msg: "@blah 42 55", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"},
+		},
+		{
+			name:     "several mentions with number",
+			req:      spamcheck.Request{Msg: "@a @b 3", Meta: spamcheck.MetaData{Mentions: 2}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"},
+		},
+		{
+			name:     "mention with punctuation only",
+			req:      spamcheck.Request{Msg: "@blah !!!", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"},
+		},
+		{
+			name:     "mention with real word",
+			req:      spamcheck.Request{Msg: "@john thanks", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "message contains text"},
+		},
+		{
+			name:     "mention with non-latin word",
+			req:      spamcheck.Request{Msg: "@user привет", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "message contains text"},
+		},
+		{
+			name:     "mention with emoji",
+			req:      spamcheck.Request{Msg: "@user 😀", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "message contains text"},
+		},
+		{
+			name:     "mention count set but empty text",
+			req:      spamcheck.Request{Msg: "  ", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "empty message"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := MentionOnlyCheck()
+			assert.Equal(t, tt.expected, check(tt.req))
+		})
+	}
+}
+
 func TestImagesCheck(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/lib/tgspam/metachecks_test.go
+++ b/lib/tgspam/metachecks_test.go
@@ -179,6 +179,26 @@ func TestMentionOnlyCheck(t *testing.T) {
 			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "message contains text"},
 		},
 		{
+			name:     "multiple mentions no other content",
+			req:      spamcheck.Request{Msg: "@a @b", Meta: spamcheck.MetaData{Mentions: 2}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"},
+		},
+		{
+			name:     "mention with percent sign is punctuation",
+			req:      spamcheck.Request{Msg: "@user 100%", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: true, Details: "message contains mentions only"},
+		},
+		{
+			name:     "mention with ascii symbol is not trivial",
+			req:      spamcheck.Request{Msg: "@user +1", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "message contains text"},
+		},
+		{
+			name:     "text_mention name without literal at is not stripped",
+			req:      spamcheck.Request{Msg: "Alice 3", Meta: spamcheck.MetaData{Mentions: 1}},
+			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "message contains text"},
+		},
+		{
 			name:     "mention count set but empty text",
 			req:      spamcheck.Request{Msg: "  ", Meta: spamcheck.MetaData{Mentions: 1}},
 			expected: spamcheck.Response{Name: "mention-only", Spam: false, Details: "empty message"},


### PR DESCRIPTION
new spam pattern showed up: a message that is just a mention and a number, like `@blah 3`. There was no "mention-only" check before (only a mention *count* check and a link-only check), so this adds one.

**what it does**

`--meta.mention-only` / `$META_MENTION_ONLY`, off by default. When enabled, a message that is nothing but @mentions plus trivial content (digits, whitespace or punctuation, in any position) is flagged as spam. Gated on at least one mention, so a bare number with no mention is never flagged. Legit replies like `@john thanks` keep a real word in the residue and pass.

modeled on the existing `LinkOnlyCheck`. Wired through every layer per the CLAUDE.md checklist: CLI/env, DB-backed `Settings` + `IsMetaEnabled`, the web settings UI form round-trip, and detector registration. Unit, handler, and e2e-ui coverage added.

**known limitations** (in the godoc, surfaced during review)

- only literal `@name` mentions are stripped, so a `text_mention` (a display-name mention with no `@`) is not caught
- the check sees `req.Msg` as built upstream, which includes quoted/reply-to text, so a mention-only message posted next to a quote is not flagged. Same as the other `*-only` checks.

also drops the legacy `unfuck-ai-comments` step from CLAUDE.md.
