### PR TITLE
fix: make dynamic lua reload reach the running checks

### DIFF
--- a/docs/backlog/checker-close-races-shared-lua-state.md
+++ b/docs/backlog/checker-close-races-shared-lua-state.md
@@ -1,0 +1,19 @@
+---
+worth: later
+where: lib/tgspam/plugin/checker.go:200
+added: 2026-08-20
+---
+# Checker.Close closes the shared Lua state without holding the lock
+
+`Close` calls `c.vm.Close()` without taking `c.lock`, so it can free the shared `*lua.LState` while a
+check is running on it. Every other path that touches `c.vm` serializes on that lock — `LoadScript`
+takes the write lock, and the closure `createMetaChecker` returns takes it for the whole Lua call — so
+`Close` is the one place that does not.
+
+`c.watcher.Stop()` on the line above closes the fsnotify watcher and returns; it does not wait for
+`watchLoop` to observe `done` and exit. A tick already in `processEvents` can therefore still be inside
+`ReloadScript` when `c.vm.Close()` lands.
+
+Not reachable from tg-spam's own shutdown path today, where nothing calls `Close` while messages are
+still being checked, which is why it was left. A library consumer of `lib/tgspam/plugin` driving its own
+lifecycle can reach it. Surfaced by the review of the issue #444 fix.

--- a/docs/backlog/lua-reload-not-transactional.md
+++ b/docs/backlog/lua-reload-not-transactional.md
@@ -1,0 +1,20 @@
+---
+worth: later
+where: lib/tgspam/plugin/checker.go:64
+added: 2026-08-20
+---
+# a failed Lua reload can still change what the previous version does
+
+`LoadScript` validates a script in a throwaway `lua.LState` and only then runs it in the shared VM with
+`c.vm.DoFile(path)`. The candidate has to run there to be registered, so a script that passes validation
+and then fails partway through in the main VM has already executed whatever ran before the failure.
+
+The two states are not equivalent: the throwaway one is bare (`RegisterHelpers` runs only on `c.vm`) and
+carries none of the globals earlier scripts left behind, so passing it does not predict the main load.
+A candidate that reassigns a global the previous version's `check` reads, then errors, leaves the old
+registry entry in place answering differently.
+
+`ReloadScript`'s godoc states this limit and `TestChecker_FailedReloadCanStillMutateSharedGlobals` pins
+it, so the behavior is documented rather than fixed. Making it transactional means either loading each
+script in its own state or snapshotting globals around the load, both of which change how scripts share
+the VM — more than the issue #444 fix should carry. Surfaced by its review.

--- a/lib/tgspam/plugin/checker.go
+++ b/lib/tgspam/plugin/checker.go
@@ -77,18 +77,9 @@ func (c *Checker) LoadScript(path string) error {
 	return nil
 }
 
-// ReloadScript reloads a specific Lua script
+// ReloadScript reloads a specific Lua script. The previously loaded version stays registered and
+// active if the new one fails to load, so a broken edit does not silently disable a working rule.
 func (c *Checker) ReloadScript(path string) error {
-	// use filename (without extension) as checker name
-	name := filepath.Base(path)
-	name = name[:len(name)-len(filepath.Ext(name))]
-
-	// remove old script from checkers
-	c.lock.Lock()
-	delete(c.checkers, name)
-	c.lock.Unlock()
-
-	// reload the script
 	return c.LoadScript(path)
 }
 
@@ -111,14 +102,14 @@ func (c *Checker) LoadDirectory(dir string) error {
 // GetCheck returns a Check for the specified Lua checker
 func (c *Checker) GetCheck(name string) (Check, error) {
 	c.lock.RLock()
-	checker, ok := c.checkers[name]
+	_, ok := c.checkers[name]
 	c.lock.RUnlock()
 
 	if !ok {
 		return nil, fmt.Errorf("lua checker %q not found", name)
 	}
 
-	return c.createMetaChecker(name, checker), nil
+	return c.createMetaChecker(name), nil
 }
 
 // GetAllChecks returns all loaded Lua checks
@@ -126,16 +117,16 @@ func (c *Checker) GetAllChecks() map[string]Check {
 	result := make(map[string]Check)
 
 	c.lock.RLock()
-	for name, checker := range c.checkers {
-		result[name] = c.createMetaChecker(name, checker)
+	for name := range c.checkers {
+		result[name] = c.createMetaChecker(name)
 	}
 	c.lock.RUnlock()
 
 	return result
 }
 
-// createMetaChecker creates a Check function from a Lua checker
-func (c *Checker) createMetaChecker(name string, checker *lua.LFunction) Check {
+// createMetaChecker creates a Check function for the named Lua checker
+func (c *Checker) createMetaChecker(name string) Check {
 	return func(req spamcheck.Request) spamcheck.Response {
 		// the write lock is required, not just a read lock: everything below mutates the shared
 		// *lua.LState (allocating tables, pushing and popping the stack) and gopher-lua states are
@@ -143,6 +134,14 @@ func (c *Checker) createMetaChecker(name string, checker *lua.LFunction) Check {
 		// checks reach this closure in parallel.
 		c.lock.Lock()
 		defer c.lock.Unlock()
+
+		// the function is resolved on every call rather than captured: callers such as the detector
+		// keep a Check for their lifetime, and capturing would pin them to the version loaded first
+		checker, ok := c.checkers[name]
+		if !ok {
+			err := fmt.Errorf("lua checker %q not found", name)
+			return spamcheck.Response{Name: "lua-" + name, Spam: false, Details: err.Error(), Error: err}
+		}
 
 		// create Lua table from request
 		reqTable := c.vm.NewTable()

--- a/lib/tgspam/plugin/checker.go
+++ b/lib/tgspam/plugin/checker.go
@@ -77,8 +77,10 @@ func (c *Checker) LoadScript(path string) error {
 	return nil
 }
 
-// ReloadScript reloads a specific Lua script. The previously loaded version stays registered and
-// active if the new one fails to load, so a broken edit does not silently disable a working rule.
+// ReloadScript reloads a specific Lua script. A script that fails to load keeps its registry entry,
+// so a broken edit does not deregister a working rule. Reloading is not transactional beyond that:
+// the candidate runs in the shared VM to be registered, so one that mutates globals before failing
+// can still change what the previous version does.
 func (c *Checker) ReloadScript(path string) error {
 	return c.LoadScript(path)
 }

--- a/lib/tgspam/plugin/checker_test.go
+++ b/lib/tgspam/plugin/checker_test.go
@@ -459,7 +459,7 @@ end
 	assert.False(t, resp.Spam)
 }
 
-func TestChecker_FailedReloadKeepsPreviousVersion(t *testing.T) {
+func TestChecker_FailedReloadKeepsRegistryEntry(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	scriptPath := filepath.Join(tmpDir, "broken_test.lua")
@@ -488,4 +488,40 @@ end
 	resp := held(createTestRequest())
 	assert.Equal(t, "original version", resp.Details)
 	assert.True(t, resp.Spam)
+}
+
+func TestChecker_FailedReloadCanStillMutateSharedGlobals(t *testing.T) {
+	// keeping the old entry does not make a failed reload a no-op: the candidate runs in the shared VM
+	tmpDir := t.TempDir()
+
+	scriptPath := filepath.Join(tmpDir, "partial_test.lua")
+	err := os.WriteFile(scriptPath, []byte(`
+GREETING = "original version"
+MAIN_VM = true
+function check(request)
+	return true, GREETING
+end
+	`), 0o644)
+	require.NoError(t, err)
+
+	checker := NewChecker()
+	defer checker.Close()
+	require.NoError(t, checker.LoadScript(scriptPath))
+	held, err := checker.GetCheck("partial_test")
+	require.NoError(t, err)
+	require.Equal(t, "original version", held(createTestRequest()).Details)
+
+	// MAIN_VM exists only in the shared VM, so this validates in the throwaway state and fails after reassigning GREETING
+	err = os.WriteFile(scriptPath, []byte(`
+GREETING = "mutated before failure"
+if MAIN_VM then error("boom") end
+function check(request)
+	return true, GREETING
+end
+	`), 0o644)
+	require.NoError(t, err)
+	require.Error(t, checker.ReloadScript(scriptPath))
+
+	assert.Contains(t, checker.GetAllChecks(), "partial_test", "the entry survives the failed reload")
+	assert.Equal(t, "mutated before failure", held(createTestRequest()).Details, "but its behavior does not")
 }

--- a/lib/tgspam/plugin/checker_test.go
+++ b/lib/tgspam/plugin/checker_test.go
@@ -424,3 +424,68 @@ end
 	}
 	wg.Wait()
 }
+
+func TestChecker_ReloadReachesAlreadyObtainedCheck(t *testing.T) {
+	// the detector keeps a Check for its lifetime, so refreshing only the registry leaves it on the old script
+	tmpDir := t.TempDir()
+
+	scriptPath := filepath.Join(tmpDir, "held_test.lua")
+	err := os.WriteFile(scriptPath, []byte(`
+function check(request)
+	return true, "original version"
+end
+	`), 0o644)
+	require.NoError(t, err)
+
+	checker := NewChecker()
+	defer checker.Close()
+	require.NoError(t, checker.LoadScript(scriptPath))
+
+	held, err := checker.GetCheck("held_test")
+	require.NoError(t, err)
+	resp := held(createTestRequest())
+	require.Equal(t, "original version", resp.Details)
+
+	err = os.WriteFile(scriptPath, []byte(`
+function check(request)
+	return false, "reloaded version"
+end
+	`), 0o644)
+	require.NoError(t, err)
+	require.NoError(t, checker.ReloadScript(scriptPath))
+
+	resp = held(createTestRequest())
+	assert.Equal(t, "reloaded version", resp.Details, "check obtained before the reload must run the new script")
+	assert.False(t, resp.Spam)
+}
+
+func TestChecker_FailedReloadKeepsPreviousVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	scriptPath := filepath.Join(tmpDir, "broken_test.lua")
+	err := os.WriteFile(scriptPath, []byte(`
+function check(request)
+	return true, "original version"
+end
+	`), 0o644)
+	require.NoError(t, err)
+
+	checker := NewChecker()
+	defer checker.Close()
+	require.NoError(t, checker.LoadScript(scriptPath))
+	held, err := checker.GetCheck("broken_test")
+	require.NoError(t, err)
+
+	err = os.WriteFile(scriptPath, []byte(`function check(request) this is not lua`), 0o644)
+	require.NoError(t, err)
+	require.Error(t, checker.ReloadScript(scriptPath))
+
+	// a broken edit must not deregister a script that is still being executed
+	assert.Contains(t, checker.GetAllChecks(), "broken_test", "plugin stays registered after a failed reload")
+	_, err = checker.GetCheck("broken_test")
+	require.NoError(t, err)
+
+	resp := held(createTestRequest())
+	assert.Equal(t, "original version", resp.Details)
+	assert.True(t, resp.Spam)
+}

--- a/lib/tgspam/plugin/watcher.go
+++ b/lib/tgspam/plugin/watcher.go
@@ -140,10 +140,14 @@ func (w *Watcher) processEvents() {
 
 		// handle the event based on whether the file exists
 		if _, err := os.Stat(filename); os.IsNotExist(err) {
-			// deleting the file does not unload the script, so say so rather than implying it is gone
 			scriptName := filepath.Base(filename)
 			scriptName = scriptName[:len(scriptName)-len(filepath.Ext(scriptName))]
-			log.Printf("[INFO] lua script file removed: %s, the loaded plugin stays active until restart", scriptName)
+			// nothing unloads a script, so a registered one keeps running after its file is gone
+			if _, err := w.checker.GetCheck(scriptName); err == nil {
+				log.Printf("[INFO] lua script file removed: %s, the loaded plugin stays active until restart", scriptName)
+			} else {
+				log.Printf("[INFO] lua script file removed: %s, it was not loaded", scriptName)
+			}
 		} else {
 			// file was created or modified
 			log.Printf("[INFO] reloading lua script: %s", filename)

--- a/lib/tgspam/plugin/watcher.go
+++ b/lib/tgspam/plugin/watcher.go
@@ -140,16 +140,16 @@ func (w *Watcher) processEvents() {
 
 		// handle the event based on whether the file exists
 		if _, err := os.Stat(filename); os.IsNotExist(err) {
-			// file was deleted
+			// deleting the file does not unload the script, so say so rather than implying it is gone
 			scriptName := filepath.Base(filename)
 			scriptName = scriptName[:len(scriptName)-len(filepath.Ext(scriptName))]
-			log.Printf("[INFO] lua script removed: %s", scriptName)
-			continue
-		}
-		// file was created or modified
-		log.Printf("[INFO] reloading lua script: %s", filename)
-		if err := w.checker.ReloadScript(filename); err != nil {
-			log.Printf("[WARN] failed to reload lua script %s: %v", filename, err)
+			log.Printf("[INFO] lua script file removed: %s, the loaded plugin stays active until restart", scriptName)
+		} else {
+			// file was created or modified
+			log.Printf("[INFO] reloading lua script: %s", filename)
+			if err := w.checker.ReloadScript(filename); err != nil {
+				log.Printf("[WARN] failed to reload lua script %s: %v", filename, err)
+			}
 		}
 
 		// remove processed event

--- a/lib/tgspam/plugin/watcher.go
+++ b/lib/tgspam/plugin/watcher.go
@@ -142,9 +142,9 @@ func (w *Watcher) processEvents() {
 		if _, err := os.Stat(filename); os.IsNotExist(err) {
 			scriptName := filepath.Base(filename)
 			scriptName = scriptName[:len(scriptName)-len(filepath.Ext(scriptName))]
-			// nothing unloads a script, so a registered one keeps running after its file is gone
+			// the registry is all the watcher can speak for; whether the detector runs a registered script is not its call
 			if _, err := w.checker.GetCheck(scriptName); err == nil {
-				log.Printf("[INFO] lua script file removed: %s, the loaded plugin stays active until restart", scriptName)
+				log.Printf("[INFO] lua script file removed: %s, it stays in the plugin registry until restart", scriptName)
 			} else {
 				log.Printf("[INFO] lua script file removed: %s, it was not loaded", scriptName)
 			}

--- a/lib/tgspam/plugin/watcher_test.go
+++ b/lib/tgspam/plugin/watcher_test.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -150,6 +152,20 @@ func TestWatcher_HandleEvent(t *testing.T) {
 	assert.False(t, exists, "Non-lua event should not be added to the queue")
 }
 
+// captureLog redirects the standard logger for the duration of the test and returns the accumulated output
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	flags, writer := log.Flags(), log.Writer()
+	log.SetOutput(buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(writer)
+		log.SetFlags(flags)
+	})
+	return buf
+}
+
 func TestWatcher_RemovedScriptEventCleared(t *testing.T) {
 	// an uncleared event is reprocessed and re-logged on every tick for the life of the process
 	tmpDir := t.TempDir()
@@ -174,12 +190,16 @@ end
 	watcher.events[scriptPath] = time.Now().Add(-time.Second) // old enough to pass the debounce
 	watcher.mu.Unlock()
 
+	out := captureLog(t)
 	watcher.processEvents()
 
 	watcher.mu.Lock()
 	pending := len(watcher.events)
 	watcher.mu.Unlock()
 	assert.Equal(t, 0, pending, "event for a removed script must not stay pending")
+
+	assert.Contains(t, out.String(), "lua script file removed: gone_script, it stays in the plugin registry until restart")
+	assert.NotContains(t, out.String(), "it was not loaded")
 
 	// the script is still registered and executable: removing the file unloads nothing
 	check, err := checker.GetCheck("gone_script")
@@ -190,7 +210,7 @@ end
 func TestWatcher_RemovedUnloadedScriptEventCleared(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// a file that never loaded has no plugin behind it, so nothing stays active after it goes
+	// a file that never loaded has no plugin behind it, so nothing must be reported as still loaded
 	scriptPath := filepath.Join(tmpDir, "never_loaded.lua")
 
 	checker := NewChecker()
@@ -203,12 +223,16 @@ func TestWatcher_RemovedUnloadedScriptEventCleared(t *testing.T) {
 	watcher.events[scriptPath] = time.Now().Add(-time.Second)
 	watcher.mu.Unlock()
 
+	out := captureLog(t)
 	watcher.processEvents()
 
 	watcher.mu.Lock()
 	pending := len(watcher.events)
 	watcher.mu.Unlock()
 	assert.Equal(t, 0, pending, "event for a removed script must not stay pending")
+
+	assert.Contains(t, out.String(), "lua script file removed: never_loaded, it was not loaded")
+	assert.NotContains(t, out.String(), "stays in the plugin registry")
 
 	_, err = checker.GetCheck("never_loaded")
 	assert.Error(t, err)

--- a/lib/tgspam/plugin/watcher_test.go
+++ b/lib/tgspam/plugin/watcher_test.go
@@ -180,6 +180,38 @@ end
 	pending := len(watcher.events)
 	watcher.mu.Unlock()
 	assert.Equal(t, 0, pending, "event for a removed script must not stay pending")
+
+	// the script is still registered and executable: removing the file unloads nothing
+	check, err := checker.GetCheck("gone_script")
+	require.NoError(t, err)
+	assert.Equal(t, "still here", check(createTestRequest()).Details)
+}
+
+func TestWatcher_RemovedUnloadedScriptEventCleared(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// a file that never loaded has no plugin behind it, so nothing stays active after it goes
+	scriptPath := filepath.Join(tmpDir, "never_loaded.lua")
+
+	checker := NewChecker()
+	defer checker.Close()
+
+	watcher, err := NewWatcher(checker, tmpDir)
+	require.NoError(t, err)
+
+	watcher.mu.Lock()
+	watcher.events[scriptPath] = time.Now().Add(-time.Second)
+	watcher.mu.Unlock()
+
+	watcher.processEvents()
+
+	watcher.mu.Lock()
+	pending := len(watcher.events)
+	watcher.mu.Unlock()
+	assert.Equal(t, 0, pending, "event for a removed script must not stay pending")
+
+	_, err = checker.GetCheck("never_loaded")
+	assert.Error(t, err)
 }
 
 // Helper function to create a test request

--- a/lib/tgspam/plugin/watcher_test.go
+++ b/lib/tgspam/plugin/watcher_test.go
@@ -150,6 +150,38 @@ func TestWatcher_HandleEvent(t *testing.T) {
 	assert.False(t, exists, "Non-lua event should not be added to the queue")
 }
 
+func TestWatcher_RemovedScriptEventCleared(t *testing.T) {
+	// an uncleared event is reprocessed and re-logged on every tick for the life of the process
+	tmpDir := t.TempDir()
+
+	scriptPath := filepath.Join(tmpDir, "gone_script.lua")
+	err := os.WriteFile(scriptPath, []byte(`
+function check(request)
+	return true, "still here"
+end
+	`), 0o644)
+	require.NoError(t, err)
+
+	checker := NewChecker()
+	defer checker.Close()
+	require.NoError(t, checker.LoadScript(scriptPath))
+
+	watcher, err := NewWatcher(checker, tmpDir)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(scriptPath))
+	watcher.mu.Lock()
+	watcher.events[scriptPath] = time.Now().Add(-time.Second) // old enough to pass the debounce
+	watcher.mu.Unlock()
+
+	watcher.processEvents()
+
+	watcher.mu.Lock()
+	pending := len(watcher.events)
+	watcher.mu.Unlock()
+	assert.Equal(t, 0, pending, "event for a removed script must not stay pending")
+}
+
 // Helper function to create a test request
 func createTestRequest() spamcheck.Request {
 	return spamcheck.Request{


### PR DESCRIPTION
`--lua-plugins.dynamic-reload` never worked. The watcher reloads a changed script into the `Checker`, but the detector keeps calling the function it captured at startup, so an edited rule keeps its old verdict until the process restarts while the log says it reloaded.

fixes the three parts of #444 that have one correct answer each.

**reloads reach the running checks.** `createMetaChecker` captured the `*lua.LFunction`, and `Detector.WithLuaEngine` stores those closures for the life of the process, so `ReloadScript` swapped a map entry nothing ever read again. The closure now resolves `c.checkers[name]` on every call, inside the write lock it already holds since #439. The missing-entry branch is unreachable today (nothing deletes from the map) and returns the same error `Response` shape as the existing failure path.

**a broken edit no longer deregisters a plugin that keeps running.** `ReloadScript` deleted the map entry before validating, so a syntax error left nothing registered while the detector still held and ran the old closure. The plugin vanished from `GetLuaPluginNames` and the admin UI while it went on classifying and banning. `LoadScript` already validates in a throwaway state and writes the map only after the main VM load succeeds, so `ReloadScript` just calls it.

**a deleted rule file stops logging forever.** The deleted-file branch of `processEvents` skipped its own `delete(w.events, filename)`, so one removed script was reprocessed and re-logged every debounce tick for the life of the process. The message also no longer claims more than the watcher can check: it asks the registry first, and says only that the entry survives, not that the detector still runs it.

`ReloadScript`'s godoc states the limit of what a failed reload guarantees. The candidate has to run in the shared VM to be registered, so one that reassigns a global and then fails has already changed what the previous version does. `TestChecker_FailedReloadCanStillMutateSharedGlobals` pins that.

not fixed here, and worth your call rather than mine:

- newly created script files still never reach the detector. `d.luaChecks` is a startup snapshot and nothing appends to it, so adding a rule at runtime does nothing until restart. Fixing it means changing how the detector holds its rule list, which is a design decision.
- there is still no way to unload a script at runtime. On a moderation bot, whether deleting a file should disable a live rule is a policy question, not an obvious one.
- `handleEvent` still ignores `fsnotify.Rename`, which is how several editors save. This one is a plain gap rather than a design question, it just needs the unload decision above to be settled first for the rename-away case.

README:460 still promises more than the code does until the first two are decided.

two unrelated defects found while working in there are recorded in `docs/backlog/` rather than fixed: `Checker.Close` frees the shared `*lua.LState` without the lock every other VM access takes, and reload is not transactional in the shared VM.

Related to #444
