### PR TITLE
feat(lua): allow plugins to approve messages as ham

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ issue.md
 *.bak
 *.local
 .DS_Store
+
+# revmux review archive (grows per round, not shared)
+.revmux/tasks/

--- a/.revmux/profile.md
+++ b/.revmux/profile.md
@@ -1,0 +1,55 @@
+# tg-spam review profile
+
+## What this software is
+
+A Telegram anti-spam bot plus a reusable Go library. The bot watches group messages, runs them
+through a detector, and on a spam verdict deletes the message and permanently bans the sender.
+`lib/` ships as `github.com/umputun/tg-spam/lib/...` at v1 and has outside consumers; `app/` is the
+bot, its web UI and its storage.
+
+## What a real failure looks like here
+
+Severity follows consequence, and the consequences are asymmetric.
+
+- **A false positive bans a real person permanently.** Any change that can turn a ham verdict into a
+  spam one, widen what a check matches, or let a check fire on text the user did not author, is a
+  correctness defect at `major` or above even when the code reads fine.
+- **A false negative lets spam through**, which is recoverable. Same class of bug, one severity lower.
+- **A verdict-path regression is the worst case**: `Detector.Check` is one function whose ordering
+  decides which checks can be vetoed and which are final. Moving a check across a `return`, or
+  changing what lands in `cr` before `isSpamDetected`, silently changes ban policy. Treat any edit to
+  its control flow as high blast radius.
+- **A v1 API break in `lib/`** is a real defect. Changing an exported signature under the same import
+  path breaks outside consumers; additive types plus adapters are the expected shape.
+- **Concurrency**: the Lua VM is a single shared `*lua.LState` and is not goroutine-safe. Anything
+  touching `plugin.Checker` must hold its write lock across the whole Lua interaction.
+- **Storage**: sqlite and postgres are both supported. A query or migration correct on one and not the
+  other is a defect, not a portability nit.
+
+## Blast radius
+
+`lib/tgspam/detector.go` and `lib/tgspam/plugin/` affect every deployment and every library consumer.
+`app/events/listener.go` decides what actually gets deleted and banned. `app/storage/` changes reach
+existing databases. Example plugins under `_examples/` and docs are read by users writing their own
+Lua, so a wrong contract there causes real misconfiguration.
+
+## Reporting bar
+
+- Report defects, not preferences. The linter config (`.golangci.yml`, `lll` at 130 cols, `wrapcheck`,
+  `dupl`, `revive`) already enforces style; a finding a linter would catch is noise.
+- Missing tests for new behavior are worth reporting. New code is expected to arrive with tests, and
+  bug fixes are expected to have a test that failed first.
+- Do not report a finding whose fix is larger than the defect. Match the fix to the finding.
+- Finding nothing is a valid answer.
+
+## Deliberate conventions, not defects
+
+- Comments and log messages are lowercase; godoc on exported items is the exception.
+- Interfaces are defined in the consuming package; mocks are generated with `moq` into `mocks/`
+  subpackages and are never hand-edited.
+- Errors are wrapped with `fmt.Errorf("context: %w", err)`.
+- Private by default: identifiers are exported only when used outside the package.
+- Functions called only from a struct's methods are themselves methods.
+- The frontend is HTMX with as little JavaScript as possible. Absence of a JS framework is intended.
+- Several checks deliberately hard-return before the LLM (short-message flood, prohibited languages)
+  so the LLM cannot veto them. That asymmetry is designed, not an oversight.

--- a/README.md
+++ b/README.md
@@ -459,21 +459,27 @@ To enable Lua plugins:
 4. Optionally, specify which plugins to enable with `--lua-plugins.enabled-plugins=plugin1,plugin2`
 5. Optionally, enable dynamic reloading with `--lua-plugins.dynamic-reload` to automatically reload plugins when they change
 
-Each Lua plugin must define a `check` function that takes a request object and returns a boolean (is it spam) and a string (details):
+Each Lua plugin must define a `check` function that takes a request object and returns a boolean (is it spam), a string (details), and an optional third boolean (approve this message):
 
 ```lua
 function check(request)
     -- request contains: msg, user_id, user_name, first_name, last_name, is_premium, meta
     -- meta contains: images, links, mentions, has_video, has_audio, has_forward, has_keyboard, has_giveaway, has_contact, has_external_reply, message_id
-    
-    -- Your custom spam detection logic here
+
     if string.match(request.msg, "some pattern") then
         return true, "matched suspicious pattern"
     end
-    
-    return false, "message looks clean"
+
+    local approve = request.user_id == "123456789"
+    return false, "message looks clean", approve
 end
 ```
+
+The third return is backward compatible. Missing, `nil`, and boolean `false` mean no approval. Only an exact boolean `true` is accepted. Other types are ignored and logged once per plugin and type. A plugin error never approves a message, and `true` cannot approve a result where the same plugin returned spam.
+
+Approval applies to the current `Detector.Check` result. It is not persistent trust. When at least one plugin approves and a soft check reports spam, the detector returns ham, skips LLM checks, and adds one `lua-approve` row naming the approving plugins. Soft checks include duplicate detection, stop words, emoji, meta checks, Lua checks, CAS, multi-language text, abnormal spacing, similarity, and the classifier. Short-message-flood and prohibited-language checks return before Lua plugins run and cannot be cleared this way.
+
+A cleared short message follows the existing short-message rule: it does not enter ham history or count toward user graduation. A cleared normal-length message follows the ordinary ham path and enters the bounded ham history. It also counts toward configured user graduation unless the request is check-only. When LLM history is enabled, that message can be included as context in later LLM checks, including checks for other users.
 
 Several helper functions are provided to Lua scripts:
 - `count_substring(text, substr)` - Counts occurrences of a substring

--- a/README.md
+++ b/README.md
@@ -462,6 +462,11 @@ To enable Lua plugins:
 Each Lua plugin must define a `check` function that takes a request object and returns a boolean (is it spam), a string (details), and an optional third boolean (approve this message):
 
 ```lua
+local approved_user_ids = {
+    -- Add Telegram user IDs that may approve the current message:
+    -- ["123456789"] = true,
+}
+
 function check(request)
     -- request contains: msg, user_id, user_name, first_name, last_name, is_premium, meta
     -- meta contains: images, links, mentions, has_video, has_audio, has_forward, has_keyboard, has_giveaway, has_contact, has_external_reply, message_id
@@ -470,16 +475,16 @@ function check(request)
         return true, "matched suspicious pattern"
     end
 
-    local approve = request.user_id == "123456789"
+    local approve = approved_user_ids[request.user_id] == true
     return false, "message looks clean", approve
 end
 ```
 
 The third return is backward compatible. Missing, `nil`, and boolean `false` mean no approval. Only an exact boolean `true` is accepted. Other types are ignored and logged once per plugin and type. A plugin error never approves a message, and `true` cannot approve a result where the same plugin returned spam.
 
-Approval applies to the current `Detector.Check` result. It is not persistent trust. When at least one plugin approves and a soft check reports spam, the detector returns ham, skips LLM checks, and adds one `lua-approve` row naming the approving plugins. Soft checks include duplicate detection, stop words, emoji, meta checks, Lua checks, CAS, multi-language text, abnormal spacing, similarity, and the classifier. Short-message-flood and prohibited-language checks return before Lua plugins run and cannot be cleared this way.
+Approval clears soft spam results from the current `Detector.Check` call. When at least one plugin approves and a soft check reports spam, the detector returns ham, skips LLM checks, and adds one `lua-approve` row naming the approving plugins. Soft checks include duplicate detection, stop words, emoji, meta checks, Lua checks, CAS, multi-language text, abnormal spacing, similarity, and the classifier. Short-message-flood and prohibited-language checks return before Lua plugins run and cannot be cleared this way.
 
-A cleared short message follows the existing short-message rule: it does not enter ham history or count toward user graduation. A cleared normal-length message follows the ordinary ham path and enters the bounded ham history. It also counts toward configured user graduation unless the request is check-only. When LLM history is enabled, that message can be included as context in later LLM checks, including checks for other users.
+A cleared short message follows the existing short-message rule: it does not enter ham history or count toward user graduation. A cleared normal-length message follows the ordinary ham path and enters the bounded ham history. It also counts toward configured user graduation unless the request is check-only. With the default `--first-messages-count=1`, one cleared normal-length message graduates the sender, so later messages skip content analysis under the existing graduation rules. When LLM history is enabled, that message can be included as context in later LLM checks, including checks for other users.
 
 Several helper functions are provided to Lua scripts:
 - `count_substring(text, substr)` - Counts occurrences of a substring

--- a/_examples/lua_plugins/README.md
+++ b/_examples/lua_plugins/README.md
@@ -19,7 +19,7 @@ Missing, `nil`, and boolean `false` approval values have no effect. Only an exac
 
 An effective approval clears soft spam results from the current `Detector.Check` call and produces one `lua-approve` result row. It can clear duplicate, stop-word, emoji, meta, Lua, CAS, multi-language, abnormal-spacing, similarity, and classifier results. It cannot clear short-message-flood or prohibited-language results because those checks return before Lua plugins run.
 
-Cleared short messages do not enter ham history or count toward user graduation. Cleared normal-length messages follow the ordinary ham path and enter the bounded ham history. They also count toward configured user graduation unless the request is check-only. They can become context for later LLM checks when LLM history is enabled.
+Cleared short messages do not enter ham history or count toward user graduation. Cleared normal-length messages follow the ordinary ham path and enter the bounded ham history. They also count toward configured user graduation unless the request is check-only. With the default `--first-messages-count=1`, one cleared normal-length message graduates the sender, so later messages skip content analysis under the existing graduation rules. Cleared messages can become context for later LLM checks when LLM history is enabled.
 
 ### Request Object Structure
 
@@ -107,7 +107,8 @@ Here's a simple example of a custom Lua plugin:
 local config = {
     max_exclamations = 3,
     approved_user_ids = {
-        ["123456789"] = true
+        -- Add Telegram user IDs that may approve the current message:
+        -- ["123456789"] = true,
     }
 }
 

--- a/_examples/lua_plugins/README.md
+++ b/_examples/lua_plugins/README.md
@@ -4,15 +4,22 @@ This directory contains examples of Lua plugins for tg-spam. These plugins demon
 
 ## How Lua Plugins Work
 
-Lua plugins allow you to create custom spam detection logic without modifying the Go code. Each plugin is a Lua script that defines a `check` function that takes a request object and returns whether the message is spam and details.
+Lua plugins allow you to create custom spam detection logic without modifying the Go code. Each plugin is a Lua script that defines a `check` function that takes a request object and returns whether the message is spam, details, and an optional approval for the current message.
 
 ### Plugin Requirements
 
 - Each plugin must be a `.lua` file
 - Each plugin must define a `check` function
-- The `check` function must return two values:
+- The `check` function must return two values and may return a third:
   - A boolean indicating whether the message is spam (true) or not (false)
   - A string providing details about the check
+  - An optional boolean approving the current message when the spam result is false
+
+Missing, `nil`, and boolean `false` approval values have no effect. Only an exact boolean `true` is accepted. Other types are ignored and logged once per plugin and type. A plugin error never approves a message, and a plugin cannot report spam and approve it in the same result.
+
+An effective approval clears soft spam results from the current `Detector.Check` call and produces one `lua-approve` result row. It can clear duplicate, stop-word, emoji, meta, Lua, CAS, multi-language, abnormal-spacing, similarity, and classifier results. It cannot clear short-message-flood or prohibited-language results because those checks return before Lua plugins run.
+
+Cleared short messages do not enter ham history or count toward user graduation. Cleared normal-length messages follow the ordinary ham path and enter the bounded ham history. They also count toward configured user graduation unless the request is check-only. They can become context for later LLM checks when LLM history is enabled.
 
 ### Request Object Structure
 
@@ -98,7 +105,10 @@ Here's a simple example of a custom Lua plugin:
 
 -- Configuration
 local config = {
-    max_exclamations = 3
+    max_exclamations = 3,
+    approved_user_ids = {
+        ["123456789"] = true
+    }
 }
 
 -- Main check function
@@ -108,8 +118,9 @@ function check(request)
     if count > config.max_exclamations then
         return true, string.format("too many exclamation marks: %d", count)
     end
-    
-    return false, "normal number of exclamation marks"
+
+    local approve = config.approved_user_ids[request.user_id] == true
+    return false, "normal number of exclamation marks", approve
 end
 ```
 

--- a/_examples/lua_plugins/repeat_chars.lua
+++ b/_examples/lua_plugins/repeat_chars.lua
@@ -5,18 +5,23 @@
 local config = {
     max_repeats = 5,  -- Max consecutive identical characters allowed
     min_msg_length = 10,  -- Don't check messages shorter than this
+    approved_user_ids = {
+        ["123456789"] = true,
+    },
 }
 
 -- Main check function - must be named "check"
 -- @param request - Table with message details
 -- @return boolean - true if spam, false if not spam
 -- @return string - Details message
+-- @return boolean|nil - Optional approval of the current message
 function check(request)
     local msg = request.msg
+    local approve = config.approved_user_ids[request.user_id] == true
     
     -- Skip very short messages
     if #msg < config.min_msg_length then
-        return false, "message too short to check"
+        return false, "message too short to check", approve
     end
     
     -- Convert to lowercase for better matching
@@ -47,6 +52,6 @@ function check(request)
         end
     end
     
-    return false, string.format("normal character repetition (%d/%d)", 
-        max_repeats, config.max_repeats)
+    return false, string.format("normal character repetition (%d/%d)",
+        max_repeats, config.max_repeats), approve
 end

--- a/_examples/lua_plugins/repeat_chars.lua
+++ b/_examples/lua_plugins/repeat_chars.lua
@@ -5,8 +5,8 @@
 local config = {
     max_repeats = 5,  -- Max consecutive identical characters allowed
     min_msg_length = 10,  -- Don't check messages shorter than this
-    approved_user_ids = {
-        ["123456789"] = true,
+    approved_user_ids = {  -- Telegram user IDs that may approve the current message; empty by default
+        -- ["123456789"] = true,
     },
 }
 

--- a/docs/backlog/checker-close-races-shared-lua-state.md
+++ b/docs/backlog/checker-close-races-shared-lua-state.md
@@ -6,8 +6,8 @@ added: 2026-08-20
 # Checker.Close closes the shared Lua state without holding the lock
 
 `Close` calls `c.vm.Close()` without taking `c.lock`, so it can free the shared `*lua.LState` while a
-check is running on it. Every other path that touches `c.vm` serializes on that lock — `LoadScript`
-takes the write lock, and the closure `createMetaChecker` returns takes it for the whole Lua call — so
+check is running on it. Every other path that touches `c.vm` serializes on that lock. `LoadScript`
+takes the write lock, and the closure `createResultCheck` returns takes it for the whole Lua call, so
 `Close` is the one place that does not.
 
 `c.watcher.Stop()` on the line above closes the fsnotify watcher and returns; it does not wait for

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -43,7 +43,7 @@ type Detector struct {
 	duplicateDetector *duplicateDetector
 	reactionDetector  *reactionDetector
 	metaChecks        []MetaCheck
-	luaChecks         []plugin.Check // separate field for Lua plugin checks
+	luaChecks         []plugin.ResultCheck // separate field for Lua plugin checks
 	tokenizedSpam     []map[string]int
 	approvedUsers     map[string]approved.UserInfo
 	stopWords         []string
@@ -196,6 +196,11 @@ type LuaPluginEngine interface {
 	Close()                                     // cleans up resources
 }
 
+type luaResultEngine interface {
+	GetResultCheck(name string) (plugin.ResultCheck, error)
+	GetAllResultChecks() map[string]plugin.ResultCheck
+}
+
 // LoadResult is a result of loading samples.
 type LoadResult struct {
 	ExcludedTokens int // number of excluded tokens
@@ -212,7 +217,7 @@ func NewDetector(p Config) *Detector {
 		approvedUsers:     make(map[string]approved.UserInfo),
 		tokenizedSpam:     []map[string]int{},
 		metaChecks:        []MetaCheck{},
-		luaChecks:         []plugin.Check{},
+		luaChecks:         []plugin.ResultCheck{},
 		hamHistory:        spamcheck.NewLastRequests(p.HistorySize),
 		spamHistory:       spamcheck.NewLastRequests(p.HistorySize),
 		duplicateDetector: newDuplicateDetector(p.DuplicateDetection.Threshold, p.DuplicateDetection.Window),
@@ -288,6 +293,7 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	}
 
 	// all the remaining checks are performed sequentially, so we can collect all the results
+	luaApprovers := make([]string, 0)
 
 	// check for stop words if any stop words are loaded
 	if len(d.stopWords) > 0 {
@@ -306,7 +312,11 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 
 	// check for spam with Lua plugin checks
 	for _, lc := range d.luaChecks {
-		cr = append(cr, lc(req))
+		result := lc(req)
+		cr = append(cr, result.Response)
+		if result.Approved && !result.Response.Spam && result.Response.Error == nil && result.Response.Name != "" {
+			luaApprovers = append(luaApprovers, result.Response.Name)
+		}
 	}
 
 	// check for spam with CAS API if CAS API URL is set
@@ -335,8 +345,12 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 		openaiChecksShort := d.openaiChecker != nil && d.openaiChecker.params.CheckShortMessagesWithOpenAI
 		geminiChecksShort := d.geminiChecker != nil && d.geminiChecker.params.CheckShortMessages
 		llmEligible := d.FirstMessageOnly || d.FirstMessagesCount > 0
-		if isSpamDetected(cr) || !llmEligible || (!openaiChecksShort && !geminiChecksShort) {
-			if isSpamDetected(cr) {
+		softSpam := isSpamDetected(cr)
+		if softSpam || !llmEligible || (!openaiChecksShort && !geminiChecksShort) {
+			if softSpam {
+				if approval, ok := luaApprovalResponse(luaApprovers); ok {
+					return false, append(cr, approval)
+				}
 				d.spamHistory.Push(req)
 				return true, cr // spam from the checks above
 			}
@@ -362,13 +376,21 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 
 	baseSpam := isSpamDetected(cr)
 	spamDetected := baseSpam
+	luaApproved := false
+	if baseSpam {
+		if approval, ok := luaApprovalResponse(luaApprovers); ok {
+			cr = append(cr, approval)
+			spamDetected = false
+			luaApproved = true
+		}
+	}
 
 	// we hit eligible LLMs in three cases:
 	//  - short message with short-message checking enabled (ignores veto mode since there's no decision to veto)
 	//  - all checks passed (ham) and veto is false - improves false negative rate
 	//  - checks failed (spam) and veto is true - improves false positive rate
 	// FirstMessageOnly or FirstMessagesCount has to be set to use LLMs, because they are slow and expensive to run on all messages
-	if d.FirstMessageOnly || d.FirstMessagesCount > 0 {
+	if !luaApproved && (d.FirstMessageOnly || d.FirstMessagesCount > 0) {
 		llmResults := make([]detectorLLMResult, 0, 2)
 		llmChecks := []detectorLLMCheck{
 			{
@@ -440,6 +462,23 @@ func (d *Detector) Check(req spamcheck.Request) (spam bool, cr []spamcheck.Respo
 	}
 	d.hamHistory.Push(req)
 	return false, cr
+}
+
+func luaApprovalResponse(names []string) (spamcheck.Response, bool) {
+	if len(names) == 0 {
+		return spamcheck.Response{}, false
+	}
+
+	unique := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		unique[name] = struct{}{}
+	}
+	names = names[:0]
+	for name := range unique {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return spamcheck.Response{Name: "lua-approve", Details: "cleared by " + strings.Join(names, ", ")}, true
 }
 
 func (d *Detector) normalizeLLMConsensusMode(mode LLMConsensusMode) LLMConsensusMode {
@@ -573,23 +612,41 @@ func (d *Detector) WithLuaEngine(engine LuaPluginEngine) error {
 	if err := d.luaEngine.LoadDirectory(d.LuaPlugins.PluginsDir); err != nil {
 		return fmt.Errorf("failed to load Lua plugins: %w", err)
 	}
+	resultEngine, supportsResults := engine.(luaResultEngine)
 
 	// register enabled plugins as Lua checks
 	if len(d.LuaPlugins.EnabledPlugins) > 0 {
 		for _, name := range d.LuaPlugins.EnabledPlugins {
+			if supportsResults {
+				pluginCheck, err := resultEngine.GetResultCheck(name)
+				if err != nil {
+					return fmt.Errorf("failed to get Lua check %q: %w", name, err)
+				}
+				d.luaChecks = append(d.luaChecks, pluginCheck)
+				continue
+			}
+
 			pluginCheck, err := d.luaEngine.GetCheck(name)
 			if err != nil {
 				return fmt.Errorf("failed to get Lua check %q: %w", name, err)
 			}
-			// add to luaChecks
-			d.luaChecks = append(d.luaChecks, pluginCheck)
+			d.luaChecks = append(d.luaChecks, func(req spamcheck.Request) plugin.Result {
+				return plugin.Result{Response: pluginCheck(req)}
+			})
 		}
 	} else {
 		// if no specific plugins are enabled, load all
-		allChecks := d.luaEngine.GetAllChecks()
-		for _, pluginCheck := range allChecks {
-			// add to luaChecks
-			d.luaChecks = append(d.luaChecks, pluginCheck)
+		if supportsResults {
+			for _, pluginCheck := range resultEngine.GetAllResultChecks() {
+				d.luaChecks = append(d.luaChecks, pluginCheck)
+			}
+		} else {
+			for _, pluginCheck := range d.luaEngine.GetAllChecks() {
+				check := pluginCheck
+				d.luaChecks = append(d.luaChecks, func(req spamcheck.Request) plugin.Result {
+					return plugin.Result{Response: check(req)}
+				})
+			}
 		}
 	}
 

--- a/lib/tgspam/detector.go
+++ b/lib/tgspam/detector.go
@@ -473,12 +473,12 @@ func luaApprovalResponse(names []string) (spamcheck.Response, bool) {
 	for _, name := range names {
 		unique[name] = struct{}{}
 	}
-	names = names[:0]
+	uniqueNames := make([]string, 0, len(unique))
 	for name := range unique {
-		names = append(names, name)
+		uniqueNames = append(uniqueNames, name)
 	}
-	sort.Strings(names)
-	return spamcheck.Response{Name: "lua-approve", Details: "cleared by " + strings.Join(names, ", ")}, true
+	sort.Strings(uniqueNames)
+	return spamcheck.Response{Name: "lua-approve", Details: "cleared by " + strings.Join(uniqueNames, ", ")}, true
 }
 
 func (d *Detector) normalizeLLMConsensusMode(mode LLMConsensusMode) LLMConsensusMode {

--- a/lib/tgspam/detector_test.go
+++ b/lib/tgspam/detector_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/umputun/tg-spam/lib/approved"
 	"github.com/umputun/tg-spam/lib/spamcheck"
 	"github.com/umputun/tg-spam/lib/tgspam/mocks"
+	"github.com/umputun/tg-spam/lib/tgspam/plugin"
 )
 
 func TestDetector_CheckWithShort(t *testing.T) {
@@ -3066,6 +3067,191 @@ func TestDetector_CheckHistory_ShortMessagesNotAddedToHam(t *testing.T) {
 		hamMsgs := d.hamHistory.Last(5)
 		assert.Len(t, hamMsgs, 1, "normal length messages should be added to hamHistory")
 		assert.Equal(t, "this is a normal length message", hamMsgs[0].Msg)
+	})
+}
+
+func TestDetector_CheckLuaApproval(t *testing.T) {
+	t.Run("short soft spam clears without graduation or history", func(t *testing.T) {
+		d := NewDetector(Config{
+			HistorySize:        5,
+			MinMsgLen:          100,
+			MaxAllowedEmoji:    -1,
+			FirstMessagesCount: 2,
+		})
+		_, err := d.LoadStopWords(strings.NewReader("spamword"))
+		require.NoError(t, err)
+		d.luaChecks = []plugin.ResultCheck{func(spamcheck.Request) plugin.Result {
+			return plugin.Result{Response: spamcheck.Response{Name: "lua-trusted", Details: "trusted message"}, Approved: true}
+		}}
+
+		spam, checks := d.Check(spamcheck.Request{Msg: "spamword", UserID: "42"})
+
+		assert.False(t, spam)
+		assert.Equal(t, &spamcheck.Response{Name: "lua-approve", Details: "cleared by lua-trusted"},
+			findResponseByName(checks, "lua-approve"))
+		assert.Empty(t, d.hamHistory.Last(5))
+		assert.Empty(t, d.spamHistory.Last(5))
+		assert.Equal(t, 0, d.approvedCount("42"))
+	})
+
+	t.Run("normal message clears once with sorted approvers and follows ham tail", func(t *testing.T) {
+		d := NewDetector(Config{
+			HistorySize:        5,
+			MinMsgLen:          5,
+			MaxAllowedEmoji:    -1,
+			FirstMessagesCount: 2,
+			OpenAIVeto:         true,
+		})
+		_, err := d.LoadStopWords(strings.NewReader("spamword"))
+		require.NoError(t, err)
+		openAIMock := &mocks.OpenAIClientMock{
+			CreateChatCompletionFunc: func(context.Context, openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+				return openai.ChatCompletionResponse{}, errors.New("must not be called")
+			},
+		}
+		d.WithOpenAIChecker(openAIMock, OpenAIConfig{Model: "gpt4"})
+		d.luaChecks = []plugin.ResultCheck{
+			func(spamcheck.Request) plugin.Result {
+				return plugin.Result{Response: spamcheck.Response{Name: "lua-z"}, Approved: true}
+			},
+			func(spamcheck.Request) plugin.Result {
+				return plugin.Result{Response: spamcheck.Response{Name: "lua-broken", Error: errors.New("plugin failed")}, Approved: true}
+			},
+			func(spamcheck.Request) plugin.Result {
+				return plugin.Result{Response: spamcheck.Response{Name: "lua-a"}, Approved: true}
+			},
+			func(spamcheck.Request) plugin.Result {
+				return plugin.Result{Response: spamcheck.Response{Name: "lua-a"}, Approved: true}
+			},
+		}
+
+		req := spamcheck.Request{Msg: "this is a spamword message", UserID: "43", UserName: "trusted"}
+		spam, checks := d.Check(req)
+
+		assert.False(t, spam)
+		assert.Empty(t, openAIMock.CreateChatCompletionCalls())
+		assert.Equal(t, &spamcheck.Response{Name: "lua-approve", Details: "cleared by lua-a, lua-z"},
+			findResponseByName(checks, "lua-approve"))
+		assert.Equal(t, 1, d.approvedCount("43"))
+		assert.Equal(t, []spamcheck.Request{req}, d.hamHistory.Last(5))
+		assert.Empty(t, d.spamHistory.Last(5))
+	})
+
+	t.Run("CAS spam is soft", func(t *testing.T) {
+		httpMock := &mocks.HTTPClientMock{DoFunc: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true,"description":"spam detected"}`)),
+			}, nil
+		}}
+		d := NewDetector(Config{CasAPI: "http://localhost", HTTPClient: httpMock, MaxAllowedEmoji: -1})
+		d.luaChecks = []plugin.ResultCheck{func(spamcheck.Request) plugin.Result {
+			return plugin.Result{Response: spamcheck.Response{Name: "lua-trusted"}, Approved: true}
+		}}
+
+		spam, checks := d.Check(spamcheck.Request{Msg: "normal message", UserID: "44"})
+
+		assert.False(t, spam)
+		require.NotNil(t, findResponseByName(checks, "cas"))
+		assert.True(t, findResponseByName(checks, "cas").Spam)
+		require.NotNil(t, findResponseByName(checks, "lua-approve"))
+	})
+
+	t.Run("moot approval does not cancel an LLM spam verdict", func(t *testing.T) {
+		d := NewDetector(Config{MaxAllowedEmoji: -1, FirstMessageOnly: true})
+		openAIMock := &mocks.OpenAIClientMock{
+			CreateChatCompletionFunc: func(context.Context, openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+				return openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{{
+					Message: openai.ChatCompletionMessage{Content: `{"spam":true,"reason":"bad text","confidence":100}`},
+				}}}, nil
+			},
+		}
+		d.WithOpenAIChecker(openAIMock, OpenAIConfig{Model: "gpt4"})
+		d.luaChecks = []plugin.ResultCheck{func(spamcheck.Request) plugin.Result {
+			return plugin.Result{Response: spamcheck.Response{Name: "lua-trusted"}, Approved: true}
+		}}
+
+		spam, checks := d.Check(spamcheck.Request{Msg: "normal message", UserID: "45"})
+
+		assert.True(t, spam)
+		assert.Len(t, openAIMock.CreateChatCompletionCalls(), 1)
+		assert.Nil(t, findResponseByName(checks, "lua-approve"))
+	})
+
+	t.Run("duplicate cache and delete IDs remain after clearance", func(t *testing.T) {
+		d := NewDetector(Config{
+			MaxAllowedEmoji: -1,
+			DuplicateDetection: struct {
+				Threshold int
+				Window    time.Duration
+			}{Threshold: 2, Window: time.Minute},
+		})
+		d.luaChecks = []plugin.ResultCheck{func(spamcheck.Request) plugin.Result {
+			return plugin.Result{Response: spamcheck.Response{Name: "lua-trusted"}, Approved: true}
+		}}
+
+		firstSpam, firstChecks := d.Check(spamcheck.Request{
+			Msg: "repeated message", UserID: "46", Meta: spamcheck.MetaData{MessageID: 100},
+		})
+		secondSpam, secondChecks := d.Check(spamcheck.Request{
+			Msg: "repeated message", UserID: "46", Meta: spamcheck.MetaData{MessageID: 101},
+		})
+		thirdSpam, thirdChecks := d.Check(spamcheck.Request{
+			Msg: "repeated message", UserID: "46", Meta: spamcheck.MetaData{MessageID: 102},
+		})
+
+		assert.False(t, firstSpam)
+		assert.Nil(t, findResponseByName(firstChecks, "lua-approve"))
+		assert.False(t, secondSpam)
+		assert.False(t, thirdSpam)
+		assert.Equal(t, []int{100}, findResponseByName(secondChecks, "duplicate").ExtraDeleteIDs)
+		assert.Equal(t, []int{100, 101}, findResponseByName(thirdChecks, "duplicate").ExtraDeleteIDs)
+		require.NotNil(t, findResponseByName(secondChecks, "lua-approve"))
+		require.NotNil(t, findResponseByName(thirdChecks, "lua-approve"))
+	})
+
+	t.Run("short message flood returns before Lua", func(t *testing.T) {
+		luaCalls := 0
+		counter := &mocks.MessageCounterMock{
+			CountUserMessagesFunc: func(context.Context, string) (int, error) { return 3, nil },
+			UserMessageIDsFunc:    func(context.Context, string, int) ([]int, error) { return []int{1, 2, 3}, nil },
+		}
+		d := NewDetector(Config{
+			MaxShortMsgCount:   3,
+			FirstMessagesCount: 2,
+			MinMsgLen:          50,
+			MaxAllowedEmoji:    -1,
+		})
+		d.WithMessageCounter(counter)
+		d.luaChecks = []plugin.ResultCheck{func(spamcheck.Request) plugin.Result {
+			luaCalls++
+			return plugin.Result{Response: spamcheck.Response{Name: "lua-trusted"}, Approved: true}
+		}}
+
+		spam, checks := d.Check(spamcheck.Request{Msg: "hi", UserID: "47"})
+
+		assert.True(t, spam)
+		assert.Zero(t, luaCalls)
+		require.NotNil(t, findResponseByName(checks, "short-msg-flood"))
+		assert.Nil(t, findResponseByName(checks, "lua-approve"))
+	})
+
+	t.Run("prohibited language returns before Lua", func(t *testing.T) {
+		scripts, err := ResolveProhibitedScripts([]string{"chinese"})
+		require.NoError(t, err)
+		luaCalls := 0
+		d := NewDetector(Config{ProhibitedScripts: scripts, ProhibitedLangsMin: 2, MaxAllowedEmoji: -1})
+		d.luaChecks = []plugin.ResultCheck{func(spamcheck.Request) plugin.Result {
+			luaCalls++
+			return plugin.Result{Response: spamcheck.Response{Name: "lua-trusted"}, Approved: true}
+		}}
+
+		spam, checks := d.Check(spamcheck.Request{Msg: "中文", UserID: "48"})
+
+		assert.True(t, spam)
+		assert.Zero(t, luaCalls)
+		require.NotNil(t, findResponseByName(checks, "prohibited-language"))
+		assert.Nil(t, findResponseByName(checks, "lua-approve"))
 	})
 }
 

--- a/lib/tgspam/plugin/checker.go
+++ b/lib/tgspam/plugin/checker.go
@@ -1,11 +1,16 @@
 // Package plugin provides a plugin system for spam detection in tg-spam.
 // It loads and executes Lua scripts that implement custom spam checking logic.
 // Scripts should provide a "check" function that takes a message context and returns
-// a boolean (is spam) and a string (details).
+// a boolean (is spam), a string (details), and an optional boolean approval. An exact
+// true approves only the current message when the plugin reports ham. It can clear soft
+// results in Detector.Check, but not the short-message-flood or prohibited-language
+// blocks that return before plugins run. A normal-length cleared message follows the
+// ordinary ham path for user graduation and ham history.
 package plugin
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"sync"
 
@@ -18,6 +23,7 @@ import (
 type Checker struct {
 	vm       *lua.LState
 	checkers map[string]*lua.LFunction
+	warned   map[string]struct{}
 	lock     sync.RWMutex // protects the checkers map and serializes access to the shared vm
 	watcher  *Watcher     // optional file watcher for dynamic reloading
 }
@@ -25,12 +31,22 @@ type Checker struct {
 // Check is a function that takes a request and returns a response indicating if message is spam
 type Check func(req spamcheck.Request) spamcheck.Response
 
+// Result contains a Lua plugin response and its optional approval of the current message.
+type Result struct {
+	Response spamcheck.Response
+	Approved bool
+}
+
+// ResultCheck is a function that returns the full result of a Lua plugin check.
+type ResultCheck func(req spamcheck.Request) Result
+
 // NewChecker creates a new Checker
 func NewChecker() *Checker {
 	L := lua.NewState()
 	lc := &Checker{
 		vm:       L,
 		checkers: make(map[string]*lua.LFunction),
+		warned:   make(map[string]struct{}),
 	}
 	lc.RegisterHelpers() // register helper functions
 	return lc
@@ -103,6 +119,17 @@ func (c *Checker) LoadDirectory(dir string) error {
 
 // GetCheck returns a Check for the specified Lua checker
 func (c *Checker) GetCheck(name string) (Check, error) {
+	resultCheck, err := c.GetResultCheck(name)
+	if err != nil {
+		return nil, err
+	}
+	return func(req spamcheck.Request) spamcheck.Response {
+		return resultCheck(req).Response
+	}, nil
+}
+
+// GetResultCheck returns a ResultCheck for the specified Lua checker.
+func (c *Checker) GetResultCheck(name string) (ResultCheck, error) {
 	c.lock.RLock()
 	_, ok := c.checkers[name]
 	c.lock.RUnlock()
@@ -111,7 +138,7 @@ func (c *Checker) GetCheck(name string) (Check, error) {
 		return nil, fmt.Errorf("lua checker %q not found", name)
 	}
 
-	return c.createMetaChecker(name), nil
+	return c.createResultCheck(name), nil
 }
 
 // GetAllChecks returns all loaded Lua checks
@@ -120,16 +147,32 @@ func (c *Checker) GetAllChecks() map[string]Check {
 
 	c.lock.RLock()
 	for name := range c.checkers {
-		result[name] = c.createMetaChecker(name)
+		resultCheck := c.createResultCheck(name)
+		result[name] = func(req spamcheck.Request) spamcheck.Response {
+			return resultCheck(req).Response
+		}
 	}
 	c.lock.RUnlock()
 
 	return result
 }
 
-// createMetaChecker creates a Check function for the named Lua checker
-func (c *Checker) createMetaChecker(name string) Check {
-	return func(req spamcheck.Request) spamcheck.Response {
+// GetAllResultChecks returns all loaded Lua result checks.
+func (c *Checker) GetAllResultChecks() map[string]ResultCheck {
+	result := make(map[string]ResultCheck)
+
+	c.lock.RLock()
+	for name := range c.checkers {
+		result[name] = c.createResultCheck(name)
+	}
+	c.lock.RUnlock()
+
+	return result
+}
+
+// createResultCheck creates a ResultCheck function for the named Lua checker
+func (c *Checker) createResultCheck(name string) ResultCheck {
+	return func(req spamcheck.Request) Result {
 		// the write lock is required, not just a read lock: everything below mutates the shared
 		// *lua.LState (allocating tables, pushing and popping the stack) and gopher-lua states are
 		// not goroutine-safe. Detector.Check holds only a read lock of its own, so concurrent
@@ -142,7 +185,7 @@ func (c *Checker) createMetaChecker(name string) Check {
 		checker, ok := c.checkers[name]
 		if !ok {
 			err := fmt.Errorf("lua checker %q not found", name)
-			return spamcheck.Response{Name: "lua-" + name, Spam: false, Details: err.Error(), Error: err}
+			return Result{Response: spamcheck.Response{Name: "lua-" + name, Spam: false, Details: err.Error(), Error: err}}
 		}
 
 		// create Lua table from request
@@ -172,28 +215,54 @@ func (c *Checker) createMetaChecker(name string) Check {
 		// call the Lua function
 		if err := c.vm.CallByParam(lua.P{
 			Fn:      checker,
-			NRet:    2,
+			NRet:    3,
 			Protect: true,
 		}, reqTable); err != nil {
-			return spamcheck.Response{
+			return Result{Response: spamcheck.Response{
 				Name:    "lua-" + name,
 				Spam:    false,
 				Details: "error executing lua checker: " + err.Error(),
 				Error:   err,
-			}
+			}}
 		}
 
 		// get return values from stack
-		isSpam := c.vm.ToBool(-2)
-		details := c.vm.ToString(-1)
-		c.vm.Pop(2) // pop results from stack
+		isSpam := c.vm.ToBool(-3)
+		details := c.vm.ToString(-2)
+		approvalValue := c.vm.Get(-1)
+		c.vm.Pop(3) // pop results from stack
 
-		return spamcheck.Response{
+		approved := false
+		switch value := approvalValue.(type) {
+		case *lua.LNilType:
+		case lua.LBool:
+			if bool(value) {
+				if isSpam {
+					c.warnOnce(name, "spam-conflict", "[WARN] lua checker %q returned approval=true with spam=true", name)
+				} else {
+					approved = true
+				}
+			}
+		default:
+			valueType := approvalValue.Type().String()
+			c.warnOnce(name, "type:"+valueType, "[WARN] lua checker %q returned approval value with type %s", name, valueType)
+		}
+
+		return Result{Response: spamcheck.Response{
 			Name:    "lua-" + name,
 			Spam:    isSpam,
 			Details: details,
-		}
+		}, Approved: approved}
 	}
+}
+
+func (c *Checker) warnOnce(name, kind, format string, args ...any) {
+	key := name + "\x00" + kind
+	if _, found := c.warned[key]; found {
+		return
+	}
+	c.warned[key] = struct{}{}
+	log.Printf(format, args...)
 }
 
 // Close cleans up resources used by the Checker

--- a/lib/tgspam/plugin/checker_test.go
+++ b/lib/tgspam/plugin/checker_test.go
@@ -408,7 +408,7 @@ end
 	require.NoError(t, err)
 
 	// every goroutine drives the same shared lua state; without the write lock in
-	// createMetaChecker this fails under -race or panics inside gopher-lua
+	// the closure returned by createResultCheck, this fails under -race or panics inside gopher-lua
 	const workers, iterations = 8, 50
 	var wg sync.WaitGroup
 	for i := range workers {

--- a/lib/tgspam/plugin/checker_test.go
+++ b/lib/tgspam/plugin/checker_test.go
@@ -462,6 +462,47 @@ end
 	assert.False(t, resp.Spam)
 }
 
+func TestChecker_ReloadReachesHeldResultChecks(t *testing.T) {
+	// Detector stores ResultCheck values for its lifetime, so a captured function would pin both
+	// the details and the approval bit to the version loaded first
+	tmpDir := t.TempDir()
+
+	scriptPath := filepath.Join(tmpDir, "held_result.lua")
+	err := os.WriteFile(scriptPath, []byte(`
+function check(request)
+	return false, "original version", false
+end
+	`), 0o644)
+	require.NoError(t, err)
+
+	checker := NewChecker()
+	defer checker.Close()
+	require.NoError(t, checker.LoadScript(scriptPath))
+
+	held, err := checker.GetResultCheck("held_result")
+	require.NoError(t, err)
+	heldAll := checker.GetAllResultChecks()["held_result"]
+	require.NotNil(t, heldAll)
+
+	res := held(createTestRequest())
+	require.Equal(t, "original version", res.Response.Details)
+	require.False(t, res.Approved)
+
+	err = os.WriteFile(scriptPath, []byte(`
+function check(request)
+	return false, "reloaded version", true
+end
+	`), 0o644)
+	require.NoError(t, err)
+	require.NoError(t, checker.ReloadScript(scriptPath))
+
+	for name, check := range map[string]ResultCheck{"GetResultCheck": held, "GetAllResultChecks": heldAll} {
+		res = check(createTestRequest())
+		assert.Equal(t, "reloaded version", res.Response.Details, "%s must run the new script", name)
+		assert.True(t, res.Approved, "%s must see the new approval", name)
+	}
+}
+
 func TestChecker_FailedReloadKeepsRegistryEntry(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/lib/tgspam/plugin/checker_test.go
+++ b/lib/tgspam/plugin/checker_test.go
@@ -1,9 +1,12 @@
 package plugin
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -524,4 +527,121 @@ end
 
 	assert.Contains(t, checker.GetAllChecks(), "partial_test", "the entry survives the failed reload")
 	assert.Equal(t, "mutated before failure", held(createTestRequest()).Details, "but its behavior does not")
+}
+
+func TestChecker_ResultCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantSpam     bool
+		wantApproved bool
+		wantError    bool
+	}{
+		{name: "absent approval remains compatible", body: `return false, "clean"`},
+		{name: "explicit false does not approve", body: `return false, "clean", false`},
+		{name: "exact true approves ham", body: `return false, "trusted message", true`, wantApproved: true},
+		{name: "true cannot approve spam", body: `return true, "spam", true`, wantSpam: true},
+		{name: "string is not an approval", body: `return false, "clean", "false"`},
+		{name: "runtime error does not approve", body: `local value = request.missing.value; return false, value, true`, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := NewChecker()
+			defer checker.Close()
+
+			scriptPath := filepath.Join(t.TempDir(), "result.lua")
+			script := "function check(request)\n" + tt.body + "\nend\n"
+			require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+			require.NoError(t, checker.LoadScript(scriptPath))
+
+			check, err := checker.GetResultCheck("result")
+			require.NoError(t, err)
+			result := check(spamcheck.Request{Msg: "test"})
+
+			assert.Equal(t, tt.wantSpam, result.Response.Spam)
+			assert.Equal(t, tt.wantApproved, result.Approved)
+			assert.Equal(t, "lua-result", result.Response.Name)
+			if tt.wantError {
+				assert.Error(t, result.Response.Error)
+			} else {
+				assert.NoError(t, result.Response.Error)
+			}
+		})
+	}
+}
+
+func TestChecker_ResultCheckWarnings(t *testing.T) {
+	var logs bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	previousPrefix := log.Prefix()
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+		log.SetPrefix(previousPrefix)
+	})
+
+	checker := NewChecker()
+	defer checker.Close()
+	scriptPath := filepath.Join(t.TempDir(), "types.lua")
+	script := `
+function check(request)
+    if request.msg == "false" then
+        return false, "clean", false
+    end
+    if request.msg == "nil" then
+        return false, "clean"
+    end
+    if request.msg == "string" then
+        return false, "clean", "false"
+    end
+    if request.msg == "number" then
+        return false, "clean", 1
+    end
+    return true, "spam", true
+end
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	require.NoError(t, checker.LoadScript(scriptPath))
+	check, err := checker.GetResultCheck("types")
+	require.NoError(t, err)
+
+	for range 2 {
+		assert.False(t, check(spamcheck.Request{Msg: "false"}).Approved)
+		assert.False(t, check(spamcheck.Request{Msg: "nil"}).Approved)
+		assert.False(t, check(spamcheck.Request{Msg: "string"}).Approved)
+		assert.False(t, check(spamcheck.Request{Msg: "number"}).Approved)
+		assert.False(t, check(spamcheck.Request{Msg: "conflict"}).Approved)
+	}
+
+	output := logs.String()
+	assert.Equal(t, 1, strings.Count(output, `lua checker "types" returned approval value with type string`))
+	assert.Equal(t, 1, strings.Count(output, `lua checker "types" returned approval value with type number`))
+	assert.Equal(t, 1, strings.Count(output, `lua checker "types" returned approval=true with spam=true`))
+	assert.NotContains(t, output, `approval value "false"`)
+	assert.Len(t, strings.Split(strings.TrimSpace(output), "\n"), 3)
+}
+
+func TestChecker_ResultAdapters(t *testing.T) {
+	checker := NewChecker()
+	defer checker.Close()
+	scriptPath := filepath.Join(t.TempDir(), "adapter.lua")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(`
+function check(request)
+    return false, "approved", true
+end
+`), 0o600))
+	require.NoError(t, checker.LoadScript(scriptPath))
+
+	legacyCheck, err := checker.GetCheck("adapter")
+	require.NoError(t, err)
+	assert.Equal(t, spamcheck.Response{Name: "lua-adapter", Details: "approved"}, legacyCheck(spamcheck.Request{}))
+
+	resultChecks := checker.GetAllResultChecks()
+	require.Contains(t, resultChecks, "adapter")
+	assert.True(t, resultChecks["adapter"](spamcheck.Request{}).Approved)
 }

--- a/lib/tgspam/plugin_test.go
+++ b/lib/tgspam/plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,109 @@ import (
 )
 
 //go:generate moq --out mocks/lua_plugin_engine.go --pkg mocks --skip-ensure --with-resets . LuaPluginEngine
+
+var oldStylePluginCheck plugin.Check = func(spamcheck.Request) spamcheck.Response {
+	return spamcheck.Response{Name: "lua-legacy", Details: "legacy response"}
+}
+
+type legacyLuaPluginEngine struct {
+	check plugin.Check
+}
+
+func (e *legacyLuaPluginEngine) LoadScript(string) error    { return nil }
+func (e *legacyLuaPluginEngine) ReloadScript(string) error  { return nil }
+func (e *legacyLuaPluginEngine) LoadDirectory(string) error { return nil }
+func (e *legacyLuaPluginEngine) Close()                     {}
+func (e *legacyLuaPluginEngine) GetAllChecks() map[string]plugin.Check {
+	return map[string]plugin.Check{"legacy": e.check}
+}
+func (e *legacyLuaPluginEngine) GetCheck(string) (plugin.Check, error) { return e.check, nil }
+
+var _ LuaPluginEngine = (*legacyLuaPluginEngine)(nil)
+
+type resultLuaPluginEngine struct {
+	*legacyLuaPluginEngine
+	result plugin.ResultCheck
+}
+
+func (e *resultLuaPluginEngine) GetResultCheck(string) (plugin.ResultCheck, error) {
+	return e.result, nil
+}
+
+func (e *resultLuaPluginEngine) GetAllResultChecks() map[string]plugin.ResultCheck {
+	return map[string]plugin.ResultCheck{"result": e.result}
+}
+
+var _ luaResultEngine = (*resultLuaPluginEngine)(nil)
+
+func TestDetector_WithLuaEngine_ResultCompatibility(t *testing.T) {
+	t.Run("legacy engine is adapted without approval", func(t *testing.T) {
+		config := Config{}
+		config.LuaPlugins.Enabled = true
+		config.LuaPlugins.PluginsDir = "/plugins"
+		config.LuaPlugins.EnabledPlugins = []string{"legacy"}
+		detector := NewDetector(config)
+		engine := &legacyLuaPluginEngine{check: oldStylePluginCheck}
+
+		require.NoError(t, detector.WithLuaEngine(engine))
+		require.Len(t, detector.luaChecks, 1)
+		assert.Equal(t, plugin.Result{Response: oldStylePluginCheck(spamcheck.Request{})}, detector.luaChecks[0](spamcheck.Request{}))
+	})
+
+	t.Run("result-capable engine preserves approval", func(t *testing.T) {
+		config := Config{}
+		config.LuaPlugins.Enabled = true
+		config.LuaPlugins.PluginsDir = "/plugins"
+		config.LuaPlugins.EnabledPlugins = []string{"result"}
+		detector := NewDetector(config)
+		resultCheck := func(spamcheck.Request) plugin.Result {
+			return plugin.Result{Response: spamcheck.Response{Name: "lua-result"}, Approved: true}
+		}
+		engine := &resultLuaPluginEngine{
+			legacyLuaPluginEngine: &legacyLuaPluginEngine{check: func(spamcheck.Request) spamcheck.Response {
+				panic("legacy GetCheck must not be used")
+			}},
+			result: resultCheck,
+		}
+
+		require.NoError(t, detector.WithLuaEngine(engine))
+		require.Len(t, detector.luaChecks, 1)
+		assert.Equal(t, resultCheck(spamcheck.Request{}), detector.luaChecks[0](spamcheck.Request{}))
+	})
+}
+
+func TestDetector_WithLuaEngine_ApprovalIntegration(t *testing.T) {
+	pluginsDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(pluginsDir, "broken.lua"), []byte(`
+function check(request)
+    local value = request.missing.value
+    return false, value, true
+end
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginsDir, "trusted.lua"), []byte(`
+function check(request)
+    return false, "trusted message", true
+end
+`), 0o600))
+
+	config := Config{MaxAllowedEmoji: -1}
+	config.LuaPlugins.Enabled = true
+	config.LuaPlugins.PluginsDir = pluginsDir
+	detector := NewDetector(config)
+	_, err := detector.LoadStopWords(strings.NewReader("spamword"))
+	require.NoError(t, err)
+	checker := plugin.NewChecker()
+	defer checker.Close()
+	require.NoError(t, detector.WithLuaEngine(checker))
+
+	spam, checks := detector.Check(spamcheck.Request{Msg: "spamword message", UserID: "49"})
+
+	assert.False(t, spam)
+	require.NotNil(t, findResponseByName(checks, "lua-broken"))
+	require.Error(t, findResponseByName(checks, "lua-broken").Error)
+	assert.Equal(t, &spamcheck.Response{Name: "lua-approve", Details: "cleared by lua-trusted"},
+		findResponseByName(checks, "lua-approve"))
+}
 
 func TestDetector_WithLuaEngine(t *testing.T) {
 	config := Config{}
@@ -526,7 +630,7 @@ end
 	config.LuaPlugins.PluginsDir = ""
 
 	// print the available checks
-	allChecks := modifiedAPICheck.GetAllChecks()
+	allChecks := modifiedAPICheck.GetAllResultChecks()
 	t.Logf("Available Lua checks: %v", allChecks)
 
 	// create detector


### PR DESCRIPTION
lua plugins can now clear a spam verdict, not just vote for one. A plugin returns an optional third value from `check`, and an exact `true` on a ham result turns the current message into ham even when other checks flagged it.

**Why**

`Detector.Check` ORs the `Spam` flag over every check result, so a plugin returning `false` was only a missing vote. The one hook that could cancel an existing verdict was LLM veto mode, which pushed people into standing up an openai-compatible REST service purely to get a veto they could script. This gives them the primitive directly.

**Contract**

```lua
function check(request)
    if string.match(request.msg, "some pattern") then
        return true, "matched suspicious pattern"
    end
    return false, "message looks clean", request.user_id == "123456789"
end
```

Missing, `nil` and `false` mean no approval. Only exact boolean `true` counts. Other types are ignored and warned once per plugin and type, logging the type and never the value. A plugin that errors never approves, and a plugin cannot report spam and approve in the same result.

**Reach**

Approval clears soft results from the current `Detector.Check` call: duplicate, stop words, emoji, meta, lua, CAS, multi-language, abnormal spacing, similarity and classifier. It does not reach short-message-flood or prohibited-languages, which return before plugins run. A moot approval on a clean base does not cancel an LLM spam verdict. One `lua-approve` row is added naming the approving plugins, sorted, so the check list explains why the spam rows did not decide it.

A cleared short message keeps the existing short-message rules, no ham history and no graduation. A cleared normal-length message follows the ordinary ham path, so it graduates the user and enters the bounded ham history, which means it can become LLM context later. That is documented in both README sections.

**Compatibility**

Both layers stay compatible. `CallByParam` pads a two-value lua function with `nil`, so existing scripts are untouched. On the Go side `plugin.Check`, `GetCheck`, `GetAllChecks` and `LuaPluginEngine` are unchanged; the new `plugin.Result` and `ResultCheck` are additive, `ResultCheck` is the single closure that calls lua, and `GetCheck` returns `.Response` from it. The detector type-asserts a small unexported capability interface and falls back to wrapping a legacy engine with `Approved=false`, so an outside implementation still compiles and the generated mock needed no regen.

No new config. Which plugins load and which are enabled is already the trust decision.
