### PR TITLE
feat: mention superusers in report notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,11 +405,13 @@ To enable user spam reporting, set `--report.enabled` to `true` and configure an
 
 1. Users reply to suspicious messages with `/report` to flag them for review
 2. The bot tracks all reports for each message
-3. When the number of unique reporters reaches the threshold (configurable via `--report.threshold=`), the bot sends a notification to the admin chat
+3. When the number of unique reporters reaches the threshold (configurable via `--report.threshold=`), the bot sends a notification to the admin chat and mentions all superusers configured by username
 4. Admins can review the reported message and take action using inline buttons:
    - **Approve Ban**: Immediately ban the reported user and delete the reported message
    - **Reject**: Reject this report without taking action
    - **Ban Reporters**: Open a dialog to select and ban a specific reporter who may be abusing the reporting system (requires confirmation)
+
+Only superusers configured by username can be included as Telegram `@username` mentions. Numeric IDs do not provide a username.
 
 #### Advanced Reporting Features
 

--- a/app/events/reports.go
+++ b/app/events/reports.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -343,6 +344,30 @@ func (r *userReports) reportedUserMD(name string, id int64) string {
 	return fmt.Sprintf("[%s (%d)](tg://user?id=%d)", label, id, id)
 }
 
+func (r *userReports) superUserAttention() string {
+	mentions := make([]string, 0, len(r.superUsers))
+	seen := make(map[string]struct{}, len(r.superUsers))
+	for _, super := range r.superUsers {
+		if _, err := strconv.ParseInt(super, 10, 64); err == nil {
+			continue
+		}
+		username := strings.TrimPrefix(super, "/")
+		key := strings.ToLower(username)
+		if username == "" {
+			continue
+		}
+		if _, found := seen[key]; found {
+			continue
+		}
+		seen[key] = struct{}{}
+		mentions = append(mentions, "@"+escapeMarkDownV1Text(username))
+	}
+	if len(mentions) == 0 {
+		return ""
+	}
+	return "attention " + strings.Join(mentions, " ")
+}
+
 // sendAutoBanNotification sends notification to admin chat about automatic ban
 func (r *userReports) sendAutoBanNotification(reports []storage.Report) error {
 	if len(reports) == 0 {
@@ -379,6 +404,9 @@ func (r *userReports) sendAutoBanNotification(reports []storage.Report) error {
 		r.reportedUserMD(reportedUserName, reportedUserID),
 		msgText,
 		strings.Join(reporterList, "\n"))
+	if attention := r.superUserAttention(); attention != "" {
+		notificationText += "\n\n" + attention
+	}
 
 	// send to admin chat (no buttons - action already taken)
 	tbMsg := tbapi.NewMessage(r.adminChatID, notificationText)
@@ -438,6 +466,9 @@ func (r *userReports) updateNotificationForAutoBan(reports []storage.Report) err
 		strings.Join(reporterList, "\n"),
 		actionType,
 		len(reports))
+	if attention := r.superUserAttention(); attention != "" {
+		updatedText += "\n\n" + attention
+	}
 
 	// edit existing admin message, remove buttons
 	editMsg := tbapi.NewEditMessageText(r.adminChatID, adminMsgID, updatedText)
@@ -492,6 +523,9 @@ func (r *userReports) sendReportNotification(ctx context.Context, reports []stor
 		r.reportedUserMD(reportedUserName, reportedUserID),
 		msgText,
 		strings.Join(reporterList, "\n"))
+	if attention := r.superUserAttention(); attention != "" {
+		notificationText += "\n\n" + attention
+	}
 
 	// add padding to ensure full-width buttons - telegram sizes buttons based on message text width
 	padding := strings.Repeat("\u2800", 30) // braille pattern blank (U+2800) - invisible but takes width
@@ -570,6 +604,9 @@ func (r *userReports) updateReportNotification(_ context.Context, reports []stor
 		fmt.Sprintf("%s\n\n", r.reportedUserMD(reportedUserName, reportedUserID)) +
 		fmt.Sprintf("%s\n\n", msgText) +
 		fmt.Sprintf("**Reporters:**\n%s", strings.Join(reporterList, "\n"))
+	if attention := r.superUserAttention(); attention != "" {
+		notification += "\n\n" + attention
+	}
 
 	// add padding to ensure full-width buttons - telegram sizes buttons based on message text width
 	padding := strings.Repeat("\u2800", 30) // braille pattern blank (U+2800) - invisible but takes width

--- a/app/events/reports.go
+++ b/app/events/reports.go
@@ -905,6 +905,9 @@ func (r *userReports) callbackReportBanReporterConfirm(ctx context.Context, quer
 			msgText,
 			strings.Join(reporterList, "\n"))
 		updText += fmt.Sprintf("\n\n_reporter %s banned by %s_", escapeMarkDownV1Text(reporterName), query.From.UserName)
+		if attention := r.superUserAttention(); attention != "" {
+			updText += "\n\n" + attention
+		}
 
 		// add padding to ensure full-width buttons - telegram sizes buttons based on message text width
 		padding := strings.Repeat("\u2800", 30) // braille pattern blank (U+2800) - invisible but takes width

--- a/app/events/reports_test.go
+++ b/app/events/reports_test.go
@@ -1106,6 +1106,7 @@ func TestUserReports_AutoBan(t *testing.T) {
 			bot:         mockBot,
 			primChatID:  200,
 			adminChatID: 456,
+			superUsers:  SuperUsers{"super1", "/super2"},
 			ReportConfig: ReportConfig{
 				Storage:          mockReports,
 				Threshold:        2,
@@ -1121,6 +1122,7 @@ func TestUserReports_AutoBan(t *testing.T) {
 		assert.GreaterOrEqual(t, len(mockAPI.RequestCalls()), 1, "should delete message")
 		assert.Len(t, mockAPI.SendCalls(), 1, "should send auto-ban notification")
 		assert.Contains(t, sentMsg.Text, "[spammer (666)](tg://user?id=666)", "reported user should render as name (id) link")
+		assert.Contains(t, sentMsg.Text, "attention @super1 @super2", "should mention superusers")
 	})
 
 	t.Run("auto-ban respects soft-ban mode", func(t *testing.T) {
@@ -1196,6 +1198,7 @@ func TestUserReports_AutoBan(t *testing.T) {
 					assert.Contains(t, editMsg.Text, "auto-banned", "should mention auto-ban in updated text")
 					assert.Contains(t, editMsg.Text, "5 reports", "should show report count")
 					assert.Contains(t, editMsg.Text, "[spammer (666)](tg://user?id=666)", "reported user should render as name (id) link")
+					assert.Contains(t, editMsg.Text, "attention @super1 @super2", "should mention superusers")
 				}
 				return tbapi.Message{MessageID: 123}, nil
 			},
@@ -1225,6 +1228,7 @@ func TestUserReports_AutoBan(t *testing.T) {
 			bot:         mockBot,
 			primChatID:  200,
 			adminChatID: 456,
+			superUsers:  SuperUsers{"super1", "/super2"},
 			ReportConfig: ReportConfig{
 				Storage:          mockReports,
 				Threshold:        2,
@@ -1399,6 +1403,26 @@ func TestUserReports_reportedUserMD(t *testing.T) {
 	}
 }
 
+func TestUserReports_superUserAttention(t *testing.T) {
+	tests := []struct {
+		name       string
+		superUsers SuperUsers
+		want       string
+	}{
+		{name: "usernames", superUsers: SuperUsers{"super1", "/super2"}, want: "attention @super1 @super2"},
+		{name: "numeric IDs skipped", superUsers: SuperUsers{"123", "-456"}, want: ""},
+		{name: "duplicates skipped", superUsers: SuperUsers{"super1", "/SUPER1", "super2"}, want: "attention @super1 @super2"},
+		{name: "empty list", superUsers: nil, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rep := &userReports{superUsers: tt.superUsers}
+			assert.Equal(t, tt.want, rep.superUserAttention())
+		})
+	}
+}
+
 func TestUserReports_SendReportNotification(t *testing.T) {
 	t.Run("successful notification with single report", func(t *testing.T) {
 		var sentMsg tbapi.MessageConfig
@@ -1422,6 +1446,7 @@ func TestUserReports_SendReportNotification(t *testing.T) {
 		rep := &userReports{
 			tbAPI:        mockAPI,
 			adminChatID:  456,
+			superUsers:   SuperUsers{"super1", "/super2"},
 			ReportConfig: ReportConfig{Storage: mockReports},
 		}
 
@@ -1439,6 +1464,7 @@ func TestUserReports_SendReportNotification(t *testing.T) {
 		assert.Contains(t, sentMsg.Text, "[spammer (666)](tg://user?id=666)", "reported user should render as name (id) link")
 		assert.Contains(t, sentMsg.Text, "spam message", "should contain message text")
 		assert.Contains(t, sentMsg.Text, "reporter1", "should contain reporter name")
+		assert.Contains(t, sentMsg.Text, "attention @super1 @super2", "should mention superusers")
 
 		// verify inline keyboard
 		keyboard, ok := sentMsg.ReplyMarkup.(tbapi.InlineKeyboardMarkup)
@@ -1753,6 +1779,7 @@ func TestUserReports_UpdateReportNotification(t *testing.T) {
 		rep := &userReports{
 			tbAPI:       mockAPI,
 			adminChatID: 456,
+			superUsers:  SuperUsers{"super1", "/super2"},
 		}
 
 		reports := []storage.Report{
@@ -1773,6 +1800,7 @@ func TestUserReports_UpdateReportNotification(t *testing.T) {
 		assert.Contains(t, editedMsg.Text, "reporter1", "should contain first reporter")
 		assert.Contains(t, editedMsg.Text, "reporter2", "should contain second reporter")
 		assert.Contains(t, editedMsg.Text, "reporter3", "should contain third reporter")
+		assert.Contains(t, editedMsg.Text, "attention @super1 @super2", "should mention superusers")
 
 		// verify inline keyboard
 		require.NotNil(t, editedMsg.ReplyMarkup, "should have inline keyboard")

--- a/app/events/reports_test.go
+++ b/app/events/reports_test.go
@@ -2315,8 +2315,10 @@ func TestUserReports_CallbackReportBanReporterAsk(t *testing.T) {
 
 func TestUserReports_CallbackReportBanReporterConfirm(t *testing.T) {
 	t.Run("ban reporter with remaining reporters", func(t *testing.T) {
+		var editedMsg tbapi.EditMessageTextConfig
 		mockAPI := &mocks.TbAPIMock{
 			SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
+				editedMsg = c.(tbapi.EditMessageTextConfig)
 				return tbapi.Message{}, nil
 			},
 			RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
@@ -2346,6 +2348,7 @@ func TestUserReports_CallbackReportBanReporterConfirm(t *testing.T) {
 		rep := &userReports{
 			tbAPI:        mockAPI,
 			primChatID:   200,
+			superUsers:   SuperUsers{"super1", "/super2"},
 			ReportConfig: ReportConfig{Storage: mockReports},
 		}
 
@@ -2359,6 +2362,7 @@ func TestUserReports_CallbackReportBanReporterConfirm(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, mockReports.GetByMessageCalls(), 2)
 		assert.Len(t, mockReports.DeleteReporterCalls(), 1)
+		assert.Contains(t, editedMsg.Text, "attention @super1 @super2")
 	})
 
 	t.Run("ban last reporter", func(t *testing.T) {


### PR DESCRIPTION
mention configured superusers in `/report` notifications so Telegram pings moderators when a report reaches the review threshold.

username entries render as `@name`; numeric IDs are skipped because they do not provide a username. The attention line is kept in notification updates and auto-ban messages.

tested with `go test ./...` and `golangci-lint run`
