### PR TITLE
fix(storage): avoid locator hash collisions for empty-text messages

### DIFF
--- a/app/storage/locator.go
+++ b/app/storage/locator.go
@@ -90,7 +90,7 @@ var locatorQueries = engine.NewQueryMap().
 		Postgres: "ALTER TABLE spam ADD COLUMN IF NOT EXISTS gid TEXT DEFAULT ''",
 	}).
 	Add(CmdAddLocatorMessage, engine.Query{
-		Sqlite: `INSERT OR REPLACE INTO messages (hash, gid, time, chat_id, user_id, user_name, msg_id) 
+		Sqlite: `INSERT OR REPLACE INTO messages (hash, gid, time, chat_id, user_id, user_name, msg_id)
             VALUES (:hash, :gid, :time, :chat_id, :user_id, :user_name, :msg_id)`,
 		Postgres: `INSERT INTO messages (hash, gid, time, chat_id, user_id, user_name, msg_id)
             VALUES (:hash, :gid, :time, :chat_id, :user_id, :user_name, :msg_id)
@@ -102,7 +102,7 @@ var locatorQueries = engine.NewQueryMap().
             msg_id = :msg_id`,
 	}).
 	Add(CmdAddLocatorSpam, engine.Query{
-		Sqlite: `INSERT OR REPLACE INTO spam (user_id, gid, time, checks) 
+		Sqlite: `INSERT OR REPLACE INTO spam (user_id, gid, time, checks)
             VALUES (:user_id, :gid, :time, :checks)`,
 		Postgres: `INSERT INTO spam (user_id, gid, time, checks)
             VALUES (:user_id, :gid, :time, :checks)
@@ -420,6 +420,9 @@ func (l *Locator) AddMessage(ctx context.Context, msg string, chatID, userID int
 	defer l.Unlock()
 
 	hash := l.MsgHash(msg)
+	if msg == "" {
+		hash = l.MsgHash(fmt.Sprintf("%d:%d:%d", chatID, userID, msgID))
+	}
 	log.Printf("[DEBUG] add message to locator: %q, hash:%s, userID:%d, user name:%q, chatID:%d, msgID:%d",
 		msg, hash, userID, userName, chatID, msgID)
 

--- a/app/storage/locator_test.go
+++ b/app/storage/locator_test.go
@@ -262,6 +262,36 @@ func (s *StorageTestSuite) TestLocator_AddAndRetrieveManyMessage() {
 	}
 }
 
+func (s *StorageTestSuite) TestLocator_AddMessage_EmptyTextNoCollision() {
+	ctx := context.Background()
+	for _, dbt := range s.getTestDB() {
+		db := dbt.DB
+		s.Run(fmt.Sprintf("with %s", db.Type()), func() {
+			locator, err := NewLocator(ctx, time.Hour, 1000, db)
+			s.Require().NoError(err)
+			defer db.Exec("DROP TABLE messages")
+			defer db.Exec("DROP TABLE spam")
+
+			// media-only messages
+			s.Require().NoError(locator.AddMessage(ctx, "", 100, 1, "user1", 111))
+			s.Require().NoError(locator.AddMessage(ctx, "", 100, 2, "user2", 222))
+			s.Require().NoError(locator.AddMessage(ctx, "", 100, 1, "user1", 333))
+
+			var count int
+			s.Require().NoError(db.Get(&count, db.Adopt("SELECT COUNT(*) FROM messages WHERE gid = ?"), db.GID()))
+			s.Equal(3, count)
+
+			ids, err := locator.GetUserMessageIDs(ctx, 1, 10)
+			s.Require().NoError(err)
+			s.ElementsMatch([]int{111, 333}, ids)
+
+			ids, err = locator.GetUserMessageIDs(ctx, 2, 10)
+			s.Require().NoError(err)
+			s.Equal([]int{222}, ids)
+		})
+	}
+}
+
 func (s *StorageTestSuite) TestLocator_AddAndRetrieveSpam() {
 	ctx := context.Background()
 	for _, dbt := range s.getTestDB() {


### PR DESCRIPTION
Media-only messages (photos/videos without a caption) all hash to sha256(""), colliding on the messages table's (gid, hash) primary key across every user in a chat. This results in each new text-less message to overwrite previous and prevent correct bulk-delete.
