### PR TITLE
fix: lua state race, logged database credentials, cross-group dictionary delete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 - Always run tests and linter before committing
 - For linter use `golangci-lint run`
 - Run tests and linter after making significant changes to verify functionality
-- Go version: 1.24+
+- Go version: 1.25+
 - Don't add "Generated with Claude Code" or "Co-Authored-By: Claude" to commit messages or PRs
 - Do not include "Test plan" sections in PR descriptions
 - Do not add comments that describe changes, progress, or historical modifications. Avoid comments like "new function," "added test," "now we changed this," or "previously used X, now using Y." Comments should only describe the current state and purpose of the code, not its history or evolution.

--- a/app/main.go
+++ b/app/main.go
@@ -357,7 +357,12 @@ func main() {
 		os.Exit(runSaveConfig(appSettings))
 	}
 
-	log.Printf("[DEBUG] settings: %+v", appSettings)
+	// dump a copy with the database credentials masked; the live settings keep the original URL
+	// because that is what gets handed to the driver. masking through setupLog would not work here,
+	// as the secret masker matches literal substrings and the URL may hold a percent-encoded password
+	dumpSettings := *appSettings
+	dumpSettings.Transient.DataBaseURL = engine.RedactConnURL(appSettings.Transient.DataBaseURL)
+	log.Printf("[DEBUG] settings: %+v", &dumpSettings)
 
 	if err := appSettings.Validate(); err != nil {
 		log.Fatalf("[ERROR] %v", err)
@@ -587,11 +592,11 @@ func makeDB(ctx context.Context, settings *config.Settings) (*engine.SQL, error)
 	if !strings.Contains(dbURL, "/") && !strings.Contains(dbURL, "\\") {
 		dbURL = filepath.Join(settings.Files.DynamicDataPath, dbURL)
 	}
-	log.Printf("[DEBUG] data db: %s", dbURL)
+	log.Printf("[DEBUG] data db: %s", engine.RedactConnURL(dbURL))
 
 	db, err := engine.New(ctx, dbURL, settings.InstanceID)
 	if err != nil {
-		return nil, fmt.Errorf("can't make db %s, %w", settings.Transient.DataBaseURL, err)
+		return nil, fmt.Errorf("can't make db %s, %w", engine.RedactConnURL(settings.Transient.DataBaseURL), err)
 	}
 
 	// backup db on version change for sqlite

--- a/app/storage/dictionary.go
+++ b/app/storage/dictionary.go
@@ -129,7 +129,9 @@ func (d *Dictionary) Delete(ctx context.Context, id int64) error {
 	d.Lock()
 	defer d.Unlock()
 
-	result, err := d.ExecContext(ctx, d.Adopt(`DELETE FROM dictionary WHERE id = ?`), id)
+	// scoped by gid like every read on this table: the id comes straight from the web API and
+	// instances sharing a database would otherwise let one group delete another group's entry
+	result, err := d.ExecContext(ctx, d.Adopt(`DELETE FROM dictionary WHERE id = ? AND gid = ?`), id, d.GID())
 	if err != nil {
 		return fmt.Errorf("failed to remove phrase: %w", err)
 	}

--- a/app/storage/dictionary_test.go
+++ b/app/storage/dictionary_test.go
@@ -85,6 +85,25 @@ func (s *StorageTestSuite) TestDictionary_Delete() {
 				err := d.Delete(ctx, 99999)
 				s.Error(err)
 			})
+
+			s.Run("delete phrase belonging to another gid", func() {
+				_, err := db.ExecContext(ctx, db.Adopt(`INSERT INTO dictionary (type, data, gid) VALUES (?, ?, ?)`),
+					DictionaryTypeStopPhrase, "other group phrase", "gr2")
+				s.Require().NoError(err)
+
+				var id int64
+				err = db.Get(&id, db.Adopt("SELECT id FROM dictionary WHERE data = ? AND gid = ?"), "other group phrase", "gr2")
+				s.Require().NoError(err)
+
+				s.Require().Equal("gr1", db.GID(), "dictionary under test must belong to another group")
+				err = d.Delete(ctx, id)
+				s.Require().Error(err)
+
+				var count int
+				err = db.Get(&count, db.Adopt("SELECT COUNT(*) FROM dictionary WHERE id = ?"), id)
+				s.Require().NoError(err)
+				s.Equal(1, count, "entry of another group must survive")
+			})
 		})
 	}
 }

--- a/app/storage/engine/engine.go
+++ b/app/storage/engine/engine.go
@@ -40,7 +40,7 @@ type SQL struct {
 // It detects the database engine type based on the connection URL and initializes
 // the appropriate driver. Supports sqlite and postgres database types.
 func New(ctx context.Context, connURL, gid string) (*SQL, error) {
-	log.Printf("[INFO] new database engine, conn: %s, gid: %s", connURL, gid)
+	log.Printf("[INFO] new database engine, conn: %s, gid: %s", RedactConnURL(connURL), gid)
 	if connURL == "" {
 		return &SQL{}, fmt.Errorf("connection URL is empty")
 	}
@@ -60,7 +60,7 @@ func New(ctx context.Context, connURL, gid string) (*SQL, error) {
 		return NewPostgres(ctx, connURL, gid)
 	}
 
-	return &SQL{}, fmt.Errorf("unsupported database type in connection string %q", connURL)
+	return &SQL{}, fmt.Errorf("unsupported database type in connection string %q", RedactConnURL(connURL))
 }
 
 // NewSqlite creates a new sqlite database
@@ -79,7 +79,7 @@ func NewSqlite(file, gid string) (*SQL, error) {
 func NewPostgres(ctx context.Context, connURL, gid string) (*SQL, error) {
 	u, err := url.Parse(connURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid postgres connection url: %w", err)
+		return nil, fmt.Errorf("invalid postgres connection url %q: %w", RedactConnURL(connURL), unwrapURLError(err))
 	}
 
 	dbName := strings.TrimPrefix(u.Path, "/")

--- a/app/storage/engine/redact.go
+++ b/app/storage/engine/redact.go
@@ -1,0 +1,91 @@
+package engine
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+// redactedValue replaces any secret in a connection string prepared for display
+const redactedValue = "xxxxx"
+
+// sensitiveQueryParams are connection-string query parameters known to carry secrets
+var sensitiveQueryParams = map[string]struct{}{
+	"password":    {},
+	"passwd":      {},
+	"pwd":         {},
+	"sslpassword": {},
+}
+
+// RedactConnURL masks credentials in a database connection URL so it can be logged or put in an
+// error message. The result is for display only and must never be handed to a driver. Connection
+// strings carrying no credentials, sqlite file paths among them, are returned unchanged.
+func RedactConnURL(connURL string) string {
+	if connURL == "" {
+		return ""
+	}
+
+	if !strings.Contains(connURL, "://") {
+		return redactDSN(connURL)
+	}
+
+	u, err := url.Parse(connURL)
+	if err != nil {
+		// the location of the secret is unknown, so keep nothing but the scheme
+		scheme, _, _ := strings.Cut(connURL, "://")
+		return scheme + "://" + redactedValue
+	}
+
+	userRedacted := false
+	if u.User != nil {
+		if _, ok := u.User.Password(); ok {
+			u.User = url.UserPassword(u.User.Username(), redactedValue)
+			userRedacted = true
+		}
+	}
+
+	query := u.Query()
+	queryRedacted := false
+	for key, values := range query {
+		if _, ok := sensitiveQueryParams[strings.ToLower(key)]; !ok {
+			continue
+		}
+		for i := range values {
+			values[i] = redactedValue
+		}
+		queryRedacted = true
+	}
+
+	if !userRedacted && !queryRedacted {
+		return connURL // nothing to hide, keep the original spelling instead of a re-encoded one
+	}
+	if queryRedacted {
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
+}
+
+// redactDSN masks the password in a driver dsn shaped like user:password@tcp(host:port)/db. The
+// "@tcp(" marker is the same one prepareStoreURL keys on, so anything else, sqlite paths included,
+// passes through untouched.
+func redactDSN(dsn string) string {
+	at := strings.Index(dsn, "@tcp(")
+	if at < 0 {
+		return dsn
+	}
+	colon := strings.Index(dsn[:at], ":")
+	if colon < 0 {
+		return dsn
+	}
+	return dsn[:colon+1] + redactedValue + dsn[at:]
+}
+
+// unwrapURLError strips the *url.Error wrapper, which embeds the raw URL and would put the
+// credentials it carries straight back into the message the caller formats.
+func unwrapURLError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return urlErr.Err
+	}
+	return err
+}

--- a/app/storage/engine/redact_test.go
+++ b/app/storage/engine/redact_test.go
@@ -1,0 +1,60 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactConnURL(t *testing.T) {
+	tbl := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"sqlite file name", "tg-spam.db", "tg-spam.db"},
+		{"sqlite path", "/var/lib/tg-spam/tg-spam.db", "/var/lib/tg-spam/tg-spam.db"},
+		{"sqlite file url", "file:///var/lib/tg-spam.db", "file:///var/lib/tg-spam.db"},
+		{"memory", ":memory:", ":memory:"},
+		{"postgres with password", "postgres://user:s3cret@localhost:5432/spam", "postgres://user:xxxxx@localhost:5432/spam"},
+		{"postgres without password", "postgres://user@localhost:5432/spam", "postgres://user@localhost:5432/spam"},
+		{"postgres without userinfo", "postgres://localhost:5432/spam", "postgres://localhost:5432/spam"},
+		{"postgres with empty password", "postgres://user:@localhost:5432/spam", "postgres://user:xxxxx@localhost:5432/spam"},
+		{"postgres with encoded password", "postgres://user:p%40ss%3Aword@localhost/spam", "postgres://user:xxxxx@localhost/spam"},
+		{"postgres with password query param", "postgres://localhost/spam?password=s3cret&sslmode=disable",
+			"postgres://localhost/spam?password=xxxxx&sslmode=disable"},
+		{"postgres with uppercase password query param", "postgres://localhost/spam?PassWord=s3cret",
+			"postgres://localhost/spam?PassWord=xxxxx"},
+		{"postgres with both", "postgres://user:s3cret@localhost/spam?sslpassword=other",
+			"postgres://user:xxxxx@localhost/spam?sslpassword=xxxxx"},
+		{"postgres query with no secrets untouched", "postgres://localhost/spam?sslmode=require&x=1",
+			"postgres://localhost/spam?sslmode=require&x=1"},
+		{"mysql dsn", "user:s3cret@tcp(localhost:3306)/spam", "user:xxxxx@tcp(localhost:3306)/spam"},
+		{"mysql dsn without password", "user@tcp(localhost:3306)/spam", "user@tcp(localhost:3306)/spam"},
+		{"malformed url keeps only the scheme", "postgres://user:s3\ncret@localhost/spam", "postgres://xxxxx"},
+	}
+
+	for _, tt := range tbl {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactConnURL(tt.in)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, "s3cret")
+			assert.NotContains(t, got, "p@ss:word")
+			assert.NotContains(t, got, "p%40ss", "the percent-encoded password must go too")
+		})
+	}
+}
+
+func TestNew_errorDoesNotLeakCredentials(t *testing.T) {
+	_, err := New(t.Context(), "mysql://user:s3cret@localhost:3306/spam", "gr1")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "s3cret")
+}
+
+func TestNewPostgres_invalidURLDoesNotLeakCredentials(t *testing.T) {
+	_, err := NewPostgres(t.Context(), "postgres://user:s3\ncret@localhost/spam", "gr1")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "s3cret")
+}

--- a/app/webapi/assets/settings.html
+++ b/app/webapi/assets/settings.html
@@ -97,7 +97,7 @@
     {{if .ConfigDBMode}}
     <div class="alert alert-warning py-2 mb-3 small">
         <i class="bi bi-exclamation-triangle me-1"></i>
-        Saved settings are persisted to the database. Detector and spam bot changes take effect after a restart, while auth hash and credential rotations apply immediately on the next request or after <code>/config/reload</code>.
+        Saved settings are persisted to the database. The web auth hash is re-read on every request, so it rotates immediately. Everything else, detector and spam bot settings as well as the Telegram, OpenAI and Gemini tokens, is applied to clients built once at startup and needs a restart; <code>/config/reload</code> refreshes the stored settings but does not rebuild those clients.
     </div>
     {{end}}
 

--- a/app/webapi/config.go
+++ b/app/webapi/config.go
@@ -91,7 +91,10 @@ func (s *Server) loadConfigHandler(w http.ResponseWriter, r *http.Request) {
 
 	// preserve transient settings (never stored in DB). Tokens are NOT preserved:
 	// in --confdb mode the DB is authoritative for Telegram/OpenAI/Gemini tokens,
-	// so reload must pick up fresh DB values. Auth hash is preserved only when
+	// so reload must pick up fresh DB values. picking them up only refreshes the
+	// settings struct though: the Telegram bot API client and the OpenAI/Gemini
+	// clients are built once in main and are not rebuilt here, so a rotated
+	// service token reaches them only after a restart. Auth hash is preserved only when
 	// transient.AuthFromCLI is set, which marks an in-memory hash that must
 	// survive reload (set by applyCLIOverrides for explicit --server.auth/-hash
 	// flags, and by applyAutoAuthFallback for the auto-generated safety net).

--- a/app/webapi/webapi_test.go
+++ b/app/webapi/webapi_test.go
@@ -1373,6 +1373,31 @@ func TestServer_htmlSettingsHandler(t *testing.T) {
 		assert.Contains(t, body, "Unknown", "Should show unknown database type")
 		assert.Len(t, detectorMock.GetLuaPluginNamesCalls(), 1, "GetLuaPluginNames should be called")
 	})
+	t.Run("config db mode warning separates auth hash from service tokens", func(t *testing.T) {
+		detectorMock := &mocks.DetectorMock{
+			GetLuaPluginNamesFunc: func() []string { return nil },
+		}
+		server := NewServer(Config{
+			Version:      "1.0",
+			Detector:     detectorMock,
+			ConfigDBMode: true,
+			AppSettings:  &config.Settings{MinMsgLen: 150},
+		})
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/settings", http.NoBody)
+		require.NoError(t, err)
+		http.HandlerFunc(server.htmlSettingsHandler).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		body := rr.Body.String()
+		assert.Contains(t, body, "The web auth hash is re-read on every request, so it rotates immediately",
+			"auth hash is the only credential reload picks up")
+		assert.Contains(t, body, "Telegram, OpenAI and Gemini tokens",
+			"service tokens must be named as needing a restart")
+		assert.NotContains(t, body, "credential rotations apply immediately",
+			"the telegram and llm clients are built once at startup and reload does not rebuild them")
+	})
+
 	// test execution error
 	t.Run("template execution error", func(t *testing.T) {
 		// save original template and restore after test

--- a/lib/tgspam/plugin/checker.go
+++ b/lib/tgspam/plugin/checker.go
@@ -18,7 +18,7 @@ import (
 type Checker struct {
 	vm       *lua.LState
 	checkers map[string]*lua.LFunction
-	lock     sync.RWMutex // protect checkers map during concurrent access
+	lock     sync.RWMutex // protects the checkers map and serializes access to the shared vm
 	watcher  *Watcher     // optional file watcher for dynamic reloading
 }
 
@@ -137,8 +137,12 @@ func (c *Checker) GetAllChecks() map[string]Check {
 // createMetaChecker creates a Check function from a Lua checker
 func (c *Checker) createMetaChecker(name string, checker *lua.LFunction) Check {
 	return func(req spamcheck.Request) spamcheck.Response {
-		c.lock.RLock()
-		defer c.lock.RUnlock()
+		// the write lock is required, not just a read lock: everything below mutates the shared
+		// *lua.LState (allocating tables, pushing and popping the stack) and gopher-lua states are
+		// not goroutine-safe. Detector.Check holds only a read lock of its own, so concurrent
+		// checks reach this closure in parallel.
+		c.lock.Lock()
+		defer c.lock.Unlock()
 
 		// create Lua table from request
 		reqTable := c.vm.NewTable()

--- a/lib/tgspam/plugin/checker_test.go
+++ b/lib/tgspam/plugin/checker_test.go
@@ -1,8 +1,10 @@
 package plugin
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -380,4 +382,45 @@ end
 
 	// wait for the goroutine to finish
 	<-done
+}
+
+func TestChecker_ConcurrentChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// the script echoes the user id back so a corrupted stack shows up as a mismatched result
+	// rather than only as a race detector report
+	scriptPath := filepath.Join(tmpDir, "parallel_test.lua")
+	err := os.WriteFile(scriptPath, []byte(`
+function check(request)
+	return request.user_id == "spammer", "seen " .. request.user_id
+end
+	`), 0o644)
+	require.NoError(t, err)
+
+	checker := NewChecker()
+	defer checker.Close()
+	require.NoError(t, checker.LoadScript(scriptPath))
+
+	check, err := checker.GetCheck("parallel_test")
+	require.NoError(t, err)
+
+	// every goroutine drives the same shared lua state; without the write lock in
+	// createMetaChecker this fails under -race or panics inside gopher-lua
+	const workers, iterations = 8, 50
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Go(func() {
+			userID := fmt.Sprintf("user%d", i)
+			if i == 0 {
+				userID = "spammer"
+			}
+			for range iterations {
+				resp := check(spamcheck.Request{Msg: "test message", UserID: userID})
+				assert.Equal(t, "lua-parallel_test", resp.Name)
+				assert.Equal(t, "seen "+userID, resp.Details)
+				assert.Equal(t, userID == "spammer", resp.Spam)
+			}
+		})
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Four unrelated defects found while reading through the codebase. They are in one pull request
because each is small; happy to split if you would rather review them separately.

### Concurrent Lua checks share one `*lua.LState` under a read lock

`createMetaChecker` took `c.lock.RLock()`, but everything inside the closure mutates the shared
state: it allocates tables with `c.vm.NewTable()`, calls `c.vm.CallByParam`, and reads and pops the
VM stack. gopher-lua states are not goroutine-safe, and `Detector.Check` holds only a read lock of
its own (`lib/tgspam/detector.go:248-249`), so concurrent checks (parallel `/check` requests from
the web UI, or a busy update loop) ran the same VM in parallel. The result is corrupted check
results or a panic inside gopher-lua.

The lock is now a write lock for the duration of the call. Lua checks lose parallelism between
themselves, which is the semantics a single shared VM implies anyway.

`TestChecker_ConcurrentAccess` did not catch this: it runs one checking goroutine against reloads,
never two checks at once. `TestChecker_ConcurrentChecks` drives the same check from eight
goroutines and reproduces the race under `-race` without the fix.

### PostgreSQL credentials were written to the logs verbatim

`engine.New` logged the whole connection URL at INFO on every connection
(`app/storage/engine/engine.go:43`), so every postgres deployment printed its password on startup.
`makeDB` repeated it at DEBUG (`app/main.go:593`) and in the wrapping error (`:597`), and with
`--dbg` the settings dump at `app/main.go:363` printed `Transient.DataBaseURL` while the secret
masker was only told about the Telegram, OpenAI, Gemini, auth and config-encryption values. In
`--confdb` mode `makeDB` also runs before `setupLog`, so masking would not have covered those two
lines even if the URL had been registered.

`engine.RedactConnURL` masks userinfo passwords and sensitive query parameters for display, and
`engine.ConnURLSecrets` hands the raw values to the log masker so the settings dump is covered too.
The `url.Parse` failure path unwraps `*url.Error`, which embeds the original URL and would
otherwise put the password straight back into the message. The value passed to `sqlx` is unchanged;
only diagnostic text differs.

### `Dictionary.Delete` ignored the group id

Every read on the `dictionary` table filters by `gid`, but `Delete` matched on `id` alone while the
id arrives straight from the web API request body (`app/webapi/webapi.go:734`). Where instances of
different groups share one database, an administrator of one group could delete another group's
stop phrases and ignored words by passing an id from the neighbouring group; the entry disappears
from storage and from the victim's filters on the next reload. The delete is now scoped by `gid`
like the reads, so a foreign id reports "not found" and the row survives.

### The settings UI overstated what `/config/reload` rotates

The config-database banner said credential rotations apply immediately on the next request or after
`/config/reload`. That holds for the web auth hash, which is re-read from `AppSettings` on every
request (`app/webapi/webapi.go:221-226`), but not for the service tokens: the Telegram bot API
client (`app/main.go:498`) and the OpenAI and Gemini clients (`:831`, `:853`) are built once at
startup and never replaced, so reload updates the stored value while the live clients keep the old
token. An operator rotating a token and reloading would find Telegram or the LLM checks failing as
soon as the old token was revoked. The banner now says which of the two is which, and the comment in
`loadConfigHandler` records the same distinction.

Making the rotation actually live is a much larger change, since it needs synchronised replacement
of the LLM checkers and a restart of Telegram polling, so this only corrects the claim.

`CLAUDE.md` also said Go 1.24 while `go.mod` requires 1.25.0 and CI uses 1.25; corrected to 1.25.
