### PR TITLE
ci: restrict docker publishing to trusted pushes and build the example against the checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,28 @@ jobs:
       env:
         TZ: "America/Chicago"
 
+    # build the example the way someone copying it out of the repository would, against the released
+    # tg-spam its go.mod pins
     - name: test examples
       run: |
+        go test -race ./...
+        go build -race ./...
+      working-directory: _examples/simplechat
+      env:
+        TZ: "America/Chicago"
+
+    # and again against this checkout, otherwise a library change that breaks the example still passes
+    # CI. the workspace is created here rather than committed: a relative replace directive would make
+    # the example unusable once copied out of the repository.
+    - name: test examples against the current checkout
+      run: |
+        go work init . ../..
+        expected=$(cd ../.. && pwd)
+        resolved=$(go list -m -f '{{.Dir}}' github.com/umputun/tg-spam)
+        if [ "$resolved" != "$expected" ]; then
+          echo "expected tg-spam to resolve to $expected, got $resolved"
+          exit 1
+        fi
         go test -race ./...
         go build -race ./...
       working-directory: _examples/simplechat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         persist-credentials: false
 
     - name: set up go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: "1.25"
       id: go

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,10 +5,20 @@ on:
     workflows: [build-app]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
+  # workflow_run runs with repository secrets and a privileged token even when the run it reacts to
+  # came from an untrusted fork, and build-app also runs on pull_request. a fork PR opened from a
+  # branch called "master" or "v1" would otherwise satisfy the head_branch test below and get this
+  # job to check out and publish fork-controlled code with the registry credentials. restrict it to
+  # pushes made in this repository.
   build:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       (github.event.workflow_run.head_branch == 'master' ||
        startsWith(github.event.workflow_run.head_branch, 'v'))
     strategy:

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -28,17 +28,17 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25"
 
       - name: cache playwright browsers and driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: playwright-cache
         with:
           # the go driver (node + playwright-core) lives beside the browser binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: set up go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25"
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -17,6 +17,9 @@ on:
 env:
   PUBLISH: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -35,7 +35,7 @@ jobs:
       packages: write
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ coverage.html
 
 # Go workspace file
 go.work
+go.work.sum
 .bin
 
 .idea


### PR DESCRIPTION
### Docker publishing accepted untrusted pull request heads

The `docker` workflow reacts to `workflow_run` from `build-app`, and `build-app` also runs on
`pull_request`. A `workflow_run` job receives the repository secrets and a privileged token no
matter where the run it reacted to came from, and the only origin test was on the branch name:

```yaml
if: >-
  github.event.workflow_run.conclusion == 'success' &&
  (github.event.workflow_run.head_branch == 'master' ||
   startsWith(github.event.workflow_run.head_branch, 'v'))
```

A fork is free to name its source branch `master` or `v1`, which is not hypothetical: PR #386 was
opened from `udivankin/tg-spam:master`. Such a PR satisfied the condition above, after which the
job checked out `github.event.workflow_run.head_sha`, logged in to ghcr.io and Docker Hub with
`secrets.PKG_TOKEN` and `secrets.DOCKER_HUB_TOKEN`, and ran `docker/build-push-action` with
`context: .` against fork-controlled content, including a fork-controlled `Dockerfile`. A `v*` head
would additionally have been tagged `latest` and triggered the deployment call at the end of the
`merge` job.

The build job is now guarded on the origin as well as the branch:

```yaml
github.event.workflow_run.event == 'push' &&
github.event.workflow_run.head_repository.full_name == github.repository &&
```

`merge` needs no separate guard, since `needs: build` means it is skipped whenever `build` is. Real
pushes to `master` and to `v*` tags are unaffected.

The `actions/checkout` bump below reinforces this independently: v7 blocks checking out a fork pull
request head under `pull_request_target` and `workflow_run` (actions/checkout#2454).

One gap this does not close, which I did not want to decide for you: `workflow_run.head_branch`
carries only a ref name, so it cannot tell the `v1.27.0` tag from a branch of that name. Anyone with
push access to this repository can therefore still publish `latest` and fire the deployment call
from a branch rather than a tag. Distinguishing the two needs a lookup of the ref against
`head_sha`, which is a separate step and a policy question about how tightly you want your own
release path locked down; say the word and I will add it.

### The example was built against a released library, not against the checkout

`_examples/simplechat` is a separate module that requires `github.com/umputun/tg-spam v1.18.0`, so
`go test`/`go build` in the CI step resolved the library from the module cache and a change in
`lib/` that broke the example still passed CI.

The existing step is kept as it is, because building against the pinned release is exactly what
somebody copying the example out of the repository gets, and a second step now builds it again
inside a CI-only workspace over the example and the checkout, asserting the module resolves to the
checkout first. The workspace is deliberately not committed: a relative `replace` would make the
example unusable once copied out. The example lint step that follows picks the workspace up, so it
also lints against the checkout.

### Other maintenance

- `actions/checkout` v6 to v7, `actions/setup-go` v6 to v7, `actions/cache` v5 to v6.
- Top-level `permissions: {contents: read}` added to `docker.yml` and `updater.yml`, which were the
  two workflows without one. The per-job `packages: write` grants are unchanged.
- `go.work.sum` added to `.gitignore` beside the existing `go.work` entry, since the example step
  now produces one locally as well.

I left `.github/dependabot.yml` alone. Both entries set `open-pull-requests-limit: 0`, which
disables version updates while leaving security updates flowing, and that looks like a deliberate
choice rather than an oversight.
