### PR TITLE
feat: add optional --meta.image-text-len for image-only check

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ This option is disabled by default. If `--meta.mention-only` set or `env:META_ME
 
 This option is disabled by default. If `--meta.image-only` set or `env:META_IMAGE_ONLY` is `true`, the bot will check the message for the presence of any image. If the message contains images with text shorter than `--min-msg-len` (default: 50 characters), it will be marked as spam. This catches common spam patterns like promotional images with just "@username" as caption.
 
+By default the image caption threshold equals `--min-msg-len`. Use `--meta.image-text-len` (`env:META_IMAGE_TEXT_LEN`) to set a separate threshold for image captions without changing `--min-msg-len`; a value of `0` (the default) keeps using `--min-msg-len`. This is useful when spam hides the pitch inside the image and the caption is a short lure that lands right at the `--min-msg-len` boundary.
+
 **Video only check**
 
 This option is disabled by default. If `--meta.video-only` set or `env:META_VIDEO_ONLY` is `true`, the bot will check the message for the presence of any video or video notes. If the message contains videos with text shorter than `--min-msg-len` (default: 50 characters), it will be marked as spam.
@@ -636,6 +638,7 @@ meta:
       --meta.links-limit=               max links in message, disabled by default (default: -1) [$META_LINKS_LIMIT]
       --meta.mentions-limit=            max mentions in message, disabled by default (default: -1) [$META_MENTIONS_LIMIT]
       --meta.image-only                 enable image only check [$META_IMAGE_ONLY]
+      --meta.image-text-len=            min text length for image messages, 0 uses min-msg-len (default: 0) [$META_IMAGE_TEXT_LEN]
       --meta.links-only                 enable links only check [$META_LINKS_ONLY]
       --meta.mention-only               enable mention only check [$META_MENTION_ONLY]
       --meta.video-only                 enable video only check [$META_VIDEO_ONLY]

--- a/app/config/settings.go
+++ b/app/config/settings.go
@@ -115,6 +115,7 @@ type MetaSettings struct {
 	LinksLimit      int    `json:"links_limit" yaml:"links_limit" db:"meta_links_limit"`
 	MentionsLimit   int    `json:"mentions_limit" yaml:"mentions_limit" db:"meta_mentions_limit"`
 	ImageOnly       bool   `json:"image_only" yaml:"image_only" db:"meta_image_only"`
+	ImageTextLen    int    `json:"image_text_len" yaml:"image_text_len" db:"meta_image_text_len"`
 	LinksOnly       bool   `json:"links_only" yaml:"links_only" db:"meta_links_only"`
 	MentionOnly     bool   `json:"mention_only" yaml:"mention_only" db:"meta_mention_only"`
 	VideosOnly      bool   `json:"videos_only" yaml:"videos_only" db:"meta_videos_only"`
@@ -366,6 +367,7 @@ var zeroAwarePaths = map[string]bool{
 	"SimilarityThreshold":     true, // lib/tgspam/detector.go:302 (> 0): 0 disables similarity check
 	"MinSpamProbability":      true, // lib/tgspam/detector.go:1014 (== 0): 0 = always classify spam
 	"MaxShortMsgCount":        true, // lib/tgspam/detector.go:253 (> 0): 0 disables
+	"Meta.ImageTextLen":       true, // app/main.go image-only wiring (> 0): 0 falls back to MinMsgLen
 	"ProhibitedLangs":         true, // lib/tgspam/detector.go:276 (len > 0): empty disables
 }
 

--- a/app/config/settings.go
+++ b/app/config/settings.go
@@ -294,6 +294,9 @@ func (s *Settings) Validate() error {
 	if s.MaxShortMsgCount < 0 {
 		return fmt.Errorf("max-short-msg-count (%d) must be >= 0 (0 disables)", s.MaxShortMsgCount)
 	}
+	if s.Meta.ImageTextLen < 0 {
+		return fmt.Errorf("meta.image-text-len (%d) must be >= 0 (0 uses min-msg-len)", s.Meta.ImageTextLen)
+	}
 	// MaxShortMsgCount needs the detector's first-message-only path active. ParanoidMode
 	// in makeDetector forces FirstMessageOnly=false and FirstMessagesCount=0 regardless
 	// of the configured FirstMessagesCount, which would silently disable this check.

--- a/app/config/settings_test.go
+++ b/app/config/settings_test.go
@@ -481,6 +481,14 @@ func TestSettings_ApplyDefaults_SkipsZeroAware(t *testing.T) {
 			assertFn: func(t *testing.T, target *Settings) { assert.Equal(t, 0, target.MaxShortMsgCount) },
 		},
 		{
+			name: "Meta.ImageTextLen",
+			setup: func(target, template *Settings) {
+				target.Meta.ImageTextLen = 0
+				template.Meta.ImageTextLen = 40
+			},
+			assertFn: func(t *testing.T, target *Settings) { assert.Equal(t, 0, target.Meta.ImageTextLen) },
+		},
+		{
 			name: "ProhibitedLangs",
 			setup: func(target, template *Settings) {
 				target.ProhibitedLangs = ""

--- a/app/main.go
+++ b/app/main.go
@@ -87,6 +87,7 @@ type options struct {
 		LinksLimit      int    `long:"links-limit" env:"LINKS_LIMIT" default:"-1" description:"max links in message, disabled by default"`
 		MentionsLimit   int    `long:"mentions-limit" env:"MENTIONS_LIMIT" default:"-1" description:"max mentions in message, disabled by default"`
 		ImageOnly       bool   `long:"image-only" env:"IMAGE_ONLY" description:"enable image only check"`
+		ImageTextLen    int    `long:"image-text-len" env:"IMAGE_TEXT_LEN" default:"0" description:"min text length for image messages, 0 uses min-msg-len"`
 		LinksOnly       bool   `long:"links-only" env:"LINKS_ONLY" description:"enable links only check"`
 		MentionOnly     bool   `long:"mention-only" env:"MENTION_ONLY" description:"enable mention only check"`
 		VideosOnly      bool   `long:"video-only" env:"VIDEO_ONLY" description:"enable video only check"`
@@ -867,8 +868,12 @@ func makeDetector(settings *config.Settings) *tgspam.Detector {
 
 	metaChecks := []tgspam.MetaCheck{}
 	if settings.Meta.ImageOnly {
-		log.Printf("[INFO] image only check enabled, min text len: %d", settings.MinMsgLen)
-		metaChecks = append(metaChecks, tgspam.ImagesCheck(settings.MinMsgLen))
+		imageTextLen := settings.MinMsgLen
+		if settings.Meta.ImageTextLen > 0 {
+			imageTextLen = settings.Meta.ImageTextLen
+		}
+		log.Printf("[INFO] image only check enabled, min text len: %d", imageTextLen)
+		metaChecks = append(metaChecks, tgspam.ImagesCheck(imageTextLen))
 	}
 	if settings.Meta.VideosOnly {
 		log.Printf("[INFO] videos only check enabled, min text len: %d", settings.MinMsgLen)

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -308,6 +308,46 @@ func Test_makeDetector(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Empty(t, res.ProhibitedScripts)
 	})
+
+	// the image-only threshold is captured inside an opaque metaCheck closure, so exercise the
+	// override-vs-fallback selection through Check and assert on the named "images" response
+	imagesResp := func(cr []spamcheck.Response) (spamcheck.Response, bool) {
+		for _, r := range cr {
+			if r.Name == "images" {
+				return r, true
+			}
+		}
+		return spamcheck.Response{}, false
+	}
+
+	t.Run("image-only uses image-text-len override", func(t *testing.T) {
+		settings := makeTestSettings()
+		settings.Meta.ImageOnly = true
+		settings.Meta.ImageTextLen = 40
+		settings.MinMsgLen = 50
+
+		det := makeDetector(settings)
+		// 45-rune caption sits above the 40 override but below the 50 fallback; with the
+		// override active the images check must not flag it
+		_, cr := det.Check(spamcheck.Request{Msg: strings.Repeat("a", 45), Meta: spamcheck.MetaData{Images: 1}})
+		img, ok := imagesResp(cr)
+		require.True(t, ok, "images check must run")
+		assert.False(t, img.Spam, "45-rune caption is above the 40 override, not spam")
+	})
+
+	t.Run("image-only falls back to min-msg-len when image-text-len is zero", func(t *testing.T) {
+		settings := makeTestSettings()
+		settings.Meta.ImageOnly = true
+		settings.Meta.ImageTextLen = 0 // fall back to MinMsgLen
+		settings.MinMsgLen = 50
+
+		det := makeDetector(settings)
+		// same 45-rune caption is below the 50 min-msg-len fallback, so it must be flagged
+		_, cr := det.Check(spamcheck.Request{Msg: strings.Repeat("a", 45), Meta: spamcheck.MetaData{Images: 1}})
+		img, ok := imagesResp(cr)
+		require.True(t, ok, "images check must run")
+		assert.True(t, img.Spam, "45-rune caption is below the 50 min-msg-len fallback, spam")
+	})
 }
 
 func Test_initLuaPlugins(t *testing.T) {

--- a/app/settings.go
+++ b/app/settings.go
@@ -53,6 +53,7 @@ func optToSettings(opts options) *config.Settings {
 			LinksLimit:      opts.Meta.LinksLimit,
 			MentionsLimit:   opts.Meta.MentionsLimit,
 			ImageOnly:       opts.Meta.ImageOnly,
+			ImageTextLen:    opts.Meta.ImageTextLen,
 			LinksOnly:       opts.Meta.LinksOnly,
 			MentionOnly:     opts.Meta.MentionOnly,
 			VideosOnly:      opts.Meta.VideosOnly,

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -310,6 +310,7 @@ func TestOptToSettings(t *testing.T) {
 		o.Meta.LinksLimit = 2
 		o.Meta.MentionsLimit = 3
 		o.Meta.ImageOnly = true
+		o.Meta.ImageTextLen = 40
 		o.Meta.LinksOnly = true
 		o.Meta.MentionOnly = true
 		o.Meta.VideosOnly = true
@@ -455,6 +456,7 @@ func TestOptToSettings(t *testing.T) {
 				assert.Equal(t, 2, settings.Meta.LinksLimit)
 				assert.Equal(t, 3, settings.Meta.MentionsLimit)
 				assert.True(t, settings.Meta.ImageOnly)
+				assert.Equal(t, 40, settings.Meta.ImageTextLen)
 				assert.True(t, settings.Meta.LinksOnly)
 				assert.True(t, settings.Meta.MentionOnly)
 				assert.True(t, settings.Meta.VideosOnly)

--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -324,7 +324,7 @@
             <div class="row mb-3">
                 <div class="col-md-6 mb-3">
                     <label for="metaImageTextLen" class="form-label">Meta Image Text Len</label>
-                    <input type="number" class="form-control" id="metaImageTextLen" name="metaImageTextLen" value="{{.Meta.ImageTextLen}}">
+                    <input type="number" min="0" class="form-control" id="metaImageTextLen" name="metaImageTextLen" value="{{.Meta.ImageTextLen}}">
                     <div class="form-text">Min caption length for image-only check (0 uses min-msg-len)</div>
                 </div>
             </div>

--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -323,6 +323,14 @@
 
             <div class="row mb-3">
                 <div class="col-md-6 mb-3">
+                    <label for="metaImageTextLen" class="form-label">Meta Image Text Len</label>
+                    <input type="number" class="form-control" id="metaImageTextLen" name="metaImageTextLen" value="{{.Meta.ImageTextLen}}">
+                    <div class="form-text">Min caption length for image-only check (0 uses min-msg-len)</div>
+                </div>
+            </div>
+
+            <div class="row mb-3">
+                <div class="col-md-6 mb-3">
                     <label for="metaUsernameSymbols" class="form-label">Meta Username Symbols</label>
                     <input type="text" class="form-control" id="metaUsernameSymbols" name="metaUsernameSymbols" value="{{.Meta.UsernameSymbols}}">
                     <div class="form-text">Symbols to check in usernames (leave empty to disable)</div>
@@ -371,6 +379,7 @@
                         <tr><th>Meta Links Only</th><td>{{.Meta.LinksOnly}}</td></tr>
                         <tr><th>Meta Mention Only</th><td>{{.Meta.MentionOnly}}</td></tr>
                         <tr><th>Meta Image Only</th><td>{{.Meta.ImageOnly}}</td></tr>
+                        <tr><th>Meta Image Text Len</th><td>{{if eq .Meta.ImageTextLen 0}}min-msg-len{{else}}{{.Meta.ImageTextLen}}{{end}}</td></tr>
                         <tr><th>Meta Video Only</th><td>{{.Meta.VideosOnly}}</td></tr>
                         <tr><th>Meta Audio Only</th><td>{{.Meta.AudiosOnly}}</td></tr>
                         <tr><th>Meta Keyboard</th><td>{{.Meta.Keyboard}}</td></tr>

--- a/app/webapi/config.go
+++ b/app/webapi/config.go
@@ -301,6 +301,7 @@ func updateSettingsFromForm(settings *config.Settings, r *http.Request) {
 	//     cannot keep meta enabled
 	metaFormFields := []string{
 		"metaEnabled", "metaLinksLimit", "metaMentionsLimit", "metaUsernameSymbols",
+		"metaImageTextLen",
 		"metaLinksOnly", "metaMentionOnly", "metaImageOnly", "metaVideoOnly", "metaAudioOnly",
 		"metaForwarded", "metaKeyboard", "metaContactOnly", "metaGiveaway", "metaExternalReply",
 	}
@@ -321,6 +322,12 @@ func updateSettingsFromForm(settings *config.Settings, r *http.Request) {
 			if val := r.FormValue("metaMentionsLimit"); val != "" {
 				if limit, err := strconv.Atoi(val); err == nil {
 					settings.Meta.MentionsLimit = limit
+				}
+			}
+			// image-text-len tunes the image-only check; 0 falls back to min-msg-len
+			if val := r.FormValue("metaImageTextLen"); val != "" {
+				if n, err := strconv.Atoi(val); err == nil {
+					settings.Meta.ImageTextLen = n
 				}
 			}
 			// honor the "leave empty to disable" UI hint: clear the setting whenever

--- a/app/webapi/config_test.go
+++ b/app/webapi/config_test.go
@@ -1163,6 +1163,7 @@ func TestUpdateSettingsFromForm(t *testing.T) {
 		form.Add("metaMentionsLimit", "5")
 		form.Add("metaLinksOnly", "on")
 		form.Add("metaImageOnly", "on")
+		form.Add("metaImageTextLen", "40")
 		form.Add("metaUsernameSymbols", "@#")
 
 		req := httptest.NewRequest("PUT", "/config", strings.NewReader(form.Encode()))
@@ -1176,6 +1177,7 @@ func TestUpdateSettingsFromForm(t *testing.T) {
 		assert.Equal(t, 5, settings.Meta.MentionsLimit)
 		assert.True(t, settings.Meta.LinksOnly)
 		assert.True(t, settings.Meta.ImageOnly)
+		assert.Equal(t, 40, settings.Meta.ImageTextLen)
 		assert.Equal(t, "@#", settings.Meta.UsernameSymbols)
 	})
 

--- a/e2e-ui/e2e_test.go
+++ b/e2e-ui/e2e_test.go
@@ -551,6 +551,7 @@ func TestSettings_MentionOnlyPersists(t *testing.T) {
 	require.NoError(t, page.Locator("#metaEnabled").Check())
 	require.NoError(t, page.Locator("#metaMentionOnly").Check())
 	require.NoError(t, page.Locator("#metaExternalReply").Check())
+	require.NoError(t, page.Locator("#metaImageTextLen").Fill("40"))
 	require.NoError(t, page.Locator("button[type='submit']:has-text('Save Changes')").Click())
 
 	// wait for the save success alert
@@ -572,6 +573,10 @@ func TestSettings_MentionOnlyPersists(t *testing.T) {
 	gotExternalReply, err := page.Locator("#metaExternalReply").IsChecked()
 	require.NoError(t, err)
 	assert.True(t, gotExternalReply, "external-reply must stay checked after reload")
+
+	gotImageTextLen, err := page.Locator("#metaImageTextLen").InputValue()
+	require.NoError(t, err)
+	assert.Equal(t, "40", gotImageTextLen, "image-text-len must persist after reload")
 }
 
 func TestSettings_ProhibitedLangsPersists(t *testing.T) {


### PR DESCRIPTION
the image-only meta check reused `--min-msg-len` as its caption-length threshold, coupling two unrelated knobs. A short caption exactly at the `--min-msg-len` boundary slips through, because the check compares with strict `<`. Seen in production: an image ad with a 15-rune caption against `MIN_MSG_LEN=15` passed every content check, since the spam pitch was baked into the image pixels and only the short caption is visible to the classifier and LLM.

this adds `--meta.image-text-len` / `META_IMAGE_TEXT_LEN` (config `Meta.ImageTextLen`) to set a separate minimum caption length for image messages. `0` (the default) falls back to `--min-msg-len`, so existing behavior is unchanged unless you set it.

wired through every config layer: CLI/env, the CLI-to-Settings mapping, DB-backed config (with a `zeroAwarePaths` entry so an explicit `0` survives merges), and the web settings UI (form input plus read-only row, `min="0"` and a `Validate` bound that rejects negatives). Covered by unit tests for the mapping, the web form parse, and the `makeDetector` override-vs-fallback selection, plus an e2e UI round-trip, and documented in both README sections.
