### PR TITLE
fix(events): make spam and /spam aliases of the report command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,13 @@
 - Admin notification text in `directReport` shows channel display name and channel ID instead of Channel_Bot identity
 - `extractUsername` supports `tg://user` links, `t.me` channel links, plain channel name+ID, and `{id name...}` formats
 
+### Report Command Routing
+- `spam`, `/spam`, `report`, `/report` are equivalent for a non-superuser: all four are matched by `isReportCommand` (`app/events/listener.go`) and behave identically in every path. `/report@botname` is additionally accepted; there is no `/spam@botname` equivalent, deliberately (nothing autocompletes it, the bot never calls `SetMyCommands`)
+- The same text from a superuser or the linked channel never reaches `isReportCommand` — `procSuperReply` intercepts it earlier in the `Do` loop for ban + spam-sample training. Identical text, different handler, decided purely by sender privilege
+- **`isReportCommand` has TWO consumers**, and this is the trap: `procUserReply` (files the report) and the orphaned-command cleanup in `Do`, which deletes a matching message sent *without* a reply. Anything added to the predicate immediately becomes deletable as an orphaned command, in every chat the bot receives updates for, and that branch is NOT gated on `ReportConfig.Enabled` — unlike `procUserReply`, which suppresses the command when reporting is off
+- The user-report dispatch requires `update.Message.SenderChat == nil`. Senders posting on behalf of a chat (anonymous admin `GroupAnonymousBot`, "post as channel" `Channel_Bot`) carry a pseudo-user in `From` that can never be an approved reporter, so without the guard `DirectUserReport` deletes their command message and files nothing
+- Known gap, unrelated to the command forms: `DirectUserReport` never resolves `SenderChat` for the *reported* message, so a channel-origin spam post is filed and banned as the shared `Channel_Bot` identity rather than the channel. `admin.go`'s `directReport` handles this correctly; the user-report path does not
+
 ### ExtraDeleteIDs Feature
 - `spamcheck.Response` includes `ExtraDeleteIDs []int` field for additional message IDs to delete when spam is detected
 - Any spam checker can populate this field to request deletion of related messages

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ To allow such a feature, `--admin.group=,  [$ADMIN_GROUP]` must be specified. Th
 
 **admin commands**
 
-* Admins can reply to the spam message with the text `spam` or `/spam` to mark it as spam. This is useful for training purposes as the bot will learn from the spam messages marked by the admin and will be able to detect similar spam in the future. The same `spam` or `/spam` text from a non-superuser does not mark the message as spam: with `--report.enabled` set it is handled as a user report instead (see [User Spam Reporting](#user-spam-reporting)), and with reporting disabled it stays an ordinary message and goes through the usual spam check.
+* Admins can reply to the spam message with the text `spam` or `/spam` to mark it as spam. This is useful for training purposes as the bot will learn from the spam messages marked by the admin and will be able to detect similar spam in the future. The same `spam` or `/spam` text from a regular user posting under his own account does not mark the message as spam: with `--report.enabled` set it is handled as a user report instead (see [User Spam Reporting](#user-spam-reporting)), and otherwise it stays an ordinary message and goes through the usual spam check.
 
 * Replying to the message with the text `ban` or `/ban` will ban the user who sent the message. This is useful for post-moderation purposes. Essentially this is the same as sending `/spam` but without adding the message to the spam samples file.
 

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ To allow such a feature, `--admin.group=,  [$ADMIN_GROUP]` must be specified. Th
 
 **admin commands**
 
-* Admins can reply to the spam message with the text `spam` or `/spam` to mark it as spam. This is useful for training purposes as the bot will learn from the spam messages marked by the admin and will be able to detect similar spam in the future. The same `spam` or `/spam` text from a regular user posting under his own account does not mark the message as spam: with `--report.enabled` set it is handled as a user report instead (see [User Spam Reporting](#user-spam-reporting)), and otherwise it stays an ordinary message and goes through the usual spam check.
+* Admins can reply to the spam message with the text `spam` or `/spam` to mark it as spam. This is useful for training purposes as the bot will learn from the spam messages marked by the admin and will be able to detect similar spam in the future. The same `spam` or `/spam` text from a regular user posting under his own account does not mark the message as spam; it is an alias for `report` and behaves exactly like it (see [User Spam Reporting](#user-spam-reporting)).
 
 * Replying to the message with the text `ban` or `/ban` will ban the user who sent the message. This is useful for post-moderation purposes. Essentially this is the same as sending `/spam` but without adding the message to the spam samples file.
 

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ To allow such a feature, `--admin.group=,  [$ADMIN_GROUP]` must be specified. Th
 
 **admin commands**
 
-* Admins can reply to the spam message with the text `spam` or `/spam` to mark it as spam. This is useful for training purposes as the bot will learn from the spam messages marked by the admin and will be able to detect similar spam in the future.
+* Admins can reply to the spam message with the text `spam` or `/spam` to mark it as spam. This is useful for training purposes as the bot will learn from the spam messages marked by the admin and will be able to detect similar spam in the future. The same `spam` or `/spam` text from a non-superuser does not mark the message as spam: with `--report.enabled` set it is handled as a user report instead (see [User Spam Reporting](#user-spam-reporting)), and with reporting disabled it stays an ordinary message and goes through the usual spam check.
 
 * Replying to the message with the text `ban` or `/ban` will ban the user who sent the message. This is useful for post-moderation purposes. Essentially this is the same as sending `/spam` but without adding the message to the spam samples file.
 
@@ -399,11 +399,11 @@ All samples are stored in the database, which can be specified using the `--db=,
 
 ### User Spam Reporting
 
-Regular users can report potential spam messages to moderators by replying to a suspicious message with `/report` or `report`. This feature provides a crowdsourced approach to spam detection, complementing automated spam filters.
+Regular users can report potential spam messages to moderators by replying to a suspicious message with `/report`, `report`, `/spam` or `spam`. This feature provides a crowdsourced approach to spam detection, complementing automated spam filters.
 
 To enable user spam reporting, set `--report.enabled` to `true` and configure an admin chat using `--admin.group=`. When enabled:
 
-1. Users reply to suspicious messages with `/report` to flag them for review
+1. Users reply to suspicious messages with `/report` or `/spam` to flag them for review
 2. The bot tracks all reports for each message
 3. When the number of unique reporters reaches the threshold (configurable via `--report.threshold=`), the bot sends a notification to the admin chat and mentions all superusers configured by username
 4. Admins can review the reported message and take action using inline buttons:
@@ -421,7 +421,7 @@ Only superusers configured by username can be included as Telegram `@username` m
 
   Example: `--report.threshold=2 --report.auto-ban-threshold=5` will notify admins after 2 reports but automatically ban after 5 reports.
 
-The reporting system includes rate limiting to prevent abuse. Each user can submit up to `--report.rate-limit=` reports (default: 10) within `--report.rate-period=` (default: 1 hour). The `/report` command message is automatically deleted to keep the chat clean.
+The reporting system includes rate limiting to prevent abuse. Each user can submit up to `--report.rate-limit=` reports (default: 10) within `--report.rate-period=` (default: 1 hour). The report command message is automatically deleted to keep the chat clean.
 
 All reports are stored in the database for audit purposes and can help identify patterns of spam or abuse over time.
 

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -506,8 +506,8 @@ func (l *TelegramListener) procSuperReply(update tbapi.Update) (handled bool) {
 func (l *TelegramListener) isReportCommand(text string) bool {
 	text = strings.TrimSpace(strings.ToLower(text))
 
-	// exact match for regular report commands; /spam is an alias for non-superusers
-	if text == "report" || text == "/report" || text == "spam" || text == "/spam" {
+	// exact match for regular report commands
+	if text == "report" || text == "/report" {
 		return true
 	}
 
@@ -538,13 +538,27 @@ func (l *TelegramListener) isReportCommand(text string) bool {
 	return false
 }
 
-// procUserReply processes regular user commands (reply) /report.
-// feature check is intentionally inside this function to keep command detection logic centralized.
+// isSpamReportAlias checks if message text is the "spam" alias for the user report command.
+// unlike isReportCommand it matches only when user reporting is enabled, so for a regular user the
+// plain word "spam" stays an ordinary message in chats without the feature. superuser "spam" is
+// handled earlier by procSuperReply and is not affected. not used by the orphaned-command cleanup,
+// which must not delete a standalone "spam" message.
+func (l *TelegramListener) isSpamReportAlias(text string) bool {
+	if !l.ReportConfig.Enabled {
+		return false
+	}
+	text = strings.TrimSpace(strings.ToLower(text))
+	return text == "spam" || text == "/spam"
+}
+
+// procUserReply processes regular user report commands sent as a reply: /report, report,
+// /report@botname and the spam, /spam alias. report commands are suppressed when the feature is off,
+// while the alias is simply not a command then, so isSpamReportAlias carries its own enabled check.
 func (l *TelegramListener) procUserReply(ctx context.Context, update tbapi.Update) (handled bool) {
 	switch {
-	case l.isReportCommand(update.Message.Text):
+	case l.isReportCommand(update.Message.Text) || l.isSpamReportAlias(update.Message.Text):
 		if !l.ReportConfig.Enabled {
-			log.Printf("[DEBUG] user spam reporting disabled, ignoring /report from %s (%d)",
+			log.Printf("[DEBUG] user spam reporting disabled, ignoring report command from %s (%d)",
 				update.Message.From.UserName, update.Message.From.ID)
 			return true // command is suppressed when feature is disabled
 		}

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -506,8 +506,8 @@ func (l *TelegramListener) procSuperReply(update tbapi.Update) (handled bool) {
 func (l *TelegramListener) isReportCommand(text string) bool {
 	text = strings.TrimSpace(strings.ToLower(text))
 
-	// exact match for "report" or "/report"
-	if text == "report" || text == "/report" {
+	// exact match for regular report commands; /spam is an alias for non-superusers
+	if text == "report" || text == "/report" || text == "spam" || text == "/spam" {
 		return true
 	}
 

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -313,15 +313,16 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 				}
 			}
 
-			// delete orphaned /report commands (sent without replying to a message)
+			// delete orphaned report commands (sent without replying to a message)
 			if !fromSuper && l.isReportCommand(update.Message.Text) && update.Message.ReplyToMessage == nil {
-				log.Printf("[DEBUG] deleting orphaned /report command from %s (%d)", update.Message.From.UserName, update.Message.From.ID)
+				log.Printf("[DEBUG] deleting orphaned report command %q from %s (%d)",
+					update.Message.Text, update.Message.From.UserName, update.Message.From.ID)
 				_, err := l.TbAPI.Request(tbapi.DeleteMessageConfig{BaseChatMessage: tbapi.BaseChatMessage{
 					MessageID:  update.Message.MessageID,
 					ChatConfig: tbapi.ChatConfig{ChatID: update.Message.Chat.ID},
 				}})
 				if err != nil {
-					log.Printf("[WARN] failed to delete orphaned /report message %d: %v", update.Message.MessageID, err)
+					log.Printf("[WARN] failed to delete orphaned report message %d: %v", update.Message.MessageID, err)
 				}
 				continue
 			}
@@ -505,12 +506,14 @@ func (l *TelegramListener) procSuperReply(update tbapi.Update) (handled bool) {
 	return false
 }
 
-// isReportCommand checks if message text is a /report command variant
+// isReportCommand checks if message text is a report command variant: report, /report,
+// /report@botname, and the spam, /spam aliases. superuser spam, /spam never reaches here, it is
+// handled earlier by procSuperReply
 func (l *TelegramListener) isReportCommand(text string) bool {
 	text = strings.TrimSpace(strings.ToLower(text))
 
-	// exact match for regular report commands
-	if text == "report" || text == "/report" {
+	// exact match for regular report commands, spam and /spam are aliases for non-superusers
+	if text == "report" || text == "/report" || text == "spam" || text == "/spam" {
 		return true
 	}
 
@@ -541,25 +544,12 @@ func (l *TelegramListener) isReportCommand(text string) bool {
 	return false
 }
 
-// isSpamReportAlias checks if message text is the "spam" alias for the user report command.
-// unlike isReportCommand it matches only when user reporting is enabled, so for a regular user the
-// plain word "spam" stays an ordinary message in chats without the feature. superuser "spam" is
-// handled earlier by procSuperReply and is not affected. not used by the orphaned-command cleanup,
-// which must not delete a standalone "spam" message.
-func (l *TelegramListener) isSpamReportAlias(text string) bool {
-	if !l.ReportConfig.Enabled {
-		return false
-	}
-	text = strings.TrimSpace(strings.ToLower(text))
-	return text == "spam" || text == "/spam"
-}
-
-// procUserReply processes regular user report commands sent as a reply: /report, report,
-// /report@botname and the spam, /spam alias. report commands are suppressed when the feature is off,
-// while the alias is simply not a command then, so isSpamReportAlias carries its own enabled check.
+// procUserReply processes regular user report commands sent as a reply: report, /report,
+// /report@botname and the spam, /spam aliases, all equivalent.
+// feature check is intentionally inside this function to keep command detection logic centralized.
 func (l *TelegramListener) procUserReply(ctx context.Context, update tbapi.Update) (handled bool) {
 	switch {
-	case l.isReportCommand(update.Message.Text) || l.isSpamReportAlias(update.Message.Text):
+	case l.isReportCommand(update.Message.Text):
 		if !l.ReportConfig.Enabled {
 			log.Printf("[DEBUG] user spam reporting disabled, ignoring report command from %s (%d)",
 				update.Message.From.UserName, update.Message.From.ID)

--- a/app/events/listener.go
+++ b/app/events/listener.go
@@ -326,8 +326,11 @@ func (l *TelegramListener) Do(ctx context.Context) error {
 				continue
 			}
 
-			// handle spam reports from regular users
-			if update.Message.ReplyToMessage != nil && !fromSuper {
+			// handle spam reports from regular users. senders posting on behalf of a chat
+			// (anonymous admin, "post as channel") are excluded: their From is a telegram pseudo-user
+			// which can never be an approved reporter, so the report would be dropped after the
+			// command message is already deleted
+			if update.Message.ReplyToMessage != nil && !fromSuper && update.Message.SenderChat == nil {
 				if l.procUserReply(ctx, update) {
 					// user command processed, skip the rest
 					continue

--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -157,8 +157,10 @@ func TestTelegramListener_DoNilFrom(t *testing.T) {
 }
 
 func TestTelegramListener_DoUserReportCommand(t *testing.T) {
-	// covers the procUserReply dispatch from the Do loop: /report suppressed when the
-	// feature is disabled, delegated to the reports handler when enabled
+	// covers the procUserReply dispatch from the Do loop: /report suppressed when the feature is
+	// disabled, delegated to the reports handler when enabled, and the spam alias which is only a
+	// regular-user command while reporting is enabled (superuser /spam goes through procSuperReply
+	// regardless, covered by TestTelegramListener_DoWithDirectSpamReport)
 
 	prep := func(reports *mocks.ReportsMock, enabled bool) (*mocks.TbAPIMock, *mocks.BotMock, *TelegramListener, func()) {
 		mockAPI := &mocks.TbAPIMock{
@@ -282,6 +284,31 @@ func TestTelegramListener_DoUserReportCommand(t *testing.T) {
 		require.Len(t, reports.AddCalls(), 1, "report should be stored")
 		assert.Equal(t, 40, reports.AddCalls()[0].Report.MsgID)
 		assert.EqualValues(t, 2, reports.AddCalls()[0].Report.ReporterUserID)
+	})
+
+	t.Run("spam alias falls through to spam check when reporting is disabled", func(t *testing.T) {
+		// unlike /report, the alias is an ordinary word: with the feature off it must not be
+		// swallowed, it has to reach the spam check and the locator like any other message
+		for _, command := range []string{"spam", "/spam"} {
+			t.Run(command, func(t *testing.T) {
+				reports := &mocks.ReportsMock{}
+				mockAPI, botMock, l, teardown := prep(reports, false)
+				defer teardown()
+
+				updChan := make(chan tbapi.Update, 1)
+				updChan <- reportUpdate(command)
+				close(updChan)
+				mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				err := l.Do(ctx)
+				require.EqualError(t, err, "telegram update chan closed")
+
+				assert.Len(t, botMock.OnMessageCalls(), 1, "alias must reach spam check when reporting is off")
+				assert.Empty(t, reports.AddCalls(), "no report should be stored when disabled")
+			})
+		}
 	})
 }
 
@@ -3808,6 +3835,67 @@ func TestTelegramListener_OrphanedReportDeletion(t *testing.T) {
 		}
 	})
 
+	t.Run("does NOT delete standalone spam alias even with reporting enabled", func(t *testing.T) {
+		// the spam alias only routes replies. a standalone "spam" is an ordinary message and must
+		// reach the spam check instead of being swallowed by the orphaned-command cleanup
+		for _, text := range []string{"spam", "/spam", "Spam", " spam "} {
+			t.Run(text, func(t *testing.T) {
+				mockLogger := &mocks.SpamLoggerMock{SaveFunc: func(msg *bot.Message, response *bot.Response) {}}
+				deleteCalled := false
+				mockAPI := &mocks.TbAPIMock{
+					GetChatFunc: func(config tbapi.ChatInfoConfig) (tbapi.ChatFullInfo, error) {
+						return tbapi.ChatFullInfo{Chat: tbapi.Chat{ID: 123}}, nil
+					},
+					RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+						if _, ok := c.(tbapi.DeleteMessageConfig); ok {
+							deleteCalled = true
+						}
+						return &tbapi.APIResponse{Ok: true}, nil
+					},
+					GetChatAdministratorsFunc: func(config tbapi.ChatAdministratorsConfig) ([]tbapi.ChatMember, error) {
+						return []tbapi.ChatMember{}, nil
+					},
+				}
+				botMock := &mocks.BotMock{OnMessageFunc: func(msg bot.Message, checkOnly bool) bot.Response {
+					return bot.Response{}
+				}}
+
+				locator, teardown := prepTestLocator(t)
+				defer teardown()
+
+				l := TelegramListener{
+					SpamLogger:   mockLogger,
+					TbAPI:        mockAPI,
+					Bot:          botMock,
+					SuperUsers:   SuperUsers{"super"},
+					Locator:      locator,
+					ReportConfig: ReportConfig{Enabled: true, Storage: &mocks.ReportsMock{}, Threshold: 2},
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				updChan := make(chan tbapi.Update, 1)
+				updChan <- tbapi.Update{
+					Message: &tbapi.Message{
+						MessageID: 100,
+						Chat:      tbapi.Chat{ID: 123},
+						Text:      text,
+						From:      &tbapi.User{UserName: "regular_user", ID: 999},
+						Date:      time.Now().Unix(),
+					},
+				}
+				close(updChan)
+				mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+				err := l.Do(ctx)
+				require.EqualError(t, err, "telegram update chan closed")
+				assert.False(t, deleteCalled, "standalone spam alias must not be deleted")
+				assert.Len(t, botMock.OnMessageCalls(), 1, "standalone spam alias should reach the spam check")
+			})
+		}
+	})
+
 	t.Run("does NOT delete orphaned /report from superuser", func(t *testing.T) {
 		mockLogger := &mocks.SpamLoggerMock{SaveFunc: func(msg *bot.Message, response *bot.Response) {}}
 		deleteCalled := false
@@ -3879,8 +3967,6 @@ func TestTelegramListener_isReportCommand(t *testing.T) {
 		{name: "plain report with trailing space", botUsername: "mybot", text: "report ", want: true},
 		{name: "plain /report with leading space", botUsername: "mybot", text: " /report", want: true},
 		{name: "plain /report with both spaces", botUsername: "mybot", text: " /report ", want: true},
-		{name: "plain spam alias", botUsername: "mybot", text: "spam", want: true},
-		{name: "plain /spam alias", botUsername: "mybot", text: "/spam", want: true},
 
 		// backward compatibility - plain commands work even with empty botUsername
 		{name: "plain /report with empty botUsername", botUsername: "", text: "/report", want: true},
@@ -3913,7 +3999,10 @@ func TestTelegramListener_isReportCommand(t *testing.T) {
 		{name: "@ command with empty botUsername", botUsername: "", text: "/report@somebot", want: false},
 		{name: "@ command exact match but empty botUsername", botUsername: "", text: "/report@", want: false},
 
-		// non-report commands
+		// non-report commands. the spam alias is matched by isSpamReportAlias, never here, so the
+		// orphaned-command cleanup in Do cannot delete a standalone "spam" message
+		{name: "not a report command spam", botUsername: "mybot", text: "spam", want: false},
+		{name: "not a report command /spam", botUsername: "mybot", text: "/spam", want: false},
 		{name: "report substring reportthis", botUsername: "mybot", text: "reportthis", want: false},
 		{name: "empty string", botUsername: "mybot", text: "", want: false},
 		{name: "just spaces", botUsername: "mybot", text: "   ", want: false},
@@ -3926,6 +4015,38 @@ func TestTelegramListener_isReportCommand(t *testing.T) {
 			}
 			got := l.isReportCommand(tt.text)
 			assert.Equal(t, tt.want, got, "isReportCommand(%q) with botUsername=%q", tt.text, tt.botUsername)
+		})
+	}
+}
+
+func TestTelegramListener_isSpamReportAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		text    string
+		want    bool
+	}{
+		{name: "spam", enabled: true, text: "spam", want: true},
+		{name: "/spam", enabled: true, text: "/spam", want: true},
+		{name: "uppercase SPAM", enabled: true, text: "SPAM", want: true},
+		{name: "mixed case /Spam", enabled: true, text: "/Spam", want: true},
+		{name: "surrounding spaces", enabled: true, text: " spam ", want: true},
+
+		// reporting off: the plain word stays an ordinary message and reaches the spam check
+		{name: "spam with reporting disabled", enabled: false, text: "spam", want: false},
+		{name: "/spam with reporting disabled", enabled: false, text: "/spam", want: false},
+
+		{name: "spam substring spammer", enabled: true, text: "spammer", want: false},
+		{name: "spam with extra text", enabled: true, text: "spam here", want: false},
+		{name: "/spam@botname not accepted", enabled: true, text: "/spam@mybot", want: false},
+		{name: "report is not the alias", enabled: true, text: "/report", want: false},
+		{name: "empty string", enabled: true, text: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &TelegramListener{ReportConfig: ReportConfig{Enabled: tt.enabled}}
+			assert.Equal(t, tt.want, l.isSpamReportAlias(tt.text), "isSpamReportAlias(%q) enabled=%v", tt.text, tt.enabled)
 		})
 	}
 }

--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -195,12 +195,12 @@ func TestTelegramListener_DoUserReportCommand(t *testing.T) {
 		return mockAPI, botMock, l, teardown
 	}
 
-	reportUpdate := func() tbapi.Update {
+	reportUpdate := func(command string) tbapi.Update {
 		return tbapi.Update{
 			Message: &tbapi.Message{
 				MessageID: 50,
 				Chat:      tbapi.Chat{ID: 123},
-				Text:      "/report",
+				Text:      command,
 				From:      &tbapi.User{UserName: "user", ID: 2},
 				ReplyToMessage: &tbapi.Message{
 					MessageID: 40,
@@ -219,7 +219,7 @@ func TestTelegramListener_DoUserReportCommand(t *testing.T) {
 		defer teardown()
 
 		updChan := make(chan tbapi.Update, 1)
-		updChan <- reportUpdate()
+		updChan <- reportUpdate("/report")
 		close(updChan)
 		mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
 
@@ -243,7 +243,7 @@ func TestTelegramListener_DoUserReportCommand(t *testing.T) {
 		defer teardown()
 
 		updChan := make(chan tbapi.Update, 1)
-		updChan <- reportUpdate()
+		updChan <- reportUpdate("/report")
 		close(updChan)
 		mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
 
@@ -253,6 +253,32 @@ func TestTelegramListener_DoUserReportCommand(t *testing.T) {
 		require.EqualError(t, err, "telegram update chan closed")
 
 		assert.Empty(t, botMock.OnMessageCalls(), "handled /report must not reach spam check")
+		require.Len(t, reports.AddCalls(), 1, "report should be stored")
+		assert.Equal(t, 40, reports.AddCalls()[0].Report.MsgID)
+		assert.EqualValues(t, 2, reports.AddCalls()[0].Report.ReporterUserID)
+	})
+
+	t.Run("non-admin spam delegates to reports handler", func(t *testing.T) {
+		reports := &mocks.ReportsMock{
+			AddFunc: func(ctx context.Context, report storage.Report) error { return nil },
+			GetByMessageFunc: func(ctx context.Context, msgID int, chatID int64) ([]storage.Report, error) {
+				return []storage.Report{{MsgID: msgID, ChatID: chatID, ReporterUserID: 2}}, nil
+			},
+		}
+		mockAPI, botMock, l, teardown := prep(reports, true)
+		defer teardown()
+
+		updChan := make(chan tbapi.Update, 1)
+		updChan <- reportUpdate("/spam")
+		close(updChan)
+		mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		err := l.Do(ctx)
+		require.EqualError(t, err, "telegram update chan closed")
+
+		assert.Empty(t, botMock.OnMessageCalls(), "handled /spam must not reach spam check")
 		require.Len(t, reports.AddCalls(), 1, "report should be stored")
 		assert.Equal(t, 40, reports.AddCalls()[0].Report.MsgID)
 		assert.EqualValues(t, 2, reports.AddCalls()[0].Report.ReporterUserID)
@@ -3853,6 +3879,8 @@ func TestTelegramListener_isReportCommand(t *testing.T) {
 		{name: "plain report with trailing space", botUsername: "mybot", text: "report ", want: true},
 		{name: "plain /report with leading space", botUsername: "mybot", text: " /report", want: true},
 		{name: "plain /report with both spaces", botUsername: "mybot", text: " /report ", want: true},
+		{name: "plain spam alias", botUsername: "mybot", text: "spam", want: true},
+		{name: "plain /spam alias", botUsername: "mybot", text: "/spam", want: true},
 
 		// backward compatibility - plain commands work even with empty botUsername
 		{name: "plain /report with empty botUsername", botUsername: "", text: "/report", want: true},
@@ -3886,7 +3914,6 @@ func TestTelegramListener_isReportCommand(t *testing.T) {
 		{name: "@ command exact match but empty botUsername", botUsername: "", text: "/report@", want: false},
 
 		// non-report commands
-		{name: "not a report command /spam", botUsername: "mybot", text: "/spam", want: false},
 		{name: "report substring reportthis", botUsername: "mybot", text: "reportthis", want: false},
 		{name: "empty string", botUsername: "mybot", text: "", want: false},
 		{name: "just spaces", botUsername: "mybot", text: "   ", want: false},

--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -157,10 +157,10 @@ func TestTelegramListener_DoNilFrom(t *testing.T) {
 }
 
 func TestTelegramListener_DoUserReportCommand(t *testing.T) {
-	// covers the procUserReply dispatch from the Do loop: /report suppressed when the feature is
-	// disabled, delegated to the reports handler when enabled, and the spam alias which is only a
-	// regular-user command while reporting is enabled (superuser /spam goes through procSuperReply
-	// regardless, covered by TestTelegramListener_DoWithDirectSpamReport)
+	// covers the procUserReply dispatch from the Do loop: report commands suppressed when the feature
+	// is disabled, delegated to the reports handler when enabled, with the spam aliases behaving
+	// identically (superuser /spam goes through procSuperReply instead, covered by
+	// TestTelegramListener_DoWithDirectSpamReport)
 
 	prep := func(reports *mocks.ReportsMock, enabled bool) (*mocks.TbAPIMock, *mocks.BotMock, *TelegramListener, func()) {
 		mockAPI := &mocks.TbAPIMock{
@@ -326,9 +326,9 @@ func TestTelegramListener_DoUserReportCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("spam alias falls through to spam check when reporting is disabled", func(t *testing.T) {
-		// unlike /report, the alias is an ordinary word: with the feature off it must not be
-		// swallowed, it has to reach the spam check and the locator like any other message
+	t.Run("spam alias is suppressed when reporting is disabled, same as /report", func(t *testing.T) {
+		// the aliases are equivalent to the report forms in every path, so with the feature off they
+		// are suppressed rather than passed to the spam check
 		for _, command := range []string{"spam", "/spam"} {
 			t.Run(command, func(t *testing.T) {
 				reports := &mocks.ReportsMock{}
@@ -345,7 +345,7 @@ func TestTelegramListener_DoUserReportCommand(t *testing.T) {
 				err := l.Do(ctx)
 				require.EqualError(t, err, "telegram update chan closed")
 
-				assert.Len(t, botMock.OnMessageCalls(), 1, "alias must reach spam check when reporting is off")
+				assert.Empty(t, botMock.OnMessageCalls(), "suppressed alias must not reach spam check")
 				assert.Empty(t, reports.AddCalls(), "no report should be stored when disabled")
 			})
 		}
@@ -3878,9 +3878,10 @@ func TestTelegramListener_OrphanedReportDeletion(t *testing.T) {
 		}
 	})
 
-	t.Run("does NOT delete standalone spam alias even with reporting enabled", func(t *testing.T) {
-		// the spam alias only routes replies. a standalone "spam" is an ordinary message and must
-		// reach the spam check instead of being swallowed by the orphaned-command cleanup
+	t.Run("deletes orphaned spam alias, same as the report forms", func(t *testing.T) {
+		// spam and /spam are plain aliases of report and /report, so a standalone one is an orphaned
+		// command and is deleted like a standalone "report". not gated on ReportConfig.Enabled,
+		// matching the report forms
 		for _, text := range []string{"spam", "/spam", "Spam", " spam "} {
 			t.Run(text, func(t *testing.T) {
 				mockLogger := &mocks.SpamLoggerMock{SaveFunc: func(msg *bot.Message, response *bot.Response) {}}
@@ -3907,12 +3908,11 @@ func TestTelegramListener_OrphanedReportDeletion(t *testing.T) {
 				defer teardown()
 
 				l := TelegramListener{
-					SpamLogger:   mockLogger,
-					TbAPI:        mockAPI,
-					Bot:          botMock,
-					SuperUsers:   SuperUsers{"super"},
-					Locator:      locator,
-					ReportConfig: ReportConfig{Enabled: true, Storage: &mocks.ReportsMock{}, Threshold: 2},
+					SpamLogger: mockLogger,
+					TbAPI:      mockAPI,
+					Bot:        botMock,
+					SuperUsers: SuperUsers{"super"},
+					Locator:    locator,
 				}
 
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -3933,8 +3933,8 @@ func TestTelegramListener_OrphanedReportDeletion(t *testing.T) {
 
 				err := l.Do(ctx)
 				require.EqualError(t, err, "telegram update chan closed")
-				assert.False(t, deleteCalled, "standalone spam alias must not be deleted")
-				assert.Len(t, botMock.OnMessageCalls(), 1, "standalone spam alias should reach the spam check")
+				assert.True(t, deleteCalled, "orphaned spam alias should be deleted")
+				assert.Empty(t, botMock.OnMessageCalls(), "bot.OnMessage should not be called for an orphaned command")
 			})
 		}
 	})
@@ -4010,6 +4010,10 @@ func TestTelegramListener_isReportCommand(t *testing.T) {
 		{name: "plain report with trailing space", botUsername: "mybot", text: "report ", want: true},
 		{name: "plain /report with leading space", botUsername: "mybot", text: " /report", want: true},
 		{name: "plain /report with both spaces", botUsername: "mybot", text: " /report ", want: true},
+		{name: "plain spam alias", botUsername: "mybot", text: "spam", want: true},
+		{name: "plain /spam alias", botUsername: "mybot", text: "/spam", want: true},
+		{name: "SPAM uppercase alias", botUsername: "mybot", text: "SPAM", want: true},
+		{name: "spam alias with both spaces", botUsername: "mybot", text: " spam ", want: true},
 
 		// backward compatibility - plain commands work even with empty botUsername
 		{name: "plain /report with empty botUsername", botUsername: "", text: "/report", want: true},
@@ -4042,11 +4046,11 @@ func TestTelegramListener_isReportCommand(t *testing.T) {
 		{name: "@ command with empty botUsername", botUsername: "", text: "/report@somebot", want: false},
 		{name: "@ command exact match but empty botUsername", botUsername: "", text: "/report@", want: false},
 
-		// non-report commands. the spam alias is matched by isSpamReportAlias, never here, so the
-		// orphaned-command cleanup in Do cannot delete a standalone "spam" message
-		{name: "not a report command spam", botUsername: "mybot", text: "spam", want: false},
-		{name: "not a report command /spam", botUsername: "mybot", text: "/spam", want: false},
+		// non-report commands
 		{name: "report substring reportthis", botUsername: "mybot", text: "reportthis", want: false},
+		{name: "spam substring spammer", botUsername: "mybot", text: "spammer", want: false},
+		{name: "spam with extra text", botUsername: "mybot", text: "spam here", want: false},
+		{name: "/spam@botname not accepted", botUsername: "mybot", text: "/spam@mybot", want: false},
 		{name: "empty string", botUsername: "mybot", text: "", want: false},
 		{name: "just spaces", botUsername: "mybot", text: "   ", want: false},
 	}
@@ -4058,38 +4062,6 @@ func TestTelegramListener_isReportCommand(t *testing.T) {
 			}
 			got := l.isReportCommand(tt.text)
 			assert.Equal(t, tt.want, got, "isReportCommand(%q) with botUsername=%q", tt.text, tt.botUsername)
-		})
-	}
-}
-
-func TestTelegramListener_isSpamReportAlias(t *testing.T) {
-	tests := []struct {
-		name    string
-		enabled bool
-		text    string
-		want    bool
-	}{
-		{name: "spam", enabled: true, text: "spam", want: true},
-		{name: "/spam", enabled: true, text: "/spam", want: true},
-		{name: "uppercase SPAM", enabled: true, text: "SPAM", want: true},
-		{name: "mixed case /Spam", enabled: true, text: "/Spam", want: true},
-		{name: "surrounding spaces", enabled: true, text: " spam ", want: true},
-
-		// reporting off: the plain word stays an ordinary message and reaches the spam check
-		{name: "spam with reporting disabled", enabled: false, text: "spam", want: false},
-		{name: "/spam with reporting disabled", enabled: false, text: "/spam", want: false},
-
-		{name: "spam substring spammer", enabled: true, text: "spammer", want: false},
-		{name: "spam with extra text", enabled: true, text: "spam here", want: false},
-		{name: "/spam@botname not accepted", enabled: true, text: "/spam@mybot", want: false},
-		{name: "report is not the alias", enabled: true, text: "/report", want: false},
-		{name: "empty string", enabled: true, text: "", want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			l := &TelegramListener{ReportConfig: ReportConfig{Enabled: tt.enabled}}
-			assert.Equal(t, tt.want, l.isSpamReportAlias(tt.text), "isSpamReportAlias(%q) enabled=%v", tt.text, tt.enabled)
 		})
 	}
 }

--- a/app/events/listener_test.go
+++ b/app/events/listener_test.go
@@ -286,6 +286,46 @@ func TestTelegramListener_DoUserReportCommand(t *testing.T) {
 		assert.EqualValues(t, 2, reports.AddCalls()[0].Report.ReporterUserID)
 	})
 
+	t.Run("anonymous admin reply is left alone, not consumed as a report", func(t *testing.T) {
+		// From is the GroupAnonymousBot pseudo-user, which can never be an approved reporter. before
+		// the SenderChat guard the report handler deleted the command message and filed nothing
+		for _, command := range []string{"spam", "/spam", "/report"} {
+			t.Run(command, func(t *testing.T) {
+				reports := &mocks.ReportsMock{}
+				mockAPI, botMock, l, teardown := prep(reports, true)
+				defer teardown()
+
+				deleteCalled := false
+				mockAPI.RequestFunc = func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+					if _, ok := c.(tbapi.DeleteMessageConfig); ok {
+						deleteCalled = true
+					}
+					return &tbapi.APIResponse{Ok: true}, nil
+				}
+				// the pseudo-user never reaches OnMessage, so it can never become approved
+				botMock.IsApprovedUserFunc = func(userID int64) bool { return false }
+
+				upd := reportUpdate(command)
+				upd.Message.From = &tbapi.User{UserName: "GroupAnonymousBot", ID: 1087968824}
+				upd.Message.SenderChat = &tbapi.Chat{ID: 123}
+
+				updChan := make(chan tbapi.Update, 1)
+				updChan <- upd
+				close(updChan)
+				mockAPI.GetUpdatesChanFunc = func(config tbapi.UpdateConfig) tbapi.UpdatesChannel { return updChan }
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				err := l.Do(ctx)
+				require.EqualError(t, err, "telegram update chan closed")
+
+				assert.False(t, deleteCalled, "anonymous admin command must not be deleted")
+				assert.Empty(t, reports.AddCalls(), "no report should be filed for a pseudo-user reporter")
+				assert.Empty(t, botMock.OnMessageCalls(), "anonymous admin post skips the spam check")
+			})
+		}
+	})
+
 	t.Run("spam alias falls through to spam check when reporting is disabled", func(t *testing.T) {
 		// unlike /report, the alias is an ordinary word: with the feature off it must not be
 		// swallowed, it has to reach the spam check and the locator like any other message
@@ -1212,6 +1252,9 @@ func TestTelegramListener_DoWithDirectSpamReport(t *testing.T) {
 		StartupMsg: "startup",
 		SuperUsers: SuperUsers{"superuser1"}, // include a test superuser
 		Locator:    locator,
+		// user reporting on, so the spam alias is live: this pins that procSuperReply still wins
+		// for a superuser and the alias never steals an admin command
+		ReportConfig: ReportConfig{Enabled: true, Storage: &mocks.ReportsMock{}, Threshold: 2},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Minute)

--- a/app/events/reports.go
+++ b/app/events/reports.go
@@ -50,7 +50,8 @@ type userReports struct {
 	dry          bool
 }
 
-// DirectUserReport handles messages replied with "/report" by regular users
+// DirectUserReport handles a regular user's report of the message he replied to. the listener decides
+// which command forms route here: /report, report, /report@botname and the spam, /spam alias
 func (r *userReports) DirectUserReport(ctx context.Context, update tbapi.Update) error {
 	origMsg := update.Message.ReplyToMessage
 	if origMsg == nil {


### PR DESCRIPTION
regular users who reply with `spam` or `/spam` to flag a message were not recognized: `isReportCommand` matched only `report`/`/report`/`/report@bot`, so a non-admin's `/spam` fell through to normal processing and got run through the spam checker itself.

now all four forms - `report`, `/report`, `spam`, `/spam` - are plain aliases for a regular user, identical in every path: an orphaned one (sent without a reply) is deleted, a reply files a report, and all are suppressed when `report.enabled` is off. `/spam@botname` is not accepted, nothing autocompletes it since the bot never calls `SetMyCommands`.

superusers are unaffected. Their `spam`/`/spam` is intercepted earlier by `procSuperReply` for ban and spam-sample training, and never reaches `isReportCommand`, so identical text routes by sender privilege.

**one fix beyond the alias itself**

the user-report dispatch now skips senders posting on behalf of a chat (`update.Message.SenderChat != nil`). An anonymous admin or a "post as channel" reply carries a telegram pseudo-user in `From` (`GroupAnonymousBot`, `Channel_Bot`) that can never be an approved reporter, so `DirectUserReport` deleted the command message and filed nothing. This also stops `/report` being swallowed the same way.
