### PR TITLE
perf: ascii fast path for multi-language script detection

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,6 +11,12 @@ on:
       - "updater/**"
       - ".github/workflows/updater.yml"
 
+# publish only from the refs that actually release. on any other ref the build job just verifies
+# that the image builds: the registry logins use github.actor, which only owns the images on those
+# refs, so a push from any other collaborator would fail the login.
+env:
+  PUBLISH: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}
+
 jobs:
   build:
     strategy:
@@ -37,7 +43,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: login to ghcr.io
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -45,14 +51,14 @@ jobs:
           password: ${{ secrets.PKG_TOKEN }}
 
       - name: login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: build only (PR)
-        if: github.event_name == 'pull_request'
+      - name: build only (no publish)
+        if: env.PUBLISH != 'true'
         uses: docker/build-push-action@v7
         with:
           context: ./updater
@@ -65,7 +71,7 @@ jobs:
 
       - name: build and push to ghcr.io
         id: build-ghcr
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH == 'true'
         uses: docker/build-push-action@v7
         with:
           context: ./updater
@@ -78,7 +84,7 @@ jobs:
 
       - name: build and push to DockerHub
         id: build-dockerhub
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH == 'true'
         uses: docker/build-push-action@v7
         with:
           context: ./updater
@@ -90,7 +96,7 @@ jobs:
           outputs: type=image,name=docker.io/${{ github.actor }}/tg-spam-updater,push-by-digest=true,name-canonical=true,push=true
 
       - name: export digests
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH == 'true'
         run: |
           mkdir -p /tmp/digests/ghcr /tmp/digests/dockerhub
           digest_ghcr="${{ steps.build-ghcr.outputs.digest }}"
@@ -99,7 +105,7 @@ jobs:
           touch "/tmp/digests/dockerhub/${digest_dockerhub#sha256:}"
 
       - name: upload ghcr digest
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: digests-ghcr-${{ matrix.artifact }}
@@ -107,7 +113,7 @@ jobs:
           retention-days: 1
 
       - name: upload dockerhub digest
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: digests-dockerhub-${{ matrix.artifact }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -1,8 +1,8 @@
 name: build-updater
 on:
   push:
-    branches:
-    tags:
+    branches: ["**"]
+    tags: ["**"]
     paths:
       - "updater/**"
       - ".github/workflows/updater.yml"

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -1220,6 +1220,27 @@ func (d *Detector) isMultiLang(msg string) spamcheck.Response {
 				continue
 			}
 
+			// ascii fast path: avoids scanning the ~170 unicode.Scripts tables for the most
+			// common runes. mirrors the slow path exactly: ascii letters are Latin, the rest
+			// of ascii belongs to Common, so it falls through to the same Other_Math check
+			// (which catches '^') and then to punctuation/symbol handling
+			if r < 128 {
+				switch {
+				case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+					scripts["Latin"] = true
+				case unicode.In(r, unicode.Other_Math, unicode.Other_Alphabetic):
+					scripts["Mathematical"] = true
+				case !unicode.IsPunct(r) && !unicode.IsSymbol(r):
+					scripts["Other"] = true
+				default:
+					continue // punctuation and symbols carry no script
+				}
+				if len(scripts) > 1 {
+					return true
+				}
+				continue
+			}
+
 			scriptFound := false
 			for name, table := range unicode.Scripts {
 				if unicode.Is(table, r) {

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -2135,6 +2135,9 @@ func TestDetector_CheckMultiLang(t *testing.T) {
 		{"strange with cyrillic", "𝐇айди и𝐇𝐓и𝐦𝐇ы𝐞 ф𝐨𝐓𝐤и лю𝐛𝐨й д𝐞𝐁𝐲ш𝐤и ч𝐞𝐩𝐞𝟓 𝐛𝐨𝐓а", 7, true},
 		{"coptic capital leter", "✔️ⲠⲢⲞⳜⲈЙ-ⲖЮⳜⲨЮ-ⲆⲈⲂⲨⲰⲔⲨ...\n\nⲎⲀЙⲆⳘ ⲤⲔⲢЫⲦⲈ ⲂⳘⲆⲞⲤЫ-ⲪⲞⲦⲞⳠⲔⳘ ⳘⲎⲦⳘⲘⲎⲞⲄⲞ-ⲬⲀⲢⲀⲔⲦⲈⲢⲀ..\n@INTIM0CHKI110DE\n\n", 5, true},
 		{"mix with gothic, cyrillic and greek", "𐌿РОВЕРЬ ЛЮБУЮ НА НАЛИЧИЕ ПОШЛЫХ ΦΟͲΟ-ΒͶДξΟ, 🍑НАБЕРИ В Т𐌲 𐌿ОИСКЕ СЛOВО: 30GRL", 5, true},
+		// '^' is ascii but carries the Other_Math property, so latin+caret counts as two scripts.
+		// guards the ascii fast path against dropping it as a plain symbol.
+		{"Latin with caret", "a^b c^d", 2, true},
 		{"Mixed Latin and numbers", "Meta-Llama-3.1-8B-Instruct-IQ4_XS Meta-Llama-3.1-8B-Instruct-Q3_K_L Meta-Llama-3.1-8B-Instruct-Q4_K_M", 0, false},
 		{"Mixed Latin, numbers, and Cyrillic", "Meta-Llama-3.1-8B-Instruct-IQ4_XS Meta-Llama-3.1-8B-Instruct-Q3_K_L коллеги, подскажите пожалуйста", 0, false},
 	}


### PR DESCRIPTION
Last of the review findings, plus two `updater.yml` CI fixes. Three commits.

## `perf: ascii fast path for multi-language script detection`

`isMultiLang` scanned all ~170 `unicode.Scripts` tables for **every rune**. Classify ascii runes directly so typical mostly-ascii messages skip the table scan. Dormant unless `--multi-lang-words` is set, but disproportionately expensive on long messages when it is.

The fast path mirrors the slow path exactly, in the same order: ascii letters → `Latin`; then `unicode.In(r, Other_Math, Other_Alphabetic)` → `Mathematical`; then `!IsPunct && !IsSymbol` → `Other`; otherwise ignored.

That middle case matters: `^` (U+005E) is ascii but carries the `Other_Math` property, so the slow path counts it as `Mathematical`. Without it, `a^b` would silently stop being reported as multi-lingual (`Latin` + `Mathematical`). It is the **only** ascii rune classified differently — verified by exhaustively comparing old vs new classification across all 128 ascii runes (0 divergences after the fix). The existing suite missed it: its one `^` case (`"Привет мир -@#$%^&*(_"`) has `^` alone in a word, so it never trips the `>1` early return. Added a `Latin with caret` case that fails if the `Other_Math` branch is dropped.

## `ci: use explicit ["**"] branches/tags in build-updater push trigger`

Mirrors #423. Both keys must be present — GitHub scopes push events by ref type, so defining one but not the other excludes the undefined ref type. `["**"]` is equivalent to the old empty/null keys (both match all refs incl. slashed names like `feature/x`, which a single `*` would not) but is not flagged by actionlint as `string should not be empty`.

## `ci: only publish updater images from master and tags`

The `build` job ran its registry logins and image pushes on **every** non-PR push, including feature branches. Those steps authenticate with `github.actor`, which only owns the images on the release refs, so a push by any other collaborator failed at `login to DockerHub` with `incorrect username or password` — and a feature branch should never have published images anyway.

Gate the login/push/digest steps on a `PUBLISH` expression (non-PR **and** master or a tag), matching the guard the `merge` job already uses, and widen the build-only step to cover every non-publishing ref. Feature branches and PRs now just verify the updater image builds.

---

> ⚠️ `e2e-ui` is red for an unrelated, pre-existing reason: playwright-go `v0.5200.1` downloads its driver from `playwright.azureedge.net`, which Microsoft has retired — `playwright-1.52.0-linux.zip` now returns HTTP 404. e2e-ui passed on master on 2026-07-07 and fails on every run since; it affects any PR touching `app/**` or `lib/**`, not just this one. Needs its own fix (a playwright-go version with both a correct module path and the new `playwright.download.prss.microsoft.com` host, or a `PLAYWRIGHT_DOWNLOAD_HOST` override).